### PR TITLE
fix(choiceList): update spacing between label and choices

### DIFF
--- a/core/components/organisms/choiceList/ChoiceList.tsx
+++ b/core/components/organisms/choiceList/ChoiceList.tsx
@@ -127,7 +127,7 @@ const getCheckboxClassName = (alignment: ChoiceListAlignment, index: number) => 
   const ChoiceListCheckboxClass = classNames({
     [`ChoiceList-checkbox--${alignment}`]: true,
     ['ml-0']: index === 0 && alignment === 'horizontal',
-    ['mt-0']: index === 0 && alignment === 'vertical',
+    ['mt-4']: alignment === 'horizontal',
   });
   return ChoiceListCheckboxClass;
 };
@@ -136,7 +136,7 @@ const getRadioClassName = (alignment: ChoiceListAlignment, index: number) => {
   const ChoiceListRadioClass = classNames({
     [`ChoiceList-radio--${alignment}`]: true,
     ['ml-0']: index === 0 && alignment === 'horizontal',
-    ['mt-0']: index === 0 && alignment === 'vertical',
+    ['mt-4']: alignment === 'horizontal',
   });
   return ChoiceListRadioClass;
 };

--- a/core/components/organisms/choiceList/__tests__/__snapshots__/ChoiceList.test.tsx.snap
+++ b/core/components/organisms/choiceList/__tests__/__snapshots__/ChoiceList.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio ChoiceList-radio--horizontal ml-0"
+          class="Radio ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -64,7 +64,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio ChoiceList-radio--horizontal"
+          class="Radio ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -133,7 +133,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio ChoiceList-radio--horizontal ml-0"
+          class="Radio ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -173,7 +173,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio ChoiceList-radio--horizontal"
+          class="Radio ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -242,7 +242,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -283,7 +283,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -353,7 +353,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -394,7 +394,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -464,7 +464,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -503,7 +503,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal"
+          class="Checkbox ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -571,7 +571,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -610,7 +610,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal"
+          class="Checkbox ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -678,7 +678,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -718,7 +718,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -787,7 +787,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -827,7 +827,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -896,7 +896,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio ChoiceList-radio--vertical mt-0"
+          class="Radio ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1005,7 +1005,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio ChoiceList-radio--vertical mt-0"
+          class="Radio ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1114,7 +1114,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--vertical mt-0"
+          class="Radio Radio--disabled ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1225,7 +1225,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--vertical mt-0"
+          class="Radio Radio--disabled ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1336,7 +1336,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -1443,7 +1443,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -1550,7 +1550,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -1659,7 +1659,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -1768,7 +1768,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio ChoiceList-radio--horizontal ml-0"
+          class="Radio ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1808,7 +1808,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio ChoiceList-radio--horizontal"
+          class="Radio ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1877,7 +1877,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio ChoiceList-radio--horizontal ml-0"
+          class="Radio ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1917,7 +1917,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio ChoiceList-radio--horizontal"
+          class="Radio ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -1986,7 +1986,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2027,7 +2027,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2097,7 +2097,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal ml-0 mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2138,7 +2138,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Radio Radio--disabled ChoiceList-radio--horizontal"
+          class="Radio Radio--disabled ChoiceList-radio--horizontal mt-4"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2208,7 +2208,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2247,7 +2247,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal"
+          class="Checkbox ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2315,7 +2315,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2354,7 +2354,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox ChoiceList-checkbox--horizontal"
+          class="Checkbox ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2422,7 +2422,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2462,7 +2462,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2531,7 +2531,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignHorizontal"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal ml-0 mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2571,7 +2571,7 @@ exports[`ChoiceList component
           </div>
         </div>
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--horizontal mt-4"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -2640,7 +2640,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio ChoiceList-radio--vertical mt-0"
+          class="Radio ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2749,7 +2749,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio ChoiceList-radio--vertical mt-0"
+          class="Radio ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2858,7 +2858,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--vertical mt-0"
+          class="Radio Radio--disabled ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -2969,7 +2969,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Radio Radio--disabled ChoiceList-radio--vertical mt-0"
+          class="Radio Radio--disabled ChoiceList-radio--vertical"
           data-test="DesignSystem-Radio"
         >
           <div
@@ -3080,7 +3080,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -3187,7 +3187,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -3294,7 +3294,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div
@@ -3403,7 +3403,7 @@ exports[`ChoiceList component
         class="ChoiceList--alignVertical"
       >
         <div
-          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical mt-0"
+          class="Checkbox Checkbox--disabled ChoiceList-checkbox--vertical"
           data-test="DesignSystem-Checkbox"
         >
           <div


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Remove the condition that overriding space between the label, and choices for vertical alignment. And add spacing for horizontal alignment.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
