### PR TITLE
fix(dropdown): update callback function call on selected value in menu variant

### DIFF
--- a/core/components/atoms/dropdown/Dropdown.tsx
+++ b/core/components/atoms/dropdown/Dropdown.tsx
@@ -566,14 +566,14 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
   };
 
   onOptionSelect = (option: OptionSchema) => {
-    const { onUpdate, selected } = this.props;
+    const { onUpdate, selected, menu } = this.props;
     if (_isControlled(selected)) {
-      if (onUpdate && this.isValidOption(option)) {
+      if (onUpdate && (this.isValidOption(option) || menu)) {
         onUpdate('select-option', option);
       }
       return;
     }
-    if (this.isValidOption(option)) {
+    if (this.isValidOption(option) || menu) {
       this.updateSelectedOptions([option], true);
     }
   };

--- a/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
+++ b/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
@@ -469,6 +469,81 @@ describe('Dropdown component with search', () => {
   });
 });
 
+describe('Dropdown component', () => {
+  const onUpdateCallback = jest.fn();
+  const options = [
+    {
+      label: `Option 1`,
+      value: `Option 1`,
+      group: 'Group 1',
+      icon: 'events',
+      subInfo: 'subInfo',
+    },
+  ];
+
+  it('check for selecting already selected value in menu dropdown', async () => {
+    const { getByTestId, getAllByTestId } = render(
+      <Dropdown options={dropdownOptions} menu={true} onChange={FunctionValue} />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+    let optionList: HTMLElement[] = [];
+
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-DropdownOption--DEFAULT');
+    });
+    fireEvent.click(optionList[1]);
+    fireEvent.click(optionList[1]);
+    expect(FunctionValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('check for selecting already selected value in dropdown', async () => {
+    jest.resetAllMocks();
+    const { getByTestId, getAllByTestId } = render(<Dropdown options={dropdownOptions} onChange={FunctionValue} />);
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+    let optionList: HTMLElement[] = [];
+
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-DropdownOption--DEFAULT');
+    });
+    fireEvent.click(optionList[0]);
+    fireEvent.click(optionList[0]);
+    expect(FunctionValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('check for selecting already selected value in controlled menu dropdown', async () => {
+    const { getByTestId, getAllByTestId } = render(
+      <Dropdown options={dropdownOptions} menu={true} selected={options} onUpdate={onUpdateCallback} />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+    let optionList: HTMLElement[] = [];
+
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-DropdownOption--DEFAULT');
+    });
+    fireEvent.click(optionList[0]);
+    expect(onUpdateCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('check for selecting already selected value in controlled dropdown', async () => {
+    jest.resetAllMocks();
+    const { getByTestId, getAllByTestId } = render(
+      <Dropdown options={dropdownOptions} selected={options} onUpdate={onUpdateCallback} />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+    let optionList: HTMLElement[] = [];
+
+    await waitFor(() => {
+      optionList = getAllByTestId('DesignSystem-DropdownOption--DEFAULT');
+    });
+    fireEvent.click(optionList[0]);
+    expect(onUpdateCallback).not.toHaveBeenCalled();
+  });
+});
+
 describe('Dropdown component with actions buttons', () => {
   it('check for apply button state when options are loading', async () => {
     const { getByTestId, getAllByTestId } = render(


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
we can select the option again which is already selected and callback function will also called everytime we select the already selected value.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
