### PR TITLE
fix(tabs): updates condition to check children component type to render tabs.

### DIFF
--- a/core/components/molecules/tabs/Tabs.tsx
+++ b/core/components/molecules/tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { Pills, Icon, Text } from '@/index';
+import { Pills, Icon, Text, Tab } from '@/index';
 import { BaseProps, extractBaseProps, SingleOrArray } from '@/utils/types';
 
 type Tab = React.ReactElement | TabConfig;
@@ -57,7 +57,7 @@ const filterTabs = (children: SingleOrArray<React.ReactElement>) => {
   const childrenArray = getChildrenArray(children);
 
   const tabs = childrenArray.filter(
-    (element: React.ReactElement) => typeof element.type === 'function' && element.type.name === 'Tab'
+    (element: React.ReactElement) => typeof element.type === 'function' && element.type.name === Tab.name
   );
 
   return tabs;
@@ -67,7 +67,7 @@ const filterInlineComponent = (children: SingleOrArray<React.ReactElement>) => {
   const childrenArray = getChildrenArray(children);
 
   const inlineComponent = childrenArray.filter(
-    (element: React.ReactElement) => !(typeof element.type === 'function' && element.type.name === 'Tab')
+    (element: React.ReactElement) => !(typeof element.type === 'function' && element.type.name === Tab.name)
   );
 
   return inlineComponent;


### PR DESCRIPTION
Updates childrend compnent name check to compare with Tab component name instead of static string
"Tab" to prevent mismatches in minified/uglified bundle.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [x] Merged with latest `develop` branch
