### PR TITLE
feat(Tooltip): added default delay on Tooltip

### DIFF
--- a/css/src/components/tooltip.css
+++ b/css/src/components/tooltip.css
@@ -10,4 +10,7 @@
   box-sizing: border-box;
   word-break: break-word;
   hyphens: auto;
+  transition: opacity 120ms;
+  transition-delay: 800ms;
+  transition-timing-function: cubic-bezier(0, 0, 0.38, 0.9);
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adds default delay of 800ms on showing the tooltip as mentioned in the design guidelines.
...

### Does this close any currently open issues?
closes #357 
...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
