### PR TITLE
fix(radio): state related issues

### DIFF
--- a/core/components/atoms/radio/Radio.tsx
+++ b/core/components/atoms/radio/Radio.tsx
@@ -102,6 +102,7 @@ export const Radio = React.forwardRef<HTMLInputElement, RadioProps>((props, forw
     <div className={RadioClass} data-test="DesignSystem-Radio">
       <div className={RadioOuterWrapper} data-test="DesignSystem-Radio-OuterWrapper">
         <input
+          tabIndex={-1}
           {...rest}
           type="radio"
           disabled={disabled}

--- a/core/components/atoms/radio/__stories__/Alignment.story.jsx
+++ b/core/components/atoms/radio/__stories__/Alignment.story.jsx
@@ -4,6 +4,9 @@ import { Radio, Row, Column, Text } from '@/index';
 export const AlignmentOfRadioGroup = () => (
   <Row>
     <Column>
+      <div className="pb-5">
+        <Text>Horizontal alignment</Text>
+      </div>
       <div className="d-flex">
         <div className="mr-9 ">
           <Radio size={'regular'} label={'Male'} name={'Gender'} value={'Male'} defaultChecked={true} />
@@ -17,21 +20,17 @@ export const AlignmentOfRadioGroup = () => (
           <Radio size={'regular'} label={'Other'} name={'Gender'} value={'Other'} />
         </div>
       </div>
-
-      <div className="pt-5">
-        <Text>Horizontal alignment</Text>
-      </div>
     </Column>
     <Column>
+      <div className="pb-5">
+        <Text>Vertical alignment</Text>
+      </div>
+
       <Radio size={'regular'} label={'Male'} name={'gender'} value={'Male'} defaultChecked={true} />
 
       <Radio size={'regular'} label={'Female'} name={'gender'} value={'Female'} />
 
       <Radio size={'regular'} label={'Other'} name={'gender'} value={'Other'} />
-
-      <div className="pt-5">
-        <Text>Vertical alignment</Text>
-      </div>
     </Column>
   </Row>
 );

--- a/core/components/atoms/radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/core/components/atoms/radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Radio component
           data-test="DesignSystem-Radio-Input"
           id="Options-Radio-Test-uid"
           name="Options"
+          tabindex="-1"
           type="radio"
           value="Options"
         />
@@ -73,6 +74,7 @@ exports[`Radio component
           disabled=""
           id="Options-Radio-Test-uid"
           name="Options"
+          tabindex="-1"
           type="radio"
           value="Options"
         />
@@ -127,6 +129,7 @@ exports[`Radio component
           data-test="DesignSystem-Radio-Input"
           id="Options-Radio-Test-uid"
           name="Options"
+          tabindex="-1"
           type="radio"
           value="Options"
         />
@@ -181,6 +184,7 @@ exports[`Radio component
           data-test="DesignSystem-Radio-Input"
           id="Options-Radio-Test-uid"
           name="Options"
+          tabindex="-1"
           type="radio"
           value="Options"
         />

--- a/core/components/organisms/choiceList/__tests__/__snapshots__/ChoiceList.test.tsx.snap
+++ b/core/components/organisms/choiceList/__tests__/__snapshots__/ChoiceList.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -75,6 +76,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -143,6 +145,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -182,6 +185,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -251,6 +255,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -291,6 +296,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -360,6 +366,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -400,6 +407,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -900,6 +908,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -939,6 +948,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1007,6 +1017,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1046,6 +1057,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1115,6 +1127,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1155,6 +1168,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1224,6 +1238,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1264,6 +1279,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1764,6 +1780,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1803,6 +1820,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1871,6 +1889,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1910,6 +1929,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -1979,6 +1999,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2019,6 +2040,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2088,6 +2110,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2128,6 +2151,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2628,6 +2652,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2667,6 +2692,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2735,6 +2761,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2774,6 +2801,7 @@ exports[`ChoiceList component
               data-test="DesignSystem-Radio-Input"
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2843,6 +2871,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2883,6 +2912,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2952,6 +2982,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />
@@ -2992,6 +3023,7 @@ exports[`ChoiceList component
               disabled=""
               id="choiceList-radio-Test-uid"
               name="choiceList"
+              tabindex="-1"
               type="radio"
               value="radio"
             />

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -989,6 +989,7 @@ exports[`TS renders children 1`] = `
         data-test="DesignSystem-Radio-Input"
         id="Hello World!-undefined-Test-uid"
         name="Hello World!"
+        tabindex="-1"
         type="radio"
         value="Hello World!"
       />

--- a/css/src/components/radio.css
+++ b/css/src/components/radio.css
@@ -8,6 +8,7 @@
   user-select: none;
   padding-top: var(--spacing-s);
   padding-bottom: var(--spacing-s);
+  width: fit-content;
 }
 
 .Radio-outerWrapper {
@@ -76,7 +77,7 @@
 }
 
 .Radio:hover .Radio-wrapper {
-  border: var(--spacing-xs) solid var(--inverse-lightest);
+  border: var(--spacing-xs) solid var(--secondary-dark);
   background-color: var(--secondary-lighter);
 }
 
@@ -158,12 +159,16 @@
   border: var(--spacing-xs) solid var(--primary);
 }
 
-.Radio-outerWrapper:hover .Radio-input:checked ~ .Radio-wrapper {
+.Radio:hover .Radio-input:checked ~ .Radio-wrapper {
   border: var(--spacing-xs) solid var(--primary-dark);
 }
 
 .Radio:hover .Radio-input:checked ~ .Radio-wrapper:after {
   background: var(--primary-dark);
+}
+
+.Radio:hover .Radio-input:checked ~ .Radio-wrapper--tiny:after {
+  border: var(--spacing-xs) solid var(--primary-dark);
 }
 
 .Radio:active .Radio-input:checked ~ .Radio-wrapper {
@@ -181,8 +186,12 @@
   border: var(--spacing-xs) solid var(--alert-darker);
 }
 
-.Radio-outerWrapper:active .Radio-input:checked ~ .Radio-wrapper:after {
+.Radio:active .Radio-input:checked ~ .Radio-wrapper:after {
   background: var(--primary-darker);
+}
+
+.Radio:active .Radio-input:checked ~ .Radio-wrapper--tiny:after {
+  border: var(--spacing-xs) solid var(--primary-darker);
 }
 
 .Radio--disabled .Radio-input:checked ~ .Radio-wrapper {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Tiny size outer border on inner circle issue

- Tiny and Regular on label hover does not highlight the outer circle

- Tiny and Regular on label active does not highlight the inner circle

- Hover on middle of label or entire width of input

- Not able to focus when user tabs first time

... 

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
