### PR TITLE
feat(metricInput): add showActionButton prop to enable or disable up and down button

### DIFF
--- a/core/components/atoms/metricInput/MetricInput.tsx
+++ b/core/components/atoms/metricInput/MetricInput.tsx
@@ -70,6 +70,10 @@ export interface MetricInputProps extends BaseProps, BaseHtmlProps<HTMLInputElem
    */
   error?: boolean;
   /**
+   * Disables the action button which is up and down arrow button.
+   */
+  showActionButton?: boolean;
+  /**
    * Callback function when `MetricInput` text changes
    */
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -124,6 +128,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
     disabled,
     readOnly,
     value: valueProp,
+    showActionButton = true,
     ...rest
   } = props;
 
@@ -161,6 +166,8 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
   const inputClass = classNames({
     ['MetricInput-input']: true,
     [`MetricInput-input--${size}`]: size,
+    [`mr-4`]: !suffix && !showActionButton && size === 'regular',
+    [`mr-6`]: !suffix && !showActionButton && size === 'large',
   });
 
   const iconClass = classNames({
@@ -226,6 +233,12 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (showActionButton) {
+      onKeyDown(e);
+    } else e.preventDefault();
+  };
+
   const actionButtonSize = size === 'large' ? 'regular' : 'tiny';
 
   return (
@@ -266,7 +279,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
         onBlur={onBlur}
         onClick={onClick}
         onFocus={onFocus}
-        onKeyDown={onKeyDown}
+        onKeyDown={handleKeyDown}
       />
       {suffix && (
         <Text
@@ -278,23 +291,24 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
           {suffix}
         </Text>
       )}
-
-      <div className="MetricInput-arrowIcons">
-        <Button
-          icon="keyboard_arrow_up"
-          size={actionButtonSize}
-          className={`${actionButton} mb-2`}
-          onClick={(e) => onArrowClick(e, 'up')}
-          data-test="DesignSystem-MetricInput--upIcon"
-        />
-        <Button
-          icon="keyboard_arrow_down"
-          size={actionButtonSize}
-          className={actionButton}
-          onClick={(e) => onArrowClick(e, 'down')}
-          data-test="DesignSystem-MetricInput--downIcon"
-        />
-      </div>
+      {showActionButton && (
+        <div className="MetricInput-arrowIcons">
+          <Button
+            icon="keyboard_arrow_up"
+            size={actionButtonSize}
+            className={`${actionButton} mb-2`}
+            onClick={(e) => onArrowClick(e, 'up')}
+            data-test="DesignSystem-MetricInput--upIcon"
+          />
+          <Button
+            icon="keyboard_arrow_down"
+            size={actionButtonSize}
+            className={actionButton}
+            onClick={(e) => onArrowClick(e, 'down')}
+            data-test="DesignSystem-MetricInput--downIcon"
+          />
+        </div>
+      )}
     </div>
   );
 });

--- a/core/components/atoms/metricInput/__tests__/MetricInput.test.tsx
+++ b/core/components/atoms/metricInput/__tests__/MetricInput.test.tsx
@@ -225,3 +225,19 @@ describe('MetricInput component with props min and max', () => {
     expect(metricInput).toHaveValue(max);
   });
 });
+
+describe('MetricInput component with props showActionButton', () => {
+  it('with showActionButton', () => {
+    const { getByTestId } = render(<MetricInput defaultValue={min} onChange={FunctionValue} min={min} />);
+    expect(getByTestId('DesignSystem-MetricInput--upIcon')).toBeInTheDocument();
+    expect(getByTestId('DesignSystem-MetricInput--downIcon')).toBeInTheDocument();
+  });
+
+  it('with showActionButton false', () => {
+    const { queryByTestId } = render(
+      <MetricInput showActionButton={false} defaultValue={min} onChange={FunctionValue} min={min} />
+    );
+    expect(queryByTestId('DesignSystem-MetricInput--upIcon')).not.toBeInTheDocument();
+    expect(queryByTestId('DesignSystem-MetricInput--downIcon')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
…and down button

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
