### PR TITLE
feat(docspage): adds noSandbox prop to doc page to disable edit in sa…

### DIFF
--- a/.storybook/docPage.css
+++ b/.storybook/docPage.css
@@ -49,3 +49,10 @@ html, body {
   border: 0 !important;
   border-bottom: var(--border);
 }
+
+.sbdocs-title {
+  font-weight: var(--font-weight-medium) !important;
+  font-size: var(--font-size-xl) !important;
+  line-height: var(--font-height-xl) !important;
+  color: var(--text) !important;
+}

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import '../css';
 import './docPage.css'
-import { addParameters } from '@storybook/react';
 import { DocsContainer } from '@storybook/addon-docs/blocks';
 import { docPage } from '@/utils/docPage';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
-
-addParameters({
-  docs: {
-    container: DocsContainer,
-    page: docPage,
-  },
-});
+import { primary } from './themes';
 
 export const decorators = [
   (Story) => (
@@ -22,6 +15,12 @@ export const decorators = [
 ];
 
 export const parameters = {
+  docs: {
+    container: DocsContainer,
+    page: docPage,
+    theme: primary
+  },
+  viewMode: 'docs',
   actions: { argTypesRegex: "^on[A-Z].*" },
   // Storybook a11y addon configuration
   a11y: {

--- a/core/components/css-utilities/Align/Align.story.tsx
+++ b/core/components/css-utilities/Align/Align.story.tsx
@@ -81,5 +81,12 @@ export const align = () => {
 
 export default {
   title: 'Others/Utilities/Align',
-  component: align
+  component: align,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Background/Background.story.tsx
+++ b/core/components/css-utilities/Background/Background.story.tsx
@@ -101,5 +101,12 @@ export const background = () => {
 
 export default {
   title: 'Others/Utilities/Background',
-  component: background
+  component: background,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Display/Display.story.tsx
+++ b/core/components/css-utilities/Display/Display.story.tsx
@@ -97,5 +97,12 @@ export const display = () => {
 
 export default {
   title: 'Others/Utilities/Display',
-  component: display
+  component: display,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Flex/Flex.story.tsx
+++ b/core/components/css-utilities/Flex/Flex.story.tsx
@@ -272,5 +272,12 @@ export const flex = () => {
 
 export default {
   title: 'Others/Utilities/Flex',
-  component: flex
+  component: flex,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Miscellaneous/Miscellaneous.story.tsx
+++ b/core/components/css-utilities/Miscellaneous/Miscellaneous.story.tsx
@@ -46,5 +46,12 @@ export const miscellaneous = () => {
 
 export default {
   title: 'Others/Utilities/Miscellaneous',
-  component: miscellaneous
+  component: miscellaneous,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Overflow/Overflow.story.tsx
+++ b/core/components/css-utilities/Overflow/Overflow.story.tsx
@@ -64,5 +64,12 @@ export const overflow = () => {
 
 export default {
   title: 'Others/Utilities/Overflow',
-  component: overflow
+  component: overflow,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Position/Position.story.tsx
+++ b/core/components/css-utilities/Position/Position.story.tsx
@@ -62,5 +62,12 @@ export const position = () => {
 
 export default {
   title: 'Others/Utilities/Position',
-  component: position
+  component: position,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Sizing/Sizing.story.tsx
+++ b/core/components/css-utilities/Sizing/Sizing.story.tsx
@@ -150,5 +150,12 @@ export const sizing = () => {
 
 export default {
   title: 'Others/Utilities/Sizing',
-  component: sizing
+  component: sizing,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/Spacing/Spacing.story.tsx
+++ b/core/components/css-utilities/Spacing/Spacing.story.tsx
@@ -82,5 +82,12 @@ blank - for classes that set a margin or padding on all 4 sides of the element<b
 
 export default {
   title: 'Others/Utilities/Spacing',
-  component: spacing
+  component: spacing,
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/designTokens/Colors.story.tsx
+++ b/core/components/css-utilities/designTokens/Colors.story.tsx
@@ -43,5 +43,12 @@ export const colors = () => {
 };
 
 export default {
-  title: 'Others/Design Tokens/Colors'
+  title: 'Others/Design Tokens/Colors',
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/designTokens/Miscellaneous.story.tsx
+++ b/core/components/css-utilities/designTokens/Miscellaneous.story.tsx
@@ -42,5 +42,12 @@ export const miscellaneous = () => {
 };
 
 export default {
-  title: 'Others/Design Tokens/Miscellaneous'
+  title: 'Others/Design Tokens/Miscellaneous',
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/designTokens/Spacing.story.tsx
+++ b/core/components/css-utilities/designTokens/Spacing.story.tsx
@@ -20,5 +20,12 @@ export const spacing = () => {
 };
 
 export default {
-  title: 'Others/Design Tokens/Spacing'
+  title: 'Others/Design Tokens/Spacing',
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/css-utilities/designTokens/Typography.story.tsx
+++ b/core/components/css-utilities/designTokens/Typography.story.tsx
@@ -91,5 +91,12 @@ export const typography = () => {
 };
 
 export default {
-  title: 'Others/Design Tokens/Typography'
+  title: 'Others/Design Tokens/Typography',
+  parameters: {
+    docs: {
+      docPage: {
+        noProps: true
+      }
+    }
+  }
 };

--- a/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
+++ b/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
@@ -74,7 +74,8 @@ export default {
     docs: {
       docPage: {
         customCode,
-        noProps: true
+        noProps: true,
+        title: 'Date and time picker'
       }
     }
   }

--- a/core/components/patterns/dateRangePicker/withCustomPopover.story.tsx
+++ b/core/components/patterns/dateRangePicker/withCustomPopover.story.tsx
@@ -151,7 +151,7 @@ export default {
     docs: {
       docPage: {
         customCode,
-        title: 'Custom Popover',
+        title: 'Date range picker with custom Popover',
         noProps: true
       }
     }

--- a/core/components/patterns/table/Table with Header/tableWithHeader.story.jsx
+++ b/core/components/patterns/table/Table with Header/tableWithHeader.story.jsx
@@ -980,6 +980,7 @@ export default {
   parameters: {
     docs: {
       docPage: {
+        title: 'Table with header',
         customCode,
         imports: {
           debounce: debounce
@@ -987,7 +988,8 @@ export default {
         props: {
           exclude: ['showHead'],
         },
-        noProps: true
+        noProps: true,
+        noSandbox: true
       }
     }
   }

--- a/core/utils/docPage/index.tsx
+++ b/core/utils/docPage/index.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import {
   Title,
   Subtitle,
-  Heading,
   Subheading,
   Description,
   Canvas,
@@ -17,7 +16,7 @@ import { html as beautifyHTML } from 'js-beautify';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco, dark, a11yDark, githubGist, dracula, vs2015 } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import * as DS from '@/';
-import { Button, Card, TabsWrapper, Tab } from '@/';
+import { Button, Card, TabsWrapper, Tab, Heading } from '@/';
 import vsDark from 'prism-react-renderer/themes/vsDark';
 import { resetComponents, Story as PureStory } from '@storybook/components';
 import { LiveProvider, LiveEditor, LiveError, LivePreview, withLive } from 'react-live';
@@ -136,7 +135,7 @@ ${jsx
 };
 
 const StoryComp = props => {
-  const { customCode, noHtml, noStory } = props;
+  const { customCode, noHtml, noStory, noSandbox } = props;
   const { story, storyId } = getStory();
   const comp = story.getOriginal()();
   const sp = story.parameters;
@@ -190,7 +189,8 @@ const StoryComp = props => {
                 onClick: ev => {
                   ev.preventDefault();
                   openSandbox(jsxCode);
-                }
+                },
+                disabled: noSandbox
               },
               {
                 title: `${!isExpanded ? 'Show' : 'Hide'} code`,
@@ -235,15 +235,16 @@ const StoryComp = props => {
 export const docPage = () => {
   const { story, storyId } = getStory();
   const sp = story.parameters;
-  const isEmbed = window.location.search.includes('embed=true');
+  const isEmbed = window.location.search.includes('embed=min');
+  const isEmbedWithProp = window.location.search.includes('embed=prop');
 
-  const { title, description, props: propsAttr, customCode, noHtml, noStory, noProps = isEmbed, imports } =
+  const { title, description, props: propsAttr, customCode, noHtml, noStory, noProps = isEmbed, noSandbox, imports } =
     sp.docs.docPage || {};
   const { component: { displayName } = {} } = sp;
 
   return (
     <div className="DocPage">
-      {!isEmbed && (
+      {!isEmbed && !isEmbedWithProp && (
         <>
           <Title> {title || displayName} </Title>
           <br />
@@ -252,13 +253,20 @@ export const docPage = () => {
       <Description>{description}</Description>
       <br />
 
-      <StoryComp key={storyId} customCode={customCode} noHtml={noHtml} noStory={noStory} imports={imports} />
+      <StoryComp
+        key={storyId}
+        customCode={customCode}
+        noHtml={noHtml}
+        noStory={noStory}
+        noSandbox={noSandbox}
+        imports={imports}
+      />
 
       {!noProps && (
         <>
           <br />
           <br />
-          <Heading>PropTable</Heading>
+          <Heading appearance="subtle">Prop table</Heading>
           <ArgsTable {...propsAttr} />
         </>
       )}


### PR DESCRIPTION
…ndbox action

docs(docpage): adds noProps parameter on stries with no prop table in doc page

chore(config): adds config to make docs tab default view

feat(docpage): adds qury param to remove title from iframe view to embed with prop table

style(docpage): updates component preview and prop table title styles

docs(stories): adds title to stories of patterns

chore(docpage): adds theme support for docs page

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
