### PR TITLE
fix(metricInput): fix default metric input story

### DIFF
--- a/core/components/atoms/metricInput/__stories__/DefaultMetric.story.jsx
+++ b/core/components/atoms/metricInput/__stories__/DefaultMetric.story.jsx
@@ -30,7 +30,7 @@ const customCode = `() => {
 
   return (
     <div className="d-flex align-items-center">
-      <Label htmlFor="metric-input" className="mr-5">
+      <Label htmlFor="metric-input" className="mr-5">  No. of Days </Label>
       <div style={{ width: 'var(--spacing-6)' }}>
         <MetricInput
           id="metric-input"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

 In the component MetricInput, the default metric can't be rendered.

### Does this close any currently open issues?

No

### Any other comments?

No

### Dependent PRs/Commits

No

### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
