### PR TITLE
fix(Table): adds support for width in string as px

### DIFF
--- a/core/components/organisms/grid/columnUtility.tsx
+++ b/core/components/organisms/grid/columnUtility.tsx
@@ -51,14 +51,18 @@ export function hideColumn(this: Grid, name: ColumnSchema['name'], value: boolea
 }
 
 export function getWidth(this: Grid, width: React.ReactText) {
-  if (typeof width === 'number') return width;
-  if (width.charAt(width.length - 1) === '%' && this.state.init) {
-    const checkboxCell = this.gridRef!.querySelector('.Grid-cell--checkbox');
-    const checkboxWidth = checkboxCell ? checkboxCell.clientWidth : 0;
-    const gridWidth = this.gridRef!.clientWidth - checkboxWidth;
-    return gridWidth * (+width.slice(0, -1) / 100);
+  const isPercent = typeof width === 'string' && width.slice(-1) === '%';
+
+  if (isPercent) {
+    if (this.state.init) {
+      const checkboxCell = this.gridRef!.querySelector('.Grid-cell--checkbox');
+      const checkboxWidth = checkboxCell ? checkboxCell.clientWidth : 0;
+      const gridWidth = this.gridRef!.clientWidth - checkboxWidth;
+      return gridWidth * (+(width as string).slice(0, -1) / 100);
+    }
+    return 0;
   }
-  return 0;
+  return width;
 }
 
 export function getCellSize(cellType: CellType) {

--- a/core/components/organisms/table/Table.tsx
+++ b/core/components/organisms/table/Table.tsx
@@ -86,9 +86,9 @@ interface SyncProps {
    * | --- | --- | --- |
    * | name | key of the value in `RowData` | |
    * | displayName | Column Head Label | |
-   * | width | width of the column(in px) | |
-   * | minWidth | min-width of the column(in px) | 100 |
-   * | maxWidth | max-width of the column(in px) | 800 |
+   * | width | width of the column(px or %) | |
+   * | minWidth | min-width of the column(px or %) | 100 |
+   * | maxWidth | max-width of the column(px or %) | 800 |
    * | resizable | Denotes if column is resizable | |
    * | sorting | Enables sorting in column | true |
    * | comparator | Sorting Function to be passed(in case of sync) | Default string comparator(localeCompare) |


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds support for '80px' in width/minWidth/maxWidth of Table column schema.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
