### PR TITLE
chore(EditableDropdown): adds status hints to options of custom renderer story

### DIFF
--- a/core/components/molecules/editableDropdown/__stories__/variants/customRenderer.story.tsx
+++ b/core/components/molecules/editableDropdown/__stories__/variants/customRenderer.story.tsx
@@ -36,6 +36,13 @@ export const customRender = () => {
     );
   };
 
+  const optionRenderer = (props: any) => {
+    const { label } = props.optionData;
+    return (
+      <StatusHint className="px-5 py-4 cursor-pointer" appearance="warning">{label}</StatusHint>
+    );
+  };
+
   return (
     <div className="w-25">
       <Label withInput={true} className="ml-5">Editable Dropdown</Label>
@@ -44,7 +51,8 @@ export const customRender = () => {
         dropdownOptions={{
           options,
           onChange,
-          triggerOptions: { customTrigger }
+          optionRenderer,
+          triggerOptions: { customTrigger },
         }}
       />
     </div>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
adds the missing status hints in the story of custom renderer when dropdown opens

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
