### PR TITLE
feat(breadcrumb): update styles to truncate long labels

### DIFF
--- a/core/components/atoms/breadcrumbs/Breadcrumbs.tsx
+++ b/core/components/atoms/breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import Dropdown from '../dropdown';
-import { Button, Link } from '@/index';
+import { Button, Link, Tooltip } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 
 interface Breadcrumb {
@@ -25,23 +25,55 @@ export interface BreadcrumbsProps extends BaseProps {
    * onClick handler for `Breadcrumb`
    */
   onClick?: (link: string) => void;
+  /**
+   * Determines whether to show tooltip for label
+   */
+  showTooltip?: boolean;
 }
 
-const renderLink = (item: Breadcrumb, onClick: BreadcrumbsProps['onClick']) => (
-  <Link
-    href={item.link}
-    onClick={(ev) => {
-      if (onClick) {
-        ev.preventDefault();
-        onClick(item.link);
-      }
-    }}
-    appearance="subtle"
-    size="tiny"
-  >
-    {item.label}
-  </Link>
-);
+interface renderLinkProps {
+  item: Breadcrumb;
+  onClick?: (link: string) => void;
+}
+
+interface renderItemProps {
+  item: Breadcrumb;
+  onClick?: (link: string) => void;
+  index?: number;
+  showTooltip?: boolean;
+}
+
+const RenderLink = ({ item, onClick }: renderLinkProps) => {
+  const onClickHandler = (ev: React.MouseEvent) => {
+    if (onClick) {
+      ev.preventDefault();
+      onClick(item.link);
+    }
+  };
+
+  return (
+    <span className="Breadcrumbs-link ellipsis--noWrap" data-test="DesignSystem-Breadcrumbs-link">
+      <Link href={item.link} onClick={onClickHandler} appearance="subtle" size="tiny">
+        {item.label}
+      </Link>
+    </span>
+  );
+};
+
+const RenderItem = ({ item, onClick, index, showTooltip }: renderItemProps) => {
+  return (
+    <div key={index} className="Breadcrumbs-item" data-test="DesignSystem-Breadcrumbs-item">
+      {showTooltip ? (
+        <Tooltip tooltip={item.label} position="bottom">
+          <RenderLink item={item} onClick={onClick} />
+        </Tooltip>
+      ) : (
+        <RenderLink item={item} onClick={onClick} />
+      )}
+      <span className="Breadcrumbs-itemSeparator">/</span>
+    </div>
+  );
+};
 
 const renderDropdown = (list: BreadcrumbsProps['list'], onClick: BreadcrumbsProps['onClick']) => {
   const options = list.map((item) => ({
@@ -79,7 +111,7 @@ const renderDropdown = (list: BreadcrumbsProps['list'], onClick: BreadcrumbsProp
 };
 
 export const Breadcrumbs = (props: BreadcrumbsProps) => {
-  const { list, onClick, className } = props;
+  const { list, onClick, className, showTooltip } = props;
 
   const baseProps = extractBaseProps(props);
 
@@ -94,27 +126,16 @@ export const Breadcrumbs = (props: BreadcrumbsProps) => {
     <div data-test="DesignSystem-Breadcrumbs" {...baseProps} className={BreadcrumbClass}>
       {list.length <= 4 ? (
         list.map((item, index) => {
-          return (
-            <div key={index} className="Breadcrumbs-item" data-test="DesignSystem-Breadcrumbs-item">
-              <span className="Breadcrumbs-link">{renderLink(item, onClick)}</span>
-              <span className="Breadcrumbs-itemSeparator">/</span>
-            </div>
-          );
+          return <RenderItem key={index} item={item} onClick={onClick} showTooltip={showTooltip} />;
         })
       ) : (
         <>
-          <div className="Breadcrumbs-item" data-test="DesignSystem-Breadcrumbs-item">
-            <span className="Breadcrumbs-link">{renderLink(list[0], onClick)}</span>
-            <span className="Breadcrumbs-itemSeparator">/</span>
-          </div>
+          <RenderItem item={list[0]} onClick={onClick} showTooltip={showTooltip} />
           <div className="Breadcrumbs-dropdown">
             {renderDropdown(list.slice(1, list.length - 1), onClick)}
             <span className="Breadcrumbs-itemSeparator">/</span>
           </div>
-          <div className="Breadcrumbs-item" data-test="DesignSystem-Breadcrumbs-item">
-            <span className="Breadcrumbs-link">{renderLink(list[list.length - 1], onClick)}</span>
-            <span className="Breadcrumbs-itemSeparator">/</span>
-          </div>
+          <RenderItem item={list[list.length - 1]} onClick={onClick} showTooltip={showTooltip} />
         </>
       )}
     </div>

--- a/core/components/atoms/breadcrumbs/__stories__/LabelTruncate.story.jsx
+++ b/core/components/atoms/breadcrumbs/__stories__/LabelTruncate.story.jsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Breadcrumbs, PageHeader } from '@/index';
+import { action } from '@/utils/action';
+
+// CSF format story
+export const labelTruncate = () => {
+  const breadcrumbs = (
+    <Breadcrumbs
+      list={[
+        {
+          label: 'eCQM Performance year 2022',
+          link: '/eCQM',
+        },
+        {
+          label: 'Report 1',
+          link: '/report1',
+        },
+      ]}
+      onClick={(link) => action(`on-click: ${link}`)}
+      showTooltip={true}
+    />
+  );
+
+  return (
+    <div className="py-6 bg-secondary-lightest">
+      <PageHeader title="eCQM Performance year 2022" breadcrumbs={breadcrumbs} />
+    </div>
+  );
+};
+
+const customCode = `() => {
+  const breadcrumbs = (
+    <Breadcrumbs
+      list={[
+        {
+          label: 'eCQM Performance year 2022',
+          link: '/eCQM',
+        },
+        {
+          label: 'Report 1',
+          link: '/report1',
+        },
+      ]}
+      onClick={link => console.log(\`on-click: \${link}\`)}
+      showTooltip={true}
+    />
+  );
+
+  return (
+    <div className="py-6 bg-secondary-lightest">
+      <PageHeader title="eCQM Performance year 2022" breadcrumbs={breadcrumbs} />
+    </div>
+  );
+}`;
+
+export default {
+  title: 'Components/Breadcrumbs/Label Truncate',
+  component: Breadcrumbs,
+  parameters: {
+    docs: {
+      docPage: {
+        customCode,
+      },
+    },
+  },
+};

--- a/core/components/atoms/breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/core/components/atoms/breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -4,7 +4,7 @@ import Breadcrumbs from '../Breadcrumbs';
 
 const list = [
   {
-    label: 'Level 0',
+    label: 'Level 0 check for truncate after 160px',
     link: '/level0',
   },
   {
@@ -80,5 +80,22 @@ describe('Breadcrumbs component', () => {
     );
     expect(getByTestId('DesignSystem-Breadcrumbs')).toHaveClass('My-custom-style');
     expect(baseElement).toMatchSnapshot();
+  });
+});
+
+describe('Breadcrumbs component', () => {
+  it('renders with truncate after 160px', () => {
+    const { getAllByTestId } = render(<Breadcrumbs list={list} onClick={onClick} />);
+    expect(getAllByTestId('DesignSystem-Breadcrumbs-link')[0]).toHaveClass('ellipsis--noWrap');
+  });
+});
+
+describe('Breadcrumbs component with Tooltip', () => {
+  it('check for prop showTooltip:true', () => {
+    const { getAllByTestId } = render(<Breadcrumbs list={list} onClick={onClick} showTooltip={true} />);
+
+    fireEvent.mouseEnter(getAllByTestId('DesignSystem-Breadcrumbs-link')[0]);
+    const tooltip = getAllByTestId('DesignSystem-Popover')[0].firstChild;
+    expect(tooltip).toHaveClass('Tooltip');
   });
 });

--- a/core/components/atoms/breadcrumbs/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/core/components/atoms/breadcrumbs/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -23,14 +23,15 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <span
-          class="Breadcrumbs-link"
+          class="Breadcrumbs-link ellipsis--noWrap"
+          data-test="DesignSystem-Breadcrumbs-link"
         >
           <a
             class="Link Link--tiny Link--subtle"
             data-test="DesignSystem-Link"
             href="/level0"
           >
-            Level 0
+            Level 0 check for truncate after 160px
           </a>
         </span>
         <span
@@ -44,7 +45,8 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <span
-          class="Breadcrumbs-link"
+          class="Breadcrumbs-link ellipsis--noWrap"
+          data-test="DesignSystem-Breadcrumbs-link"
         >
           <a
             class="Link Link--tiny Link--subtle"
@@ -65,7 +67,8 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <span
-          class="Breadcrumbs-link"
+          class="Breadcrumbs-link ellipsis--noWrap"
+          data-test="DesignSystem-Breadcrumbs-link"
         >
           <a
             class="Link Link--tiny Link--subtle"
@@ -86,7 +89,8 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <span
-          class="Breadcrumbs-link"
+          class="Breadcrumbs-link ellipsis--noWrap"
+          data-test="DesignSystem-Breadcrumbs-link"
         >
           <a
             class="Link Link--tiny Link--subtle"

--- a/css/src/components/breadcrumbs.css
+++ b/css/src/components/breadcrumbs.css
@@ -12,6 +12,18 @@
 
 .Breadcrumbs-link {
   margin: var(--spacing-m);
+  /* 160px */
+  max-width: calc(var(--spacing-2) * 10);
+  line-height: var(--font-height);
+  color: var(--inverse-lighter);
+}
+
+.Breadcrumbs-link:hover {
+  color: var(--inverse-light);
+}
+
+.Breadcrumbs-link:active {
+  color: var(--inverse);
 }
 
 .Breadcrumbs-item:first-child .Breadcrumbs-link {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

truncate the breadcrumb labels after 160px and tooltip on hover.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
