### PR TITLE
fix(tabs): center alignment of icons in tabs

### DIFF
--- a/core/components/molecules/tabs/Tabs.tsx
+++ b/core/components/molecules/tabs/Tabs.tsx
@@ -262,6 +262,7 @@ export const Tabs = (props: TabsProps) => {
       ['Tab--disabled']: disabled,
       ['Tab--active']: !disabled && activeIndex === index,
       ['Tab-selected']: !disabled && activeIndex === index,
+      ['align-items-center']: true,
     });
 
     return (

--- a/core/components/molecules/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/core/components/molecules/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Tabs component
       class="TabsWrapper-header"
     >
       <div
-        class="Tab Tab--active Tab-selected"
+        class="Tab Tab--active Tab-selected align-items-center"
         data-test="DesignSystem-Tabs--Tab"
         tabindex="0"
       >
@@ -39,7 +39,7 @@ exports[`Tabs component
         </i>
       </div>
       <div
-        class="Tab"
+        class="Tab align-items-center"
         data-test="DesignSystem-Tabs--Tab"
         tabindex="-1"
       >
@@ -59,7 +59,7 @@ exports[`Tabs component
         </span>
       </div>
       <div
-        class="Tab Tab--disabled"
+        class="Tab Tab--disabled align-items-center"
         data-test="DesignSystem-Tabs--Tab"
         tabindex="-1"
       >
@@ -93,7 +93,7 @@ exports[`Tabs component
       class="TabsWrapper-header TabsWrapper-header--withSeparator"
     >
       <div
-        class="Tab Tab--active Tab-selected"
+        class="Tab Tab--active Tab-selected align-items-center"
         data-test="DesignSystem-Tabs--Tab"
         tabindex="0"
       >
@@ -120,7 +120,7 @@ exports[`Tabs component
         </i>
       </div>
       <div
-        class="Tab"
+        class="Tab align-items-center"
         data-test="DesignSystem-Tabs--Tab"
         tabindex="-1"
       >
@@ -140,7 +140,7 @@ exports[`Tabs component
         </span>
       </div>
       <div
-        class="Tab Tab--disabled"
+        class="Tab Tab--disabled align-items-center"
         data-test="DesignSystem-Tabs--Tab"
         tabindex="-1"
       >


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Vertical alignment of icons in tabs was not in the center. Added styling for the same.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
