### PR TITLE
fix(Modal): removes margin bottom from modal body when there is no footer

### DIFF
--- a/core/components/molecules/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/core/components/molecules/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -186,7 +186,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -305,7 +305,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -425,7 +425,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -545,7 +545,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -665,7 +665,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -785,7 +785,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -905,7 +905,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1025,7 +1025,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1145,7 +1145,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1265,7 +1265,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1385,7 +1385,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1505,7 +1505,7 @@ exports[`Dialog component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div

--- a/core/components/molecules/modal/Modal.tsx
+++ b/core/components/molecules/modal/Modal.tsx
@@ -217,6 +217,13 @@ class Modal extends React.Component<ModalProps, ModalState> {
       ['Overlay-container--open']: open,
     });
 
+    const isAPINew = (headerOptions || footerOptions || footer || header);
+    const bodyClass = classNames({
+      ['Modal-body']: true,
+      ['Modal-body--withMargin']: isAPINew ? !!footer : true,
+      ['Modal-body--withPadding']: isAPINew ? !footer : true,
+    })
+
     const baseProps = extractBaseProps(this.props);
     const sizeMap: Record<ModalProps['dimension'], Partial<ColumnProps>> = {
       small: {
@@ -270,7 +277,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
           {children && (
             <>
               {headerOptions || footerOptions || footer || header ? (
-                <OverlayBody className="Modal-body">{this.props.children}</OverlayBody>
+                <OverlayBody className={bodyClass}>{this.props.children}</OverlayBody>
               ) : (
                 children
               )}

--- a/core/components/molecules/modal/ModalBody.tsx
+++ b/core/components/molecules/modal/ModalBody.tsx
@@ -17,6 +17,7 @@ export const ModalBody = (props: ModalBodyProps) => {
   const classes = classNames(
     {
       'Modal-body': true,
+      'Modal-body--withMargin': true
     },
     className
   );

--- a/core/components/molecules/modal/__stories__/NoFooter.story.tsx
+++ b/core/components/molecules/modal/__stories__/NoFooter.story.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { updateKnob } from '@/utils/storybookEventEmitter';
+import { Modal, ModalDescription, ModalHeader, ModalBody, ModalFooter, Text, Paragraph } from '@/index';
+
+export const noFooter = () => {
+  const open = boolean('open', true);
+  const backdropClose = boolean('backdropClose', false);
+  const dimension = select('dimension', ['small', 'medium', 'large'], 'medium');
+
+  const onClose = () => {
+    updateKnob('open', false);
+    action('on close triggered')();
+  };
+
+  return (
+    <div>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua.
+        <br />
+        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+        <br />
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. <br />
+        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        <br />
+      </Paragraph>
+      <Modal
+        open={open}
+        dimension={dimension}
+        backdropClose={backdropClose}
+        onClose={onClose}
+        headerOptions={{
+          heading: 'Heading',
+          subHeading: 'Subheading',
+        }}
+
+      >
+        <Text>Modal Body</Text>
+        <ModalDescription
+          title="Description Title"
+          description="Adding a subheading clearly indicates the hierarchy of the information."
+        />
+        <ModalDescription description="Card Sections include supporting text like an article summary or a restaurant description." />
+      </Modal>
+    </div>
+  );
+};
+
+const customCode = `() => {
+  const [open, setOpen] = React.useState(true);
+  const dimension = 'medium';
+  const backdropClose = true;
+
+  const onClose = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <div>
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.<br />
+        Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<br />
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. <br />
+        Excepteur sint occaecat cupidatat non proident,
+        sunt in culpa qui officia deserunt mollit anim id est laborum.<br />
+        <Button appearance="primary" onClick={() => setOpen(true)}>Open</Button>
+      </Paragraph>
+      <Modal
+        open={open}
+        dimension={dimension}
+        backdropClose={backdropClose}
+        onClose={onClose}
+        headerOptions={{
+          heading: 'Heading',
+          subHeading: 'Subheading'
+        }}
+      >
+        <Text>Modal Body</Text>
+        <ModalDescription
+          title="Description Title"
+          description="Adding a subheading clearly indicates the hierarchy of the information."
+        />
+        <ModalDescription
+          description="Card Sections include supporting text like an article summary or a restaurant description."
+        />
+      </Modal>
+    </div>
+  );
+}`;
+
+export default {
+  title: 'Components/Modal/No Footer',
+  component: Modal,
+  subcomponents: { ModalHeader, ModalBody, ModalDescription, ModalFooter },
+  parameters: {
+    docs: {
+      docPage: {
+        customCode,
+        title: 'Modal',
+        noHtml: true,
+      },
+    },
+  },
+};

--- a/core/components/molecules/modal/__tests__/Modal.test.tsx
+++ b/core/components/molecules/modal/__tests__/Modal.test.tsx
@@ -168,6 +168,15 @@ describe('Modal component with props', () => {
     expect(queryByTestId('DesignSystem-Modal--FooterButton')).not.toBeInTheDocument();
   });
 
+  it('renders children without footer props', () => {
+    const { getByTestId, queryByTestId } = render(<Modal backdropClose={FunctionValue} open={true} header={header}/>);
+    expect(getByTestId('DesignSystem-ModalContainer')).toBeInTheDocument();
+    expect(getByTestId('DesignSystem-Modal')).toBeInTheDocument();
+    expect(queryByTestId('Modal-body--withMargin')).not.toBeInTheDocument();
+    expect(queryByTestId('DesignSystem-Modal--footer')).not.toBeInTheDocument();
+    expect(queryByTestId('DesignSystem-Modal--FooterButton')).not.toBeInTheDocument();
+  });
+
   it('renders with prop: backdropClose', () => {
     const { getByTestId } = render(
       <>

--- a/core/components/molecules/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/core/components/molecules/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`Modal component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -372,7 +372,7 @@ exports[`Modal component
             </div>
           </div>
           <div
-            class="OverlayBody Modal-body"
+            class="OverlayBody Modal-body Modal-body--withMargin"
             data-test="DesignSystem-OverlayBody"
           >
             <div
@@ -531,7 +531,7 @@ exports[`Modal component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withPadding"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -678,7 +678,7 @@ exports[`Modal component
             </div>
           </div>
           <div
-            class="OverlayBody Modal-body"
+            class="OverlayBody Modal-body Modal-body--withPadding"
             data-test="DesignSystem-OverlayBody"
           >
             <div
@@ -976,7 +976,7 @@ exports[`Modal component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1123,7 +1123,7 @@ exports[`Modal component
             </div>
           </div>
           <div
-            class="OverlayBody Modal-body"
+            class="OverlayBody Modal-body Modal-body--withMargin"
             data-test="DesignSystem-OverlayBody"
           >
             <div
@@ -1282,7 +1282,7 @@ exports[`Modal component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withPadding"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1429,7 +1429,7 @@ exports[`Modal component
             </div>
           </div>
           <div
-            class="OverlayBody Modal-body"
+            class="OverlayBody Modal-body Modal-body--withPadding"
             data-test="DesignSystem-OverlayBody"
           >
             <div
@@ -1727,7 +1727,7 @@ exports[`Modal component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withMargin"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -1874,7 +1874,7 @@ exports[`Modal component
             </div>
           </div>
           <div
-            class="OverlayBody Modal-body"
+            class="OverlayBody Modal-body Modal-body--withMargin"
             data-test="DesignSystem-OverlayBody"
           >
             <div
@@ -2033,7 +2033,7 @@ exports[`Modal component
           </div>
         </div>
         <div
-          class="OverlayBody Modal-body"
+          class="OverlayBody Modal-body Modal-body--withPadding"
           data-test="DesignSystem-OverlayBody"
         >
           <div
@@ -2180,7 +2180,7 @@ exports[`Modal component
             </div>
           </div>
           <div
-            class="OverlayBody Modal-body"
+            class="OverlayBody Modal-body Modal-body--withPadding"
             data-test="DesignSystem-OverlayBody"
           >
             <div

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -1338,7 +1338,7 @@ exports[`TS renders children 1`] = `
     </span>
   </div>
   <div
-    class="OverlayBody Modal-body"
+    class="OverlayBody Modal-body Modal-body--withMargin"
     data-test="DesignSystem-OverlayBody"
   >
     <span

--- a/css/src/components/modal.css
+++ b/css/src/components/modal.css
@@ -75,5 +75,12 @@
 
 .Modal-body {
   padding: 0 var(--spacing-xl);
+}
+
+.Modal-body--withMargin {
   margin-bottom: 80px;
+}
+
+.Modal-body--withPadding {
+  padding-bottom: var(--spacing-2);
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
when there is no footer in modal component so removed the margin bottom from modal body.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
