### PR TITLE
feat: add vscode settings for lint on save

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "jsx-a11y"],
+  "plugins": ["@typescript-eslint", "jsx-a11y", "prettier"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -11,9 +11,9 @@
   "settings": { "react": { "version": "detect" } },
   "globals": { "_": "readonly", "__": "readonly" },
   "rules": {
+    "prettier/prettier": "error",
     "no-unused-vars": "off",
     "prefer-conditional-expression": "off",
-    "max-line-length": "off",
     "object-literal-sort-keys": "off",
     "no-submodule-imports": "off",
     "member-ordering": "off",

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm install
       
       - name: lint
-        run: npm run lint
+        run: npm run lint:check
 
       - name: test
         run: npm run test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+  },
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -718,7 +718,13 @@ For formating prettier issues:
 npm run prettier
 ```
 
-For lint:
+For checking lint issues:
+
+```bash
+npm run lint:check
+```
+
+For formating lint issues:
 
 ```bash
 npm run lint

--- a/core/components/organisms/grid/GridContext.ts
+++ b/core/components/organisms/grid/GridContext.ts
@@ -1,4 +1,4 @@
-import * as  React from 'react';
+import * as React from 'react';
 import { GridProps } from '@/index.type';
 import { GridRef } from './Grid';
 import defaultProps from './defaultProps';

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "deploy-storybook": "storybook-to-ghpages",
     "setup-css-dev": "./scripts/setup-local-css.sh",
     "pre-commit": "lint-staged",
-    "lint": "eslint ./core --ext .tsx,.ts",
-    "prettier": "prettier --config ./.prettierrc --write 'core/**/*.{tx,tsx}' 'css/src/**/*.css'",
+    "lint:check": "eslint ./core --ext .tsx,.ts",
+    "lint": "npm run lint:check -- --fix",
     "prettier:check": "prettier --config ./.prettierrc --check",
+    "prettier": "prettier --config ./.prettierrc --write 'css/src/**/*.css'",
     "build-css": "gulp --gulpfile css/gulpfile.js build",
     "clean-css": "gulp --gulpfile css/gulpfile.js clean",
     "watch-css": "gulp --gulpfile css/gulpfile.js build && gulp --gulpfile css/gulpfile.js watch",
@@ -80,6 +81,7 @@
     "dts-bundle-generator": "5.9.0",
     "eslint": "^7.31.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "fork-ts-checker-webpack-plugin": "^4.0.0-beta.4",
@@ -138,8 +140,7 @@
   "repository": "github:innovaccer/design-system",
   "lint-staged": {
     "core/**/*.{tx,tsx}": [
-      "npm run prettier:check",
-      "npm run lint"
+      "npm run lint:check"
     ],
     "css/src/**/*.css": [
       "npm run prettier:check"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
1. Adds vscode workspace settings to fix lint issues on file save.
2. Adds "eslint-plugin-prettier" package so that eslint.json can respect prettier rules as lint rules only. Removing prettier for .tsx files formatting.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
