### PR TITLE
fix(overlays): fixes margin on overlays in case of optional footer support

### DIFF
--- a/core/components/molecules/fullscreenModal/Modal.tsx
+++ b/core/components/molecules/fullscreenModal/Modal.tsx
@@ -178,11 +178,16 @@ class FullscreenModal extends React.Component<FullscreenModalProps, ModalState> 
                 {children}
               </div>
 
-              <div data-test="DesignSystem-ModalFooter" className="d-flex justify-content-end p-7">
-                {!footer && <ModalFooter {...footerOptions} open={open} />}
+              {
+                (!!footer || !!footerOptions) &&
+                (
+                  <div data-test="DesignSystem-ModalFooter" className="d-flex justify-content-end p-7">
+                    {!footer && <ModalFooter {...footerOptions} open={open} />}
 
-                {!!footer && footer}
-              </div>
+                    {!!footer && footer}
+                  </div>
+                )
+              }
             </Column>
           </Row>
         </div>

--- a/core/components/molecules/fullscreenModal/__tests__/Modal.test.tsx
+++ b/core/components/molecules/fullscreenModal/__tests__/Modal.test.tsx
@@ -35,6 +35,7 @@ describe('FullscreenModal component with props', () => {
           heading: 'this is heading',
           subHeading: 'this is subheading'
         }}
+        footerOptions={{ actions: [] }}
       >
         <p>FullscreenModal Body</p>
       </FullscreenModal>

--- a/core/components/molecules/fullscreenModal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/core/components/molecules/fullscreenModal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -57,14 +57,6 @@ exports[`FullscreenModal component
             >
               this is modal body
             </div>
-            <div
-              class="d-flex justify-content-end p-7"
-              data-test="DesignSystem-ModalFooter"
-            >
-              <div
-                class="d-flex"
-              />
-            </div>
           </div>
         </div>
       </div>
@@ -131,14 +123,6 @@ exports[`FullscreenModal component
               data-test="DesignSystem-ModalBody"
             >
               this is modal body
-            </div>
-            <div
-              class="d-flex justify-content-end p-7"
-              data-test="DesignSystem-ModalFooter"
-            >
-              <div
-                class="d-flex"
-              />
             </div>
           </div>
         </div>

--- a/core/components/molecules/modal/Modal.tsx
+++ b/core/components/molecules/modal/Modal.tsx
@@ -188,7 +188,9 @@ class Modal extends React.Component<ModalProps, ModalState> {
           {children && (
             <>
               {headerOptions || footer ? (
-                <ModalBody>
+                <ModalBody
+                  withFooter={!!footer}
+                >
                   {children}
                 </ModalBody>
               ) : (

--- a/core/components/molecules/modalBody/ModalBody.tsx
+++ b/core/components/molecules/modalBody/ModalBody.tsx
@@ -5,16 +5,17 @@ import { BaseProps, extractBaseProps } from '@/utils/types';
 export interface ModalBodyProps extends BaseProps {
   children: React.ReactNode;
   stickFooter: boolean;
+  withFooter: boolean;
 }
 
 export const ModalBody = (props: ModalBodyProps) => {
-  const { children, className, stickFooter } = props;
+  const { children, className, stickFooter, withFooter } = props;
 
   const baseProps = extractBaseProps(props);
 
   const classes = classNames({
     'Modal-body': true,
-    ['Modal-body--stickFooter']: stickFooter
+    ['Modal-body--stickFooter']: withFooter && stickFooter
   }, className);
 
   return (
@@ -25,7 +26,8 @@ export const ModalBody = (props: ModalBodyProps) => {
 };
 
 ModalBody.defaultProps = {
-  stickFooter: true
+  stickFooter: true,
+  withFooter: true
 };
 
 ModalBody.displayName = 'ModalBody';

--- a/core/components/molecules/sidesheet/Sidesheet.tsx
+++ b/core/components/molecules/sidesheet/Sidesheet.tsx
@@ -44,6 +44,10 @@ export interface SidesheetProps extends BaseProps {
    */
   stickFooter?: boolean;
   /**
+   * Determines if margin bottom is to be applied to modal body
+   */
+  withFooter?: boolean;
+  /**
    * Show dividers in the header and the footer.
    */
   seperator?: boolean;
@@ -183,7 +187,10 @@ class Sidesheet extends React.Component<SidesheetProps, SidesheetState> {
             }}
             {...headerObj}
           />
-          <ModalBody stickFooter={stickFooter}>
+          <ModalBody
+            stickFooter={stickFooter}
+            withFooter={!!footer}
+          >
             {this.props.children}
           </ModalBody>
           {footer && (


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Removed extra margin bottom if footer is not there. Earlier margin bottom was being applied in all cases.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
