### PR TITLE
feat(icon): adds support for children

### DIFF
--- a/core/components/atoms/icon/Icon.tsx
+++ b/core/components/atoms/icon/Icon.tsx
@@ -15,7 +15,7 @@ export interface IconProps extends BaseProps {
   /**
    * Material icon name
    */
-  name: string;
+  name?: string;
   /**
    * Size of `Icon`
    */
@@ -34,6 +34,10 @@ export interface IconProps extends BaseProps {
    * Handler to be called when icon is clicked
    */
   onClick?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  /**
+   * DOM node to be passed as child to the component
+   */
+  children? :React.ReactNode;
 }
 
 export const Icon = (props: IconProps) => {
@@ -42,7 +46,8 @@ export const Icon = (props: IconProps) => {
     className,
     name,
     size,
-    onClick
+    onClick,
+    children
   } = props;
 
   const baseProps = extractBaseProps(props);
@@ -69,6 +74,16 @@ export const Icon = (props: IconProps) => {
   };
 
   // change `children` to {name} after migration
+  if (children && React.isValidElement(children)) {
+    return(
+      <span
+        {...baseProps}
+        className={className}
+      >
+        {children}
+      </span>
+    );
+  }
   return (
     <i
       {...baseProps}

--- a/core/components/atoms/icon/__stories__/variants/Image.story.tsx
+++ b/core/components/atoms/icon/__stories__/variants/Image.story.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Icon } from '@/index';
+
+export const image = () => {
+  return (
+    <Icon
+      size={50}
+    >
+      <img
+        src="https://innovaccer.com/static/image/site-logo/innovaccer-logo-black.svg"
+        width="150"
+        height="150"
+      />
+    </Icon>
+  );
+};
+
+export default {
+  title: 'Atoms|Icon/Variants',
+  component: Icon,
+  parameters: {
+    docs: {
+      docPage: {
+        title: 'Icon'
+      }
+    }
+  }
+};


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Added support for child in Icon component. We can pass a string or React Component or HTML tag as child in Icon component.

### Does this close any currently open issues?
Closes #544

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
