### PR TITLE
fix(dropdown): update selection label and padding

### DIFF
--- a/core/components/atoms/dropdown/DropdownList.tsx
+++ b/core/components/atoms/dropdown/DropdownList.tsx
@@ -62,6 +62,11 @@ export interface DropdownListProps extends TriggerAndOptionProps {
    */
   selectedSectionLabel?: string;
   /**
+   * Label for the rest all items options section
+   * @default "All Items"
+   */
+  allItemsSectionLabel?: string;
+  /**
    * Label of Apply button
    *
    * (visible in case of `withCheckbox` and `showApplyButton`)
@@ -310,15 +315,6 @@ const DropdownList = (props: OptionsProps) => {
     minHeight: minHeight,
   };
 
-  const getDropdownClass = (index: number, isGroup: boolean) => {
-    const Dropdown = classNames({
-      ['Dropdown--border']: isGroup && index !== 0,
-      ['Option-checkboxWrapper']: true,
-    });
-
-    return Dropdown;
-  };
-
   const getDropdownSectionClass = (showClearButton?: boolean) => {
     return classNames({
       ['Dropdown-section']: true,
@@ -540,7 +536,12 @@ const DropdownList = (props: OptionsProps) => {
   };
 
   const renderDropdownSection = () => {
-    const { selectedSectionLabel = 'Selected Items', loadersCount = 10, loadingOptions } = props;
+    const {
+      selectedSectionLabel = 'Selected Items',
+      allItemsSectionLabel = 'All Items',
+      loadersCount = 10,
+      loadingOptions,
+    } = props;
     const selectAllPresent = _isSelectAllPresent(searchTerm, remainingOptions, withSelectAll, withCheckbox);
 
     const groupedListOptions = groupListOptions(listOptions);
@@ -571,16 +572,20 @@ const DropdownList = (props: OptionsProps) => {
         {selectAllPresent && renderSelectAll()}
         {selected.length > 0 && renderGroups(selectedSectionLabel, true)}
         {selected.map((option, index) => renderOptions(option, index))}
+        {selected.length > 0 &&
+          listOptions.length - selected.length > 0 &&
+          !listOptions[0].group?.trim() && // allItemsSectionLabel is displayed only when there are no groups
+          renderGroups(allItemsSectionLabel)}
         {groupedListOptions.map((option, index) => {
           const prevGroup =
             index > 0 ? groupedListOptions[index - 1].group : selected.length ? selectedSectionLabel : undefined;
           const currentGroup = option.group;
-          const isGroup = prevGroup !== currentGroup;
+          const isGroupDifferent = prevGroup !== currentGroup;
           const updatedIndex = index + selected.length;
 
           return (
-            <div className={getDropdownClass(updatedIndex, isGroup)} key={index}>
-              {isGroup && currentGroup && renderGroups(currentGroup)}
+            <div className="Option-checkboxWrapper" key={index}>
+              {isGroupDifferent && currentGroup && renderGroups(currentGroup)}
               {renderOptions(option, updatedIndex)}
             </div>
           );

--- a/core/components/atoms/dropdown/__stories__/Options.tsx
+++ b/core/components/atoms/dropdown/__stories__/Options.tsx
@@ -150,11 +150,12 @@ for (let i = 1; i <= 10; i++) {
 
 export const groupedStoryOptions: OptionSchema[] = [];
 
-for (let i = 1; i <= 10; i++) {
+for (let i = 1; i <= 100; i++) {
   groupedStoryOptions.push({
     label: `Option ${i}`,
     value: `Option ${i}`,
     group: i >= 3 && i <= 6 ? 'Group 1' : 'Group 2',
+    selected: i === 2 || i === 5,
     icon: 'events',
     subInfo: 'subInfo',
   });

--- a/core/components/atoms/dropdown/__tests__/Option.test.tsx
+++ b/core/components/atoms/dropdown/__tests__/Option.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import { Dropdown } from '@/index';
 
 import {
@@ -9,6 +9,7 @@ import {
   disabledStoryOptions,
   iconWithSubinfoOptions,
   groupedStoryOptions,
+  preSelectedOptions,
 } from '../__stories__/Options';
 
 const FunctionValue = jest.fn();
@@ -195,6 +196,32 @@ describe('renders selected option', () => {
     expect(selectedOption).toHaveClass('Option--selected');
     expect(selectedOption).toHaveClass('color-primary-dark');
   });
+
+  it('with All Items label', async () => {
+    const { getAllByTestId, getByTestId } = render(<Dropdown options={preSelectedOptions} withCheckbox={true} />);
+
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+
+    await waitFor(() => {
+      const labels = getAllByTestId('DesignSystem-Text');
+      const count = labels.filter((label) => label.textContent === 'All Items').length;
+      expect(count).toBe(1);
+    });
+  });
+
+  it('without All Items label when options are grouped', async () => {
+    const { getAllByTestId, getByTestId } = render(<Dropdown options={groupedStoryOptions} withCheckbox={true} />);
+
+    const dropdownTrigger = getByTestId(trigger);
+    fireEvent.click(dropdownTrigger);
+
+    await waitFor(() => {
+      const labels = getAllByTestId('DesignSystem-Text');
+      const count = labels.filter((label) => label.textContent === 'All Items').length;
+      expect(count).toBe(0);
+    });
+  });
 });
 
 describe('renders disabled option', () => {
@@ -235,13 +262,15 @@ describe('renders disabled option', () => {
 });
 
 describe('renders grouped option', () => {
-  it('with same groups together', () => {
+  it('with same groups together', async () => {
     const { getAllByTestId, getByTestId } = render(<Dropdown options={groupedStoryOptions} withCheckbox={true} />);
     const dropdownTrigger = getByTestId(trigger);
     fireEvent.click(dropdownTrigger);
 
-    const labels = getAllByTestId('DesignSystem-Text');
-    const count = labels.filter((label) => label.textContent === 'Group 2').length;
-    expect(count).toBe(1);
+    await waitFor(() => {
+      const labels = getAllByTestId('DesignSystem-Text');
+      const count = labels.filter((label) => label.textContent === 'Group 2').length;
+      expect(count).toBe(1);
+    });
   });
 });

--- a/css/src/components/dropdown.css
+++ b/css/src/components/dropdown.css
@@ -31,17 +31,13 @@
   justify-content: space-between;
   align-items: center;
   margin-left: var(--spacing-l);
-  margin-top: var(--spacing);
+  margin-top: var(--spacing-l);
   margin-bottom: 6px;
 }
 
 .Dropdown-section--withClear {
-  margin-top: var(--spacing-m);
+  margin-top: var(--spacing);
   margin-bottom: var(--spacing-s);
-}
-
-.Dropdown--border {
-  border-top: var(--spacing-xs) solid var(--secondary-light);
 }
 
 .Dropdown-buttonWrapper {
@@ -70,7 +66,7 @@
   padding-top: 6px;
   padding-bottom: 6px;
   padding-left: var(--spacing-l);
-  padding-right: var(--spacing-l);
+  padding-right: var(--spacing);
 }
 
 .Option-checkbox .Checkbox-outerWrapper {

--- a/css/src/components/dropdownButton.css
+++ b/css/src/components/dropdownButton.css
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: row;
   overflow: hidden;
+  align-items: center;
 }
 
 .DropdownButton-text {


### PR DESCRIPTION
Current PR makes following changes:
- When number of available options greater than 50, All Item label will be displayed on selecting options if groups are not present.
- Add allItemsSectionLabel prop for user to input desired label for rest non selected items.
- Fix padding for options.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
