### PR TITLE
docs: change utilities structure in storybook

### DIFF
--- a/core/components/atoms/outsideClick/__stories__/index.story.tsx
+++ b/core/components/atoms/outsideClick/__stories__/index.story.tsx
@@ -35,7 +35,7 @@ const customCode = `() => {
 }`;
 
 export default {
-  title: 'Components/OutsideClick/All',
+  title: 'Others/Utilities/OutsideClick/All',
   component: OutsideClick,
   parameters: {
     docs: {

--- a/core/components/css-utilities/Align/Align.story.tsx
+++ b/core/components/css-utilities/Align/Align.story.tsx
@@ -86,7 +86,7 @@ export const align = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Align',
+  title: 'Others/Styles/Align',
   component: align,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Background/Background.story.tsx
+++ b/core/components/css-utilities/Background/Background.story.tsx
@@ -111,7 +111,7 @@ export const background = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Background',
+  title: 'Others/Styles/Background',
   component: background,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Border/Border.story.tsx
+++ b/core/components/css-utilities/Border/Border.story.tsx
@@ -116,7 +116,7 @@ export const border = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Border',
+  title: 'Others/Styles/Border',
   component: border,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Display/Display.story.tsx
+++ b/core/components/css-utilities/Display/Display.story.tsx
@@ -103,7 +103,7 @@ export const display = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Display',
+  title: 'Others/Styles/Display',
   component: display,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Flex/Flex.story.tsx
+++ b/core/components/css-utilities/Flex/Flex.story.tsx
@@ -294,7 +294,7 @@ export const flex = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Flex',
+  title: 'Others/Styles/Flex',
   component: flex,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Miscellaneous/Miscellaneous.story.tsx
+++ b/core/components/css-utilities/Miscellaneous/Miscellaneous.story.tsx
@@ -43,7 +43,7 @@ export const miscellaneous = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Miscellaneous',
+  title: 'Others/Styles/Miscellaneous',
   component: miscellaneous,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Overflow/Overflow.story.tsx
+++ b/core/components/css-utilities/Overflow/Overflow.story.tsx
@@ -74,7 +74,7 @@ export const overflow = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Overflow',
+  title: 'Others/Styles/Overflow',
   component: overflow,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Position/Position.story.tsx
+++ b/core/components/css-utilities/Position/Position.story.tsx
@@ -66,7 +66,7 @@ export const position = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Position',
+  title: 'Others/Styles/Position',
   component: position,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Sizing/Sizing.story.tsx
+++ b/core/components/css-utilities/Sizing/Sizing.story.tsx
@@ -150,7 +150,7 @@ export const sizing = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Sizing',
+  title: 'Others/Styles/Sizing',
   component: sizing,
   parameters: {
     viewMode: 'story',

--- a/core/components/css-utilities/Spacing/Spacing.story.tsx
+++ b/core/components/css-utilities/Spacing/Spacing.story.tsx
@@ -105,7 +105,7 @@ export const spacing = () => {
 };
 
 export default {
-  title: 'Others/Utilities/Spacing',
+  title: 'Others/Styles/Spacing',
   component: spacing,
   parameters: {
     viewMode: 'story',


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
I did following changes in Storybook:

- `OutsideClick` moved to `Others/Utilities`
- All elements included in `Others/Utilities` moved to `Others/Styles`

...

### Does this close any currently open issues?
Resolves #525 
...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
