### PR TITLE
fix(Table): cell overflow on cell type status hint

### DIFF
--- a/css/src/components/grid.css
+++ b/css/src/components/grid.css
@@ -354,6 +354,15 @@
   overflow: hidden;
 }
 
+.GridCell--statusHint .StatusHint {
+  overflow: hidden;
+}
+
+.GridCell--statusHint .StatusHint .Text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .GridCell--avatar .Avatar {
   margin: 0;
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fixed cell overflow when cell type = STATUS_HINT and added ellipsis.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
