### PR TITLE
fix(dropdown): update selection label, padding and option grouping

### DIFF
--- a/css/src/components/dropdown.css
+++ b/css/src/components/dropdown.css
@@ -31,12 +31,12 @@
   justify-content: space-between;
   align-items: center;
   margin-left: var(--spacing-l);
-  margin-top: var(--spacing);
+  margin-top: var(--spacing-l);
   margin-bottom: 6px;
 }
 
 .Dropdown-section--withClear {
-  margin-top: var(--spacing-m);
+  margin-top: var(--spacing);
   margin-bottom: var(--spacing-s);
 }
 
@@ -70,7 +70,7 @@
   padding-top: 6px;
   padding-bottom: 6px;
   padding-left: var(--spacing-l);
-  padding-right: var(--spacing-l);
+  padding-right: var(--spacing);
 }
 
 .Option-checkbox .Checkbox-outerWrapper {

--- a/css/src/components/dropdownButton.css
+++ b/css/src/components/dropdownButton.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: row;
   overflow: hidden;
+  align-items: center;
 }
 
 .DropdownButton-text {


### PR DESCRIPTION
Current PR makes following changes:
- When number of available options greater than 50, All Item label will be displayed on selecting options.
- Add allItemsSectionLabel prop for user to input desired label for rest non selected items.
- Fix padding for options.
- Add grouping logic for different option groups provided by user.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
