### PR TITLE
fix(dropzone): update format label as per the accept prop in stories

### DIFF
--- a/core/components/molecules/dropzone/__stories__/index.story.jsx
+++ b/core/components/molecules/dropzone/__stories__/index.story.jsx
@@ -65,10 +65,11 @@ export const all = () => {
     <React.Fragment>
       <Dropzone
         accept="image/jpeg, image/png"
-        formatLabel="Accepted formats: PDF, jpg"
+        formatLabel="Accepted formats: jpeg, png"
         sizeLabel="Maximum size: 25 MB"
         multiple={true}
         onDrop={onDropHandler}
+        maxSize={26214400}
         className="mb-5"
         sampleFileLink={
           <Link
@@ -152,10 +153,11 @@ const customCode = `() => {
     <React.Fragment>
       <Dropzone
         accept="image/jpeg, image/png"
-        formatLabel="Accepted formats: PDF, jpg"
+        formatLabel="Accepted formats: jpeg, png"
         sizeLabel="Maximum size: 25 MB"
         multiple={true}
         onDrop={onDropHandler}
+        maxSize={26214400}
         className="mb-5"
         sampleFileLink={(
           <Link

--- a/core/components/molecules/dropzone/__stories__/variants/Disabled.story.jsx
+++ b/core/components/molecules/dropzone/__stories__/variants/Disabled.story.jsx
@@ -9,35 +9,15 @@ export const disabled = () => {
 
   return (
     <div className="w-50 d-flex flex-column align-items-center">
-      <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel="Maximum size: 25 MB"
-        onDrop={onDrop}
-        disabled={true}
-        className="mb-3"
-      />
+      <Dropzone onDrop={onDrop} disabled={true} className="mb-3" />
       <Text size="large" weight="strong">
         Standard
       </Text>
-      <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel="Maximum size: 25 MB"
-        onDrop={onDrop}
-        disabled={true}
-        type="compressed"
-        className="mt-6 mb-3"
-      />
+      <Dropzone onDrop={onDrop} disabled={true} type="compressed" className="mt-6 mb-3" />
       <Text size="large" weight="strong">
         Compressed
       </Text>
-      <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel="Maximum size: 25 MB"
-        onDrop={onDrop}
-        disabled={true}
-        type="tight"
-        className="mt-6 mb-3"
-      />
+      <Dropzone onDrop={onDrop} disabled={true} type="tight" className="mt-6 mb-3" />
       <Text size="large" weight="strong">
         Tight
       </Text>
@@ -53,16 +33,12 @@ const customCode = `() => {
   return (
     <div className="w-50 d-flex flex-column align-items-center">
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel='Maximum size: 25 MB'
         onDrop={onDrop}
         disabled={true}
         className="mb-3"
       />
       <Text size="large" weight="strong">Standard</Text>
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel='Maximum size: 25 MB'
         onDrop={onDrop}
         disabled={true}
         type="compressed"
@@ -70,8 +46,6 @@ const customCode = `() => {
       />
       <Text size="large" weight="strong">Compressed</Text>
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel='Maximum size: 25 MB'
         onDrop={onDrop}
         disabled={true}
         type="tight"

--- a/core/components/molecules/dropzone/__stories__/variants/Format.story.jsx
+++ b/core/components/molecules/dropzone/__stories__/variants/Format.story.jsx
@@ -10,8 +10,7 @@ export const format = () => {
   return (
     <Dropzone
       accept="image/jpeg, image/png"
-      formatLabel="Accepted formats: PDF, jpg"
-      sizeLabel="Maximum size: 25 MB"
+      formatLabel="Accepted formats: jpeg, png"
       onDrop={onDrop}
       className="mb-3"
       sampleFileLink={
@@ -35,8 +34,7 @@ const customCode = `() => {
   return (
     <Dropzone
       accept="image/jpeg, image/png"
-      formatLabel="Accepted formats: PDF, jpg"
-      sizeLabel='Maximum size: 25 MB'
+      formatLabel="Accepted formats: jpeg, png"
       onDrop={onDrop}
       className="mb-3"
       sampleFileLink={(

--- a/core/components/molecules/dropzone/__stories__/variants/Size.story.jsx
+++ b/core/components/molecules/dropzone/__stories__/variants/Size.story.jsx
@@ -10,8 +10,6 @@ export const size = () => {
   return (
     <div className="w-50 d-flex flex-column align-items-center">
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel="Maximum size: 25 MB"
         onDrop={onDrop}
         className="mb-3"
         sampleFileLink={
@@ -28,8 +26,6 @@ export const size = () => {
         Standard
       </Text>
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel="Maximum size: 25 MB"
         onDrop={onDrop}
         type="compressed"
         className="mt-6 mb-3"
@@ -47,8 +43,6 @@ export const size = () => {
         Compressed
       </Text>
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel="Maximum size: 25 MB"
         onDrop={onDrop}
         type="tight"
         className="mt-6 mb-3"
@@ -77,8 +71,6 @@ const customCode = `() => {
   return (
     <div className="w-50 d-flex flex-column align-items-center">
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel='Maximum size: 25 MB'
         onDrop={onDrop}
         className="mb-3"
         sampleFileLink={(
@@ -93,8 +85,6 @@ const customCode = `() => {
       />
       <Text size="large" weight="strong">Standard</Text>
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel='Maximum size: 25 MB'
         onDrop={onDrop}
         type="compressed"
         className="mt-6 mb-3"
@@ -110,8 +100,6 @@ const customCode = `() => {
       />
       <Text size="large" weight="strong">Compressed</Text>
       <Dropzone
-        formatLabel="Accepted formats: PDF, jpg"
-        sizeLabel='Maximum size: 25 MB'
         onDrop={onDrop}
         type="tight"
         className="mt-6 mb-3"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
There is a discrepancy in the format label and accept props in the story as these should communicate the same format that is accepted.So, format label is updated as per the accept props. 
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
