### PR TITLE
chore(EditableDropdown): Added status hints in docs tab of custom render

### DIFF
--- a/core/components/molecules/editableDropdown/__stories__/variants/customRenderer.story.tsx
+++ b/core/components/molecules/editableDropdown/__stories__/variants/customRenderer.story.tsx
@@ -71,12 +71,19 @@ const customCode = `() => {
   };
 
   const onChange = (selectedValues) => {
-    consol.log(selectedValues);
+    console.log(selectedValues);
   };
 
   const customRenderer = (label) => {
     return (
       <StatusHint appearance="warning">{label}</StatusHint>
+    );
+  };
+
+  const optionRenderer = (props) => {
+    const { label } = props.optionData;
+    return (
+      <StatusHint className="px-5 py-4 cursor-pointer" appearance="warning">{label}</StatusHint>
     );
   };
 
@@ -101,7 +108,8 @@ const customCode = `() => {
         dropdownOptions={{
           options,
           onChange,
-          triggerOptions: { customTrigger }
+          optionRenderer,
+          triggerOptions: { customTrigger },
         }}
       />
     </div>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Added status hints in docs tab options of custom render. Earlier status hints were present only in canvas tab options.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
