### PR TITLE
fix(dropdown): invisible subtext in menu dropdown after click

### DIFF
--- a/core/components/atoms/dropdown/__stories__/MenuWithInfo.story.jsx
+++ b/core/components/atoms/dropdown/__stories__/MenuWithInfo.story.jsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import Dropdown from '../Dropdown';
+import { Uncontrolled, Controlled } from './_common_/types';
+
+// CSF format story
+export const dropdownAsMenuWithSubinfo = () => {
+  const options = [
+    { label: 'Below 18', subInfo: 'People below 18 years old', value: 'below_18', optionType: 'WITH_META' },
+    { label: '19 - 35', subInfo: 'People 19-35 years old', value: '19-35', optionType: 'WITH_META' },
+    { label: '36 - 55', subInfo: 'People 36-55 years old', value: '36-55', optionType: 'WITH_META' },
+    { label: '56 and above', subInfo: 'People above 56 years old', value: '56_above', optionType: 'WITH_META' },
+  ];
+  return (
+    <div className="d-flex w-50">
+      <Dropdown options={options} menu={true} className="mr-5" align="right" />
+      <Dropdown options={options} menu={true} className="mr-5" align="right" />
+    </div>
+  );
+};
+
+export default {
+  title: 'Components/Dropdown/Dropdown As Menu With Subinfo',
+  component: Dropdown,
+  parameters: {
+    docs: {
+      docPage: {
+        title: 'Dropdown',
+        props: {
+          components: { Uncontrolled, Controlled },
+          exclude: ['showHead'],
+        },
+      },
+    },
+  },
+};

--- a/core/components/atoms/dropdown/option/index.tsx
+++ b/core/components/atoms/dropdown/option/index.tsx
@@ -150,7 +150,7 @@ const Option = (props: OptionProps) => {
   }
 
   const renderSubInfo = (subInfo: string | MetaListProps) => {
-    const labelAppearance = disabled ? 'disabled' : selected ? 'white' : 'subtle';
+    const labelAppearance = disabled ? 'disabled' : selected && !menu ? 'white' : 'subtle';
     const iconAppearance = selected ? 'white' : 'disabled';
 
     if (typeof subInfo === 'string') {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Fixed faded/invisible subtext when option is clicked from dropdown menu
Added story for dropdown as menu with subtext 
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
