### PR TITLE
fix(input): fixes input focus on padding click

### DIFF
--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -211,7 +211,12 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
   const trigger = <div className={rightIconClass}><Icon name={'info'} size={sizeMapping[size]} /></div>;
 
   return (
-    <div data-test="DesignSystem-InputWrapper" className={classes} style={{ minWidth }}>
+    <div
+      data-test="DesignSystem-InputWrapper"
+      className={classes}
+      style={{ minWidth }}
+      onClick={() => ref.current?.focus()}
+    >
       {inlineLabel && (
         <div className="Input-inlineLabel">
           <Text appearance="subtle">{inlineLabel}</Text>

--- a/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -29,6 +30,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -61,6 +63,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -85,6 +88,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -118,6 +122,7 @@ exports[`Input component
 <div
   className="Input Input--large"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -140,6 +145,7 @@ exports[`Input component
 <div
   className="Input Input--large"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": undefined,
@@ -172,6 +178,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -194,6 +201,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": undefined,
@@ -226,6 +234,7 @@ exports[`Input component
 <div
   className="Input Input--tiny"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -248,6 +257,7 @@ exports[`Input component
 <div
   className="Input Input--tiny"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": undefined,
@@ -280,6 +290,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": undefined,
@@ -302,6 +313,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -324,6 +336,7 @@ exports[`Input component
 <div
   className="Input Input--regular"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -346,6 +359,7 @@ exports[`Input component
 <div
   className="Input Input--regular Input--disabled"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -369,6 +383,7 @@ exports[`Input component
 <div
   className="Input Input--regular Input--disabled"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -401,6 +416,7 @@ exports[`Input component
 <div
   className="Input Input--regular Input--disabled"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -425,6 +441,7 @@ exports[`Input component
 <div
   className="Input Input--regular Input--disabled"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -458,6 +475,7 @@ exports[`Input component
 <div
   className="Input Input--regular Input--error"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,
@@ -481,6 +499,7 @@ exports[`Input component
 <div
   className="Input Input--regular Input--error"
   data-test="DesignSystem-InputWrapper"
+  onClick={[Function]}
   style={
     Object {
       "minWidth": 256,

--- a/css/src/components/input.css
+++ b/css/src/components/input.css
@@ -41,7 +41,7 @@
 .Input:hover {
     background: var(--secondary-lightest);
     border-color: var(--secondary-lightest);
-    cursor: pointer;
+    cursor: text;
 }
 
 .Input:focus-within {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
The input field was not getting focused on clicking along the edges. This PR brings the focus on the complete input field by clicking anywhere inside the input field.

### Does this close any currently open issues?
Closes #549 

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
