### PR TITLE
docs: prevent shifting icon in Collapsible

### DIFF
--- a/core/components/atoms/collapsible/__stories__/index.story.tsx
+++ b/core/components/atoms/collapsible/__stories__/index.story.tsx
@@ -12,7 +12,7 @@ export const all = () => {
     <div className="d-flex">
       <Collapsible expanded={expanded} hoverable={hoverable} height="100vh" onToggle={setExpanded}>
         <div className="d-flex pt-4">
-          <Icon name="events" className="d-flex align-items-center px-5" />
+          <Icon name="events" className="d-flex align-items-center px-5 Text--regular" />
           {expanded && <Text className="mr-6">Collapsible</Text>}
         </div>
       </Collapsible>
@@ -31,7 +31,7 @@ const customCode = `() => {
         onToggle={setExpanded}
       >
         <div className="d-flex pt-4">
-          <Icon name="events" className="d-flex align-items-center px-5" />
+          <Icon name="events" className="d-flex align-items-center px-5 Text--regular" />
           {expanded && (
             <Text className="mr-6">Collapsible</Text>
           )}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This fix adds "Text--regular" class to the icon className to align the appearing text line height. Before the fix a text that appears after expanding the panel increased the height of the header row and moved the icon a little bit.
...

### Does this close any currently open issues?
fixes #917
...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
