### PR TITLE
fix(docs): change style for cards in overview of component.

### DIFF
--- a/docs/src/pages/components/overview/tabs/Overview.js
+++ b/docs/src/pages/components/overview/tabs/Overview.js
@@ -45,7 +45,7 @@ function Overview() {
                       className='w-100 overflow-hidden overview-card pb-5'
                     >
                       <CardBody>
-                        <div className='py-5'>
+                        <div className='py-5 card-opacity'>
                           <div className='d-flex justify-content-center align-items-center' style={{ overflow: 'hidden', height: '136px' }}>
                             {React.createElement(image)}
                           </div>

--- a/docs/src/pages/components/overview/tabs/overview.css
+++ b/docs/src/pages/components/overview/tabs/overview.css
@@ -1,9 +1,8 @@
-.overview-cardBody {
-  height: 134px;
+.card-opacity {
   opacity: 0.6;
 }
 
-.overview-cardBody:hover {
+.overview-card:hover .card-opacity {
   opacity: 1;
 }
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
 - In normal state opacity of cards in overview of component is 0.6 and on hover the opacity becomes 1 .
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
