### PR TITLE
fix(dropdown): disable action buttons on option loading state

### DIFF
--- a/core/components/atoms/dropdown/DropdownList.tsx
+++ b/core/components/atoms/dropdown/DropdownList.tsx
@@ -417,7 +417,8 @@ const DropdownList = (props: OptionsProps) => {
   };
 
   const renderApplyButton = () => {
-    const disable = _isEqual(previousSelected, tempSelected);
+    const disable = _isEqual(previousSelected, tempSelected) || props.loadingOptions;
+
     return (
       <div className="Dropdown-buttonWrapper">
         <Button
@@ -425,8 +426,10 @@ const DropdownList = (props: OptionsProps) => {
           className="mr-4"
           appearance={'basic'}
           onClick={onCancelOptions}
+          disabled={props.loadingOptions}
           size={'tiny'}
           tabIndex={-1}
+          data-test="DesignSystem-Dropdown-CancelButton"
           type="button"
         >
           {cancelButtonLabel}
@@ -437,6 +440,7 @@ const DropdownList = (props: OptionsProps) => {
           disabled={disable}
           size={'tiny'}
           onClick={onApplyOptions}
+          data-test="DesignSystem-Dropdown-ApplyButton"
           type="button"
         >
           {applyButtonLabel}

--- a/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
+++ b/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
@@ -311,7 +311,7 @@ describe('renders async dropdown', () => {
 
 describe('Dropdown component', () => {
   it('check prop:showApplyButton', () => {
-    const { getByTestId, getAllByTestId } = render(
+    const { getByTestId } = render(
       <Dropdown
         options={dropdownOptions}
         showApplyButton={true}
@@ -322,9 +322,8 @@ describe('Dropdown component', () => {
     );
     const dropdownTrigger = getByTestId(trigger);
     fireEvent.click(dropdownTrigger);
-    expect(getAllByTestId('DesignSystem-Button')).toHaveLength(2);
-    expect(getAllByTestId('DesignSystem-Button')[0]).toHaveTextContent('Cancel');
-    expect(getAllByTestId('DesignSystem-Button')[1]).toHaveTextContent('Apply');
+    expect(getByTestId('DesignSystem-Dropdown-CancelButton')).toHaveTextContent('Cancel');
+    expect(getByTestId('DesignSystem-Dropdown-ApplyButton')).toHaveTextContent('Apply');
   });
 
   it('check checkbox classes with onClick event', () => {
@@ -452,9 +451,9 @@ describe('Dropdown component action buttons', () => {
     await waitFor(() => {
       expect(getAllByTestId('DesignSystem-DropdownOption--WITH_CHECKBOX')[1]).toBeInTheDocument();
     });
-    expect(getAllByTestId('DesignSystem-Button')[1]).toHaveTextContent('Cancel');
+    expect(getByTestId('DesignSystem-Dropdown-CancelButton')).toHaveTextContent('Cancel');
     fireEvent.click(getAllByTestId('DesignSystem-DropdownOption--WITH_CHECKBOX')[1]);
-    fireEvent.click(getAllByTestId('DesignSystem-Button')[1]);
+    fireEvent.click(getByTestId('DesignSystem-Dropdown-CancelButton'));
     expect(screen.queryByText('DesignSystem-Popover')).not.toBeInTheDocument();
   });
 });
@@ -467,5 +466,91 @@ describe('Dropdown component with search', () => {
     const dropdownTrigger = getByTestId(trigger);
     fireEvent.click(dropdownTrigger);
     expect(screen.getByPlaceholderText('Custom search text')).toBeInTheDocument();
+  });
+});
+
+describe('Dropdown component with actions buttons', () => {
+  it('check for apply button state when options are loading', async () => {
+    const { getByTestId, getAllByTestId } = render(
+      <Dropdown fetchOptions={fetchOptions} withCheckbox={true} showApplyButton={true} />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+
+    expect(getByTestId('DesignSystem-Dropdown-ApplyButton')).toHaveAttribute('disabled');
+    let optionList: HTMLElement[] = [];
+
+    // wait for options to load
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-Checkbox-Label');
+    });
+    fireEvent.click(optionList[1]);
+    const applyButton = getByTestId('DesignSystem-Dropdown-ApplyButton');
+    expect(applyButton).not.toHaveAttribute('disabled');
+    fireEvent.click(applyButton);
+
+    // reopen the dropdown
+    fireEvent.click(dropdownTrigger);
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-Checkbox-Label');
+    });
+
+    // check for previously selected option is in selected state
+    const selectedOption = getAllByTestId('DesignSystem-Checkbox-InputBox')[0];
+    expect(selectedOption).toHaveAttribute('checked');
+
+    // unselect the previously selected option
+    fireEvent.click(selectedOption);
+    const loader = getAllByTestId('DesignSystem-Dropdown--Placeholder')[0];
+
+    // check if applyButton is disabled while options are loading
+    expect(loader).toBeInTheDocument();
+    expect(applyButton).toHaveAttribute('disabled');
+  });
+
+  it('check for apply button state when same options are selected', async () => {
+    const { getByTestId, getAllByTestId } = render(
+      <Dropdown fetchOptions={fetchOptions} withCheckbox={true} showApplyButton={true} />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+
+    expect(getByTestId('DesignSystem-Dropdown-ApplyButton')).toHaveAttribute('disabled');
+    let optionList: HTMLElement[] = [];
+
+    // wait for options to load
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-Checkbox-Label');
+    });
+
+    // select first two options from dropdown list
+    fireEvent.click(optionList[1]);
+    fireEvent.click(optionList[2]);
+
+    const applyButton = getByTestId('DesignSystem-Dropdown-ApplyButton');
+    expect(applyButton).not.toHaveAttribute('disabled');
+    fireEvent.click(applyButton);
+
+    // reopen the dropdown
+    fireEvent.click(dropdownTrigger);
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-Checkbox-Label');
+    });
+
+    // check for previously selected option is in selected state
+    const selectedOption = getAllByTestId('DesignSystem-Checkbox-InputBox');
+    expect(applyButton).toHaveAttribute('disabled');
+
+    // Deselect the previously selected option
+    fireEvent.click(selectedOption[0]);
+    expect(applyButton).not.toHaveAttribute('disabled');
+
+    // applyButton should be disabled if same options are selected
+    fireEvent.click(selectedOption[0]);
+    expect(applyButton).toHaveAttribute('disabled');
+
+    // enable apply button when different options are selected
+    fireEvent.click(selectedOption[4]);
+    expect(applyButton).not.toHaveAttribute('disabled');
   });
 });

--- a/core/components/atoms/dropdown/utility.tsx
+++ b/core/components/atoms/dropdown/utility.tsx
@@ -5,9 +5,21 @@ export const getSearchedOptions = (options: any, searchTerm: string) => {
   return result;
 };
 
-export const _isEqual = (arr1: Option[], arr2: Option[]) =>
-  arr1.length === arr2.length &&
-  arr1.every((option, index) => option.value === arr2[index].value || option.label === arr2[index].label);
+const sortList = (arr: Option[]) => {
+  return arr.sort((a, b) => (a.value > b.value ? 1 : b.value > a.value ? -1 : 0));
+};
+
+export const _isEqual = (firstList: Option[], secondList: Option[]) => {
+  const firstSortedList = sortList(firstList);
+  const secondSortedList = sortList(secondList);
+  return (
+    firstSortedList.length === secondSortedList.length &&
+    firstSortedList.every(
+      (option, index) =>
+        option.value === secondSortedList[index].value || option.label === secondSortedList[index].label
+    )
+  );
+};
 
 export const _isControlled = (selected?: Option[]) => selected !== undefined;
 

--- a/core/components/organisms/grid/__tests__/Grid.test.tsx
+++ b/core/components/organisms/grid/__tests__/Grid.test.tsx
@@ -207,14 +207,14 @@ describe('renders children with pagination and page', () => {
   ];
   const data = [{ name: 'Zara' }];
   it('renders children with pagination', () => {
-    const { getAllByTestId } = render(
+    const { getAllByTestId, getByTestId } = render(
       <Grid withPagination={true} schema={schema} data={data} showFilters={true} updateFilterList={updateFilterList} />
     );
     const popoverButton = getAllByTestId('DesignSystem-Button')[0];
     fireEvent.click(popoverButton);
     const dropdownOption = getAllByTestId('DesignSystem-Checkbox-InputBox')[0];
     fireEvent.click(dropdownOption);
-    const applyButton = getAllByTestId('DesignSystem-Button')[2];
+    const applyButton = getByTestId('DesignSystem-Dropdown-ApplyButton');
     fireEvent.click(applyButton);
     expect(updateFilterList).toHaveBeenCalledTimes(1);
   });

--- a/core/components/organisms/table/__tests__/Table.test.tsx
+++ b/core/components/organisms/table/__tests__/Table.test.tsx
@@ -119,7 +119,7 @@ describe('render Table component with header', () => {
     const dropdownCheckbox = getAllByTestId('DesignSystem-Checkbox-InputBox')[1];
     expect(dropdownCheckbox).not.toBeChecked();
     fireEvent.click(dropdownCheckbox);
-    const applyButton = getAllByTestId('DesignSystem-Button')[3];
+    const applyButton = getByTestId('DesignSystem-Dropdown-ApplyButton');
     fireEvent.click(applyButton);
     expect(dropdownCheckbox).toBeChecked();
   });


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This PR resolves the following issue:
User is able to click on the Apply button while dropdown options are still loading this will cause issues in managing the internal states of selected options. So Apply Button should be disabled while the dropdown options are in loading state
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
