### PR TITLE
fix(fileList): fix font size weight and spacing in between the text

### DIFF
--- a/core/components/molecules/fileList/FileListItem.tsx
+++ b/core/components/molecules/fileList/FileListItem.tsx
@@ -89,12 +89,18 @@ export const FileListItem = (props: FileListItemProps) => {
             data-test="DesignSystem-FileListItem--Name"
             className="FileItem-text"
             appearance={status === 'completed' ? 'default' : 'subtle'}
+            weight="medium"
           >
             {name}
           </Text>
         </div>
         <div className="FileItem-actions">
-          <Text className="FileItem-size" appearance={'subtle'} data-test="DesignSystem-FileListItem--Size">
+          <Text
+            className="FileItem-size"
+            size="small"
+            appearance={'subtle'}
+            data-test="DesignSystem-FileListItem--Size"
+          >
             {fileSize || file.size}
           </Text>
           {!!actions && actions}

--- a/core/components/molecules/fileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/core/components/molecules/fileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`FileList component
             />
           </svg>
           <span
-            class="Text Text--subtle Text--regular FileItem-text"
+            class="Text Text--subtle Text--medium Text--regular FileItem-text"
             data-test="DesignSystem-FileListItem--Name"
           >
             Audio File.mp3
@@ -55,7 +55,7 @@ exports[`FileList component
           class="FileItem-actions"
         >
           <span
-            class="Text Text--subtle Text--regular FileItem-size"
+            class="Text Text--subtle Text--small FileItem-size"
             data-test="DesignSystem-FileListItem--Size"
           >
             3 MB
@@ -82,7 +82,7 @@ exports[`FileList component
             movie
           </i>
           <span
-            class="Text Text--default Text--regular FileItem-text"
+            class="Text Text--default Text--medium Text--regular FileItem-text"
             data-test="DesignSystem-FileListItem--Name"
           >
             Video File.mp4
@@ -92,7 +92,7 @@ exports[`FileList component
           class="FileItem-actions"
         >
           <span
-            class="Text Text--subtle Text--regular FileItem-size"
+            class="Text Text--subtle Text--small FileItem-size"
             data-test="DesignSystem-FileListItem--Size"
           >
             4 MB
@@ -119,7 +119,7 @@ exports[`FileList component
             image
           </i>
           <span
-            class="Text Text--subtle Text--regular FileItem-text"
+            class="Text Text--subtle Text--medium Text--regular FileItem-text"
             data-test="DesignSystem-FileListItem--Name"
           >
             Image File.jpeg
@@ -129,7 +129,7 @@ exports[`FileList component
           class="FileItem-actions"
         >
           <span
-            class="Text Text--subtle Text--regular FileItem-size"
+            class="Text Text--subtle Text--small FileItem-size"
             data-test="DesignSystem-FileListItem--Size"
           >
             3 MB
@@ -175,7 +175,7 @@ exports[`FileList component
             insert_drive_file
           </i>
           <span
-            class="Text Text--default Text--regular FileItem-text"
+            class="Text Text--default Text--medium Text--regular FileItem-text"
             data-test="DesignSystem-FileListItem--Name"
           >
             Document File.pdf
@@ -185,7 +185,7 @@ exports[`FileList component
           class="FileItem-actions"
         >
           <span
-            class="Text Text--subtle Text--regular FileItem-size"
+            class="Text Text--subtle Text--small FileItem-size"
             data-test="DesignSystem-FileListItem--Size"
           >
             3 MB
@@ -212,7 +212,7 @@ exports[`FileList component
             text_snippet
           </i>
           <span
-            class="Text Text--default Text--regular FileItem-text"
+            class="Text Text--default Text--medium Text--regular FileItem-text"
             data-test="DesignSystem-FileListItem--Name"
           >
             Other File
@@ -222,7 +222,7 @@ exports[`FileList component
           class="FileItem-actions"
         >
           <span
-            class="Text Text--subtle Text--regular FileItem-size"
+            class="Text Text--subtle Text--small FileItem-size"
             data-test="DesignSystem-FileListItem--Size"
           >
             3 MB

--- a/css/src/components/fileList.css
+++ b/css/src/components/fileList.css
@@ -23,6 +23,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-shrink: 0;
 }
 .FileItem-file {
   display: flex;
@@ -38,6 +39,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-right: var(--spacing);
   margin-left: var(--spacing-l);
 }
 .FileItem-error {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- In the third row of the file list fix the spacing between the image text and 3MB, there should be a spacing of 8px between them
- The font size of 3MB is 12 not 14
- Fix the alignment of the close button
- The font weight of file name is medium, it's not regular
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
