### PR TITLE
feat(Inline-editable): adds component

### DIFF
--- a/core/components/atoms/editable/Editable.tsx
+++ b/core/components/atoms/editable/Editable.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { BaseProps, extractBaseProps } from '@/utils/types';
+
+export interface EditableProps extends BaseProps {
+  editing?: boolean;
+  children: React.ReactNode;
+  onChange: (eventType: string) => void;
+}
+
+export const Editable = (props: EditableProps) => {
+  const {
+    className,
+    onChange,
+    editing,
+    children,
+  } = props;
+
+  const baseProps = extractBaseProps(props);
+
+  const EditableClass = classNames({
+    ['Editable']: true,
+  }, className);
+
+  return (
+    <div data-test="DesignSystem-Editable" {...baseProps} className={EditableClass}>
+      <div
+        data-test="DesignSystem-EditableWrapper"
+        onClick={() => onChange('edit')}
+        onMouseEnter={() => !editing && onChange('hover')}
+        onMouseLeave={() => !editing && onChange('default')}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+Editable.displayName = 'Editable';
+
+export default Editable;

--- a/core/components/atoms/editable/__tests__/Editable.test.tsx
+++ b/core/components/atoms/editable/__tests__/Editable.test.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Editable, { EditableProps as Props } from '../Editable';
+import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
+
+const onChange = jest.fn();
+
+describe('Editable component', () => {
+  const mapper = {
+    editing: valueHelper(true, { required: true }),
+    onChange: valueHelper(onChange, { required: true })
+  };
+
+  const testFunc = (props: Record<string, any>): void => {
+    const attr = filterUndefined(props) as Props;
+
+    it(testMessageHelper(attr), () => {
+      const { asFragment } = render(
+        <Editable
+          {...attr}
+        >
+          <div>First Name</div>
+        </Editable>
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+  };
+
+  testHelper(mapper, testFunc);
+});
+
+describe('Editable component', () => {
+
+  it('renders children', () => {
+    const { getByTestId } = render(
+      <Editable onChange={onChange}>
+        <div data-test="DS-Editable">First Name</div>
+      </Editable>
+    );
+
+    expect(getByTestId('DS-Editable')).toBeInTheDocument();
+  });
+
+  it('Editable component with props editing (true) and onChange', () => {
+    const { getByTestId } = render(
+      <Editable onChange={onChange} editing={true}>
+        <span />
+      </Editable>
+    );
+
+    const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
+
+    fireEvent.click(editableWrapper);
+    expect(onChange).toHaveBeenCalledWith('edit');
+
+    fireEvent.mouseEnter(editableWrapper);
+    expect(onChange).not.toHaveBeenCalledWith('hover');
+
+    fireEvent.mouseLeave(editableWrapper);
+    expect(onChange).not.toHaveBeenCalledWith('default');
+  });
+
+  it('Editable component with props editing (false) and onChange', () => {
+    const { getByTestId } = render(
+      <Editable onChange={onChange} editing={false}>
+        <span />
+      </Editable>
+    );
+
+    const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
+
+    fireEvent.click(editableWrapper);
+    expect(onChange).toHaveBeenCalledWith('edit');
+
+    fireEvent.mouseEnter(editableWrapper);
+    expect(onChange).toHaveBeenCalledWith('hover');
+
+    fireEvent.mouseLeave(editableWrapper);
+    expect(onChange).toHaveBeenCalledWith('default');
+  });
+
+});
+
+describe('Editable Component with overwrite class', () => {
+  const className = 'DS-Editable';
+
+  it('overwrite Editable class', () => {
+    const { getByTestId } = render(
+      <Editable onChange={onChange} className={className}>
+        <span />
+      </Editable>
+    );
+    expect(getByTestId('DesignSystem-Editable')).toHaveClass(className);
+  });
+
+});

--- a/core/components/atoms/editable/__tests__/__snapshots__/Editable.test.tsx.snap
+++ b/core/components/atoms/editable/__tests__/__snapshots__/Editable.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Editable component 
+  editing: true, onChange: "[Function]"
+ 1`] = `
+<DocumentFragment>
+  <div
+    class="Editable"
+    data-test="DesignSystem-Editable"
+  >
+    <div
+      data-test="DesignSystem-EditableWrapper"
+    >
+      <div>
+        First Name
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/core/components/atoms/editable/index.tsx
+++ b/core/components/atoms/editable/index.tsx
@@ -1,0 +1,2 @@
+export { default } from './Editable';
+export * from './Editable';


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
1.  Dropdown: adds stopPropagation on option click.
2. Input: adds hover state.
3. Popover: adds left and right positions
4. Adds Editable Input.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
