### PR TITLE
fix(dropdown): pointer on disabled option

### DIFF
--- a/css/src/components/dropdown.css
+++ b/css/src/components/dropdown.css
@@ -109,7 +109,8 @@
 
 .Option--disabled,
 .OptionWrapper--disabled {
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: default;
 }
 
 .Option-label {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Pointer cursor on disabled dropdown option
Click on disabled option bubbles to parent component
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
