### PR TITLE
fix(dateRangePicker): fix range selection behaviour

### DIFF
--- a/core/components/organisms/calendar/__stories__/index.story.jsx
+++ b/core/components/organisms/calendar/__stories__/index.story.jsx
@@ -8,10 +8,6 @@ export const all = () => {
 
   const dateValue = new Date('Jan 11 2023');
 
-  const startDate = new Date('Jan 15 2023');
-
-  const endDate = new Date('Jan 20 2023');
-
   const view = 'date';
 
   const rangePicker = false;
@@ -97,8 +93,6 @@ export const all = () => {
       rangePicker={rangePicker}
       jumpView={jumpView}
       date={convertToDate(dateValue)}
-      startDate={convertToDate(startDate)}
-      endDate={convertToDate(endDate)}
       onDateChange={(currDate) => action(`on date change : ${currDate}`)()}
       onRangeChange={(sDate, eDate) => action(`on range change: ${sDate} - ${eDate}`)()}
       view={view}

--- a/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
+++ b/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
@@ -315,7 +315,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -955,7 +955,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -1595,7 +1595,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -2236,7 +2236,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -2930,7 +2930,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -3525,7 +3525,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -4219,7 +4219,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -4792,7 +4792,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -5475,7 +5475,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -6092,7 +6092,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -6742,7 +6742,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -7348,7 +7348,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -7968,7 +7968,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -8983,7 +8983,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -10555,7 +10555,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -11252,7 +11252,7 @@ exports[`Calendar component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--regular color-primary Calendar-text"
+                class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2021
@@ -11655,7 +11655,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -12275,7 +12275,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -13290,7 +13290,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -14862,7 +14862,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   15
@@ -15559,7 +15559,7 @@ exports[`Calendar component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--small color-primary Calendar-text"
+                class="Text Text--small color-primary Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2021

--- a/core/components/organisms/calendar/utility.ts
+++ b/core/components/organisms/calendar/utility.ts
@@ -174,3 +174,30 @@ export const translateToDate = (format: string, val: string, validators: Validat
     return undefined;
   }
 };
+
+export const dateComparison = (
+  date: Date | undefined,
+  operator: Operator,
+  currDate: string,
+  currMonth: string,
+  currYear: string
+): boolean => {
+  const currentDate = new Date(`${currYear}-${currMonth}-${currDate}`);
+
+  if (date) {
+    switch (operator) {
+      case 'less':
+        return date <= currentDate;
+
+      case 'equal':
+        return date.toDateString() === currentDate.toDateString();
+
+      case 'more':
+        return date >= currentDate;
+
+      default:
+        return false;
+    }
+  }
+  return false;
+};

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -157,7 +157,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -2145,7 +2145,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -2807,7 +2807,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -3469,7 +3469,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -4374,7 +4374,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   data-test="DesignSystem-Calendar--yearValue"
                 >
                   <span
-                    class="Text Text--regular color-primary Calendar-text"
+                    class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
                     data-test="DesignSystem-Text"
                   >
                     2021
@@ -4638,7 +4638,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--regular color-white Calendar-value Calendar-inRangeValue Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1

--- a/core/components/organisms/dateRangePicker/__tests__/DateRangePicker.test.tsx
+++ b/core/components/organisms/dateRangePicker/__tests__/DateRangePicker.test.tsx
@@ -763,8 +763,6 @@ describe('DateRangePicker component with prop:rangeLimit', () => {
         onRangeChange={FunctionValue}
       />
     );
-    // expect(getAllByTestId('designSystem-Calendar-WrapperClass')[5])
-    // .toHaveClass('Calendar-valueWrapper--inRangeError');
     expect(FunctionValue).toHaveBeenCalled();
   });
 });

--- a/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
@@ -239,11 +239,11 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--end"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-inverse-lightest Calendar-value Calendar-value--end Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white inverse-lightest Calendar-value Calendar-value--active Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -865,11 +865,11 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--end"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-inverse-lightest Calendar-value Calendar-value--end Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white inverse-lightest Calendar-value Calendar-value--active Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -1387,7 +1387,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -1453,7 +1453,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -1468,7 +1468,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -1505,7 +1505,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -2012,7 +2012,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -2078,7 +2078,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -2093,7 +2093,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -2108,7 +2108,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -2637,7 +2637,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -2703,7 +2703,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -2718,7 +2718,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -2766,7 +2766,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -3262,7 +3262,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -3328,7 +3328,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -3343,7 +3343,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -3369,7 +3369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -3887,7 +3887,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -3953,7 +3953,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -3968,7 +3968,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -3994,7 +3994,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -4512,7 +4512,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -4578,7 +4578,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -4593,11 +4593,11 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--end"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -5137,7 +5137,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -5203,7 +5203,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -5218,7 +5218,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -5233,7 +5233,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -5762,7 +5762,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -5828,7 +5828,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -5843,7 +5843,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -5869,7 +5869,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -6387,7 +6387,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -6453,7 +6453,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -6468,7 +6468,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -6494,7 +6494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -7012,7 +7012,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -7078,7 +7078,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -7093,7 +7093,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -7119,7 +7119,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -7637,7 +7637,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -7703,7 +7703,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -7718,7 +7718,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -7744,7 +7744,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -8262,7 +8262,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -8328,7 +8328,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -8343,7 +8343,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -8369,7 +8369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -8887,7 +8887,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -8953,7 +8953,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -8968,7 +8968,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -8994,7 +8994,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -9512,7 +9512,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -9578,7 +9578,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -9593,7 +9593,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -9619,7 +9619,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -10137,7 +10137,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -10203,7 +10203,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -10218,7 +10218,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -10244,7 +10244,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -10762,7 +10762,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -10828,7 +10828,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -10843,7 +10843,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -10869,7 +10869,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -11387,7 +11387,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -11453,7 +11453,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -11468,7 +11468,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -11494,7 +11494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -12012,7 +12012,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -12078,7 +12078,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -12093,7 +12093,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -12119,7 +12119,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -12637,7 +12637,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -12703,7 +12703,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -12718,7 +12718,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -12744,7 +12744,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -13262,7 +13262,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -13328,7 +13328,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -13343,7 +13343,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -13369,7 +13369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -13887,7 +13887,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -13953,7 +13953,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -13968,7 +13968,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -13994,7 +13994,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -14512,7 +14512,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -14578,7 +14578,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -14593,7 +14593,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -14619,7 +14619,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -15137,7 +15137,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -15203,7 +15203,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -15218,7 +15218,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -15244,7 +15244,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -15762,7 +15762,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -15828,7 +15828,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -15843,7 +15843,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -15869,7 +15869,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -16387,7 +16387,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -16453,7 +16453,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -16468,7 +16468,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -16494,7 +16494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -17012,7 +17012,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -17078,7 +17078,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -17093,7 +17093,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -17119,7 +17119,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -17637,7 +17637,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -17703,7 +17703,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -17718,7 +17718,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -17744,7 +17744,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -18262,7 +18262,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -18328,7 +18328,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -18343,7 +18343,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -18369,7 +18369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -18887,7 +18887,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -18953,7 +18953,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -18968,7 +18968,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -18994,7 +18994,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -19512,7 +19512,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -19578,7 +19578,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -19593,7 +19593,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -19619,7 +19619,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -20137,7 +20137,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -20203,7 +20203,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -20218,7 +20218,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -20244,7 +20244,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -20762,7 +20762,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -20828,7 +20828,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -20843,7 +20843,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -20869,7 +20869,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -21387,7 +21387,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -21453,7 +21453,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -21468,7 +21468,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -21494,7 +21494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -22012,7 +22012,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -22078,7 +22078,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -22093,7 +22093,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -22119,7 +22119,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -22637,7 +22637,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -22703,7 +22703,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -22718,7 +22718,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -22744,7 +22744,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -23262,7 +23262,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -23328,7 +23328,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -23343,7 +23343,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -23369,7 +23369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -23887,7 +23887,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -23953,7 +23953,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -23968,7 +23968,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -23994,7 +23994,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -24512,7 +24512,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -24578,7 +24578,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -24593,7 +24593,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -24619,7 +24619,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -25137,7 +25137,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -25203,7 +25203,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -25218,7 +25218,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -25244,7 +25244,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -25762,7 +25762,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -25828,7 +25828,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -25843,7 +25843,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -25869,7 +25869,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -26387,7 +26387,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -26453,7 +26453,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -26468,7 +26468,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -26494,7 +26494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -27012,7 +27012,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -27078,7 +27078,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -27093,7 +27093,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -27119,7 +27119,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -27637,7 +27637,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -27703,7 +27703,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -27718,7 +27718,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -27744,7 +27744,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -28262,7 +28262,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28328,7 +28328,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28343,7 +28343,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28409,7 +28409,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28424,7 +28424,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28490,7 +28490,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28505,7 +28505,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28571,7 +28571,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28586,7 +28586,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28652,7 +28652,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28667,7 +28667,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28733,7 +28733,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28868,7 +28868,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28934,7 +28934,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -28949,7 +28949,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29015,7 +29015,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29030,7 +29030,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29096,7 +29096,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29111,7 +29111,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29177,7 +29177,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29192,7 +29192,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29223,7 +29223,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -29337,7 +29337,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -29396,7 +29396,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29411,7 +29411,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29477,7 +29477,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29492,7 +29492,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29558,7 +29558,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29573,7 +29573,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29639,7 +29639,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29654,7 +29654,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29720,7 +29720,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29855,7 +29855,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29921,7 +29921,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -29936,7 +29936,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30002,7 +30002,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30017,7 +30017,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30083,7 +30083,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30098,7 +30098,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30164,7 +30164,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30179,7 +30179,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30210,7 +30210,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -30305,7 +30305,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -30364,7 +30364,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30379,7 +30379,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30445,7 +30445,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30460,7 +30460,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30526,7 +30526,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30541,7 +30541,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30607,7 +30607,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30622,7 +30622,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30674,7 +30674,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -30788,7 +30788,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -30826,7 +30826,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30841,7 +30841,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30907,7 +30907,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30922,7 +30922,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -30988,7 +30988,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31003,7 +31003,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31069,7 +31069,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31084,7 +31084,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31150,7 +31150,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31304,7 +31304,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31370,7 +31370,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31385,7 +31385,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31451,7 +31451,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31466,7 +31466,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31532,7 +31532,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31547,7 +31547,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31613,7 +31613,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31628,7 +31628,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31694,7 +31694,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31709,7 +31709,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31775,7 +31775,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31910,7 +31910,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31976,7 +31976,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -31991,7 +31991,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32057,7 +32057,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32072,7 +32072,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32138,7 +32138,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32153,7 +32153,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32219,7 +32219,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32234,7 +32234,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32286,7 +32286,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -32400,7 +32400,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -32438,7 +32438,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32453,7 +32453,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32519,7 +32519,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32534,7 +32534,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32600,7 +32600,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32615,7 +32615,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32681,7 +32681,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32696,7 +32696,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32762,7 +32762,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32897,7 +32897,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32963,7 +32963,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -32978,7 +32978,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33044,7 +33044,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33059,7 +33059,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33125,7 +33125,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33140,7 +33140,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33206,7 +33206,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33221,7 +33221,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33273,7 +33273,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -33368,7 +33368,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -33406,7 +33406,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33421,7 +33421,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33487,7 +33487,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33502,7 +33502,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33568,7 +33568,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33583,7 +33583,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33649,7 +33649,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33664,7 +33664,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33730,7 +33730,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -33844,7 +33844,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -33868,7 +33868,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33883,7 +33883,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33949,7 +33949,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -33964,7 +33964,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34030,7 +34030,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34045,7 +34045,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34111,7 +34111,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34126,7 +34126,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34192,7 +34192,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34207,7 +34207,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34273,7 +34273,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34427,7 +34427,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34493,7 +34493,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34508,7 +34508,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34574,7 +34574,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34589,7 +34589,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34655,7 +34655,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34670,7 +34670,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34736,7 +34736,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34751,7 +34751,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34817,7 +34817,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34832,7 +34832,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -34898,7 +34898,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35033,7 +35033,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35099,7 +35099,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35114,7 +35114,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35180,7 +35180,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35195,7 +35195,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35261,7 +35261,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35276,7 +35276,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35342,7 +35342,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35357,7 +35357,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35423,7 +35423,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -35537,7 +35537,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -35561,7 +35561,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35576,7 +35576,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35642,7 +35642,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35657,7 +35657,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35723,7 +35723,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35738,7 +35738,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35804,7 +35804,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35819,7 +35819,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35885,7 +35885,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35900,7 +35900,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -35966,7 +35966,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36101,7 +36101,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36167,7 +36167,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36182,7 +36182,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36248,7 +36248,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36263,7 +36263,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36329,7 +36329,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36344,7 +36344,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36410,7 +36410,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36425,7 +36425,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36491,7 +36491,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -36586,7 +36586,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -36610,7 +36610,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36625,7 +36625,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36691,7 +36691,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36706,7 +36706,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36772,7 +36772,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36787,7 +36787,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36853,7 +36853,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36868,7 +36868,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36934,7 +36934,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36949,7 +36949,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -36987,7 +36987,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
             </div>
@@ -37101,7 +37101,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               />
               <div
@@ -37153,7 +37153,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -37168,7 +37168,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -37194,7 +37194,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -37631,7 +37631,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -37697,7 +37697,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -37712,7 +37712,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -37738,7 +37738,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -38513,7 +38513,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--regular color-primary Calendar-text"
+                class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2023
@@ -39133,7 +39133,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -39199,7 +39199,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -39214,7 +39214,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -39240,7 +39240,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -40015,7 +40015,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--small color-primary Calendar-text"
+                class="Text Text--small color-primary Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2023
@@ -40635,7 +40635,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -40701,7 +40701,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -40716,7 +40716,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -40742,7 +40742,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -41517,7 +41517,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--regular color-primary Calendar-text"
+                class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2023
@@ -41835,7 +41835,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -41901,7 +41901,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -41916,7 +41916,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -41942,7 +41942,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -42962,7 +42962,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -43028,7 +43028,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -43043,7 +43043,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -43069,7 +43069,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -44089,7 +44089,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -44155,7 +44155,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -44170,7 +44170,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -44196,7 +44196,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -45095,7 +45095,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -45161,7 +45161,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -45176,7 +45176,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -45202,7 +45202,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -45977,7 +45977,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--small color-primary Calendar-text"
+                class="Text Text--small color-primary Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2023
@@ -46295,7 +46295,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -46361,7 +46361,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -46376,7 +46376,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -46402,7 +46402,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -47422,7 +47422,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -47488,7 +47488,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -47503,7 +47503,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -47529,7 +47529,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -48549,7 +48549,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -48615,7 +48615,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -48630,7 +48630,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--inRangeError"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inRangeError Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -48656,7 +48656,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--small color-white Calendar-value Calendar-value--end Calendar-value--endError Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -49555,7 +49555,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -49621,7 +49621,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -49636,7 +49636,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -49662,7 +49662,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -50180,7 +50180,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--dummy"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--dummy Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -50246,7 +50246,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -50261,7 +50261,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -50287,7 +50287,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -53250,7 +53250,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -53875,7 +53875,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -54500,7 +54500,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -55125,7 +55125,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -55750,7 +55750,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -56375,7 +56375,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -57000,7 +57000,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -57625,7 +57625,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -58250,7 +58250,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -58875,7 +58875,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -59500,7 +59500,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -60125,7 +60125,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -60750,7 +60750,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -61375,7 +61375,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -62000,7 +62000,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -62625,7 +62625,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--regular color-white Calendar-value Calendar-value--end Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-white Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -65422,7 +65422,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -66047,7 +66047,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -66672,7 +66672,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -67297,7 +67297,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -67922,7 +67922,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -68547,7 +68547,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -69172,7 +69172,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -69797,7 +69797,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -70422,7 +70422,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -71047,7 +71047,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -71672,7 +71672,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -72297,7 +72297,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -72922,7 +72922,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -73547,7 +73547,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -74172,7 +74172,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -74797,7 +74797,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--startEnd"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange Calendar-valueWrapper--start Calendar-valueWrapper--end"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -75455,7 +75455,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -76010,7 +76010,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -76635,7 +76635,7 @@ exports[`DateRangePicker component
                 </span>
               </div>
               <div
-                class="Calendar-valueWrapper"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inEndRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
@@ -76650,7 +76650,7 @@ exports[`DateRangePicker component
               class="Calendar-valueRow"
             >
               <div
-                class="Calendar-valueWrapper"
+                class="Calendar-valueWrapper Calendar-valueWrapper--inEdgeRange Calendar-valueWrapper--inStartRange"
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -415,7 +415,7 @@ exports[`TS renders children 1`] = `
                   data-test="designSystem-Calendar-WrapperClass"
                 >
                   <span
-                    class="Text Text--regular color-primary Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large Calendar-value--currDateMonthYear"
+                    class="Text Text--regular color-primary Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large Calendar-value--currDateMonthYear Calendar-value--currDate"
                     data-test="DesignSystem-Calendar--dateValue"
                   >
                     14
@@ -2065,7 +2065,7 @@ exports[`TS renders children 1`] = `
               data-test="designSystem-Calendar-WrapperClass"
             >
               <span
-                class="Text Text--regular color-primary Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large Calendar-value--currDateMonthYear"
+                class="Text Text--regular color-primary Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large Calendar-value--currDateMonthYear Calendar-value--currDate"
                 data-test="DesignSystem-Calendar--dateValue"
               >
                 14

--- a/css/src/components/calendar.css
+++ b/css/src/components/calendar.css
@@ -142,6 +142,11 @@
   border-radius: 0 var(--spacing-m) var(--spacing-m) 0;
 }
 
+.Calendar-valueWrapper--hoverDate {
+  background: linear-gradient(90deg, var(--primary-lightest) 10%, white 50%);
+  border-radius: 0 var(--spacing-m) var(--spacing-m) 0;
+}
+
 .Calendar-valueWrapper--endError {
   background: linear-gradient(90deg, var(--alert-lightest) 50%, white 50%);
 }
@@ -167,6 +172,10 @@
 
 .Calendar-value:active {
   background: var(--secondary);
+}
+
+.Calendar-value:active .Calendar-value--currDate {
+  color: var(--primary-dark);
 }
 
 .Calendar-value--start:hover,
@@ -199,6 +208,10 @@
 
 .Calendar-value--currDateMonthYear:active {
   background: var(--primary-lighter);
+}
+
+.Calendar-value--currDate:active {
+  color: var(--primary-dark);
 }
 
 .Calendar-value--active {
@@ -276,4 +289,24 @@
 }
 .Calendar-eventsIndicator--active {
   background-color: var(--white);
+}
+
+.Calendar-valueWrapper--inStartRange {
+  background: linear-gradient(90deg, white 50%, var(--primary-lightest) 50%);
+}
+
+.Calendar-valueWrapper--inEndRange {
+  background: linear-gradient(90deg, var(--primary-lightest) 50%, white 50%);
+}
+
+.Calendar-valueWrapper--inEdgeRange .Calendar-inRangeValue {
+  background: var(--primary-lightest);
+}
+
+.Calendar-valueWrapper--inEdgeRange .Calendar-inRangeValue:hover {
+  background: var(--primary-lighter);
+}
+
+.Calendar-valueWrapper--inEdgeRange .Calendar-inRangeValue:active {
+  background: var(--primary-light);
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR resolves the following issues:
- Selection behaviour for next/previous month is incorrect.
- Selected state of previous month's date is incorrect.
- While selecting the dates from next month, adjacent dates should not show hover state. 
- Fix active state of current date

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
