### PR TITLE
fix(DatePicker): updates the get today date logic to use Date.now 

### DIFF
--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -187,8 +187,9 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
     const { date } = this.state;
     const { months } = config;
-    const monthIndex: number = new Date().getMonth();
-    const todayMonthAndDate: string = `${months[monthIndex]} ${new Date().getDate()}`;
+    const todayDate = new Date(Date.now());
+    const todayMonthAndDate: string = `${months[todayDate.getMonth()]} ${todayDate.getDate()}`;
+
     return (
       <div>
         <Calendar

--- a/core/components/organisms/datePicker/__tests__/DatePicker.test.tsx
+++ b/core/components/organisms/datePicker/__tests__/DatePicker.test.tsx
@@ -4,6 +4,18 @@ import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/u
 import { DatePicker } from '@/index';
 import { DatePickerProps as Props } from '@/index.type';
 
+let dateNowSpy: any;
+
+beforeAll(() => {
+  // Lock Time
+  dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => 1632314975530);
+});
+
+afterAll(() => {
+  // Unlock Time
+  dateNowSpy.mockRestore();
+});
+
 const view = ['year', 'month', 'date'];
 const booleanValue = [true, false];
 const FunctionValue = jest.fn();

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -631,7 +631,7 @@ exports[`TS renders children 1`] = `
           class="Text Text--default Text--regular"
           data-test="DesignSystem-GenericChip--Text"
         >
-          Today, Sep 22
+          Today, Jun 14
         </span>
       </div>
     </div>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Updates today date logic to use Date.now so that is can be mocked easily in tests.


### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits




### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
