### PR TITLE
fix(popover): fix boundary element story

### DIFF
--- a/core/components/molecules/popover/__stories__/variants/boundaryElement.story.jsx
+++ b/core/components/molecules/popover/__stories__/variants/boundaryElement.story.jsx
@@ -38,8 +38,8 @@ export const boundaryElement = () => {
   const ref = React.useRef<HTMLDivElement>(null);
 
   return (
-    <div ref={ref} style={{ height: 150, border: '1px dashed', padding: 20, overflow: 'auto' }}>
-      <Popover {...options} boundaryElement={ref}>
+    <div ref={ref.current} style={{ height: 150, border: '1px dashed', padding: 20, overflow: 'auto' }}>
+      <Popover {...options} boundaryElement={ref.current}>
         <div style={{ width: 100 }} className="mx-6 my-6">
           <Text>Popup</Text>
           <Button className="mt-4" appearance="primary" onClick={action('button clicked inside popover')}>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

The boundary element story in the popover component was not being rendered.

### Does this close any currently open issues?

No

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
