### PR TITLE
fix(table): update draggable dropdown

### DIFF
--- a/core/components/organisms/table/__tests__/Table.test.tsx
+++ b/core/components/organisms/table/__tests__/Table.test.tsx
@@ -230,6 +230,18 @@ describe('render Table component with header', () => {
 });
 
 describe('render Table component with DraggableDropdown', () => {
+  it('render table : draggableDropDown Apply button is enabled on change', () => {
+    const schema = [{ name: 'name', displayName: 'Name', width: '50%' }];
+    const { getAllByTestId } = render(<Table withHeader={true} data={tableData} schema={schema} />);
+    const draggableDropdown = getAllByTestId('DesignSystem-Button')[0];
+    fireEvent.click(draggableDropdown);
+    const draggableApplyButton = getAllByTestId('DesignSystem-Button')[3];
+    expect(draggableApplyButton).toHaveAttribute('disabled');
+    const draggableDropdownCheckbox = getAllByTestId('DesignSystem-Checkbox-InputBox')[0];
+    fireEvent.click(draggableDropdownCheckbox);
+    expect(draggableApplyButton).not.toHaveAttribute('disabled');
+  });
+
   it('render table : draggableDropDown Apply button is triggered', () => {
     const schema = [{ name: 'name', displayName: 'Name', width: '50%' }];
     const { getAllByTestId } = render(<Table withHeader={true} data={tableData} schema={schema} />);

--- a/core/components/organisms/table/utility.tsx
+++ b/core/components/organisms/table/utility.tsx
@@ -1,0 +1,8 @@
+import { OptionSchema as Option } from '@/components/atoms/dropdown/option';
+
+export const _isEqual = (firstList: Option[], secondList: Option[]) => {
+  return (
+    firstList.every((option, index) => option.selected === secondList[index].selected) &&
+    firstList.every((option, index) => option.value === secondList[index].value)
+  );
+};

--- a/core/components/patterns/table/TableWithHeader/style.css
+++ b/core/components/patterns/table/TableWithHeader/style.css
@@ -16,6 +16,13 @@
   padding: 0 var(--spacing-l);
 }
 
+.Table-filters--horizontal {
+  flex-direction: row;
+  height: 100%;
+  width: 100%;
+  padding: 0 var(--spacing-l);
+}
+
 .Table-filtersHeading {
   display: flex;
   align-items: center;
@@ -39,7 +46,7 @@
 }
 
 .Table-filters--horizontal .Table-filter {
-  padding: 0 var(--spacing-m);
+  padding: 0 var(--spacing);
 }
 
 .Table-filters--horizontal .Table-filter:first-of-type {

--- a/css/src/components/grid.css
+++ b/css/src/components/grid.css
@@ -588,3 +588,11 @@
     )
     1 100%;
 }
+
+.DraggableDropdown--open {
+  background-color: var(--secondary-dark) !important;
+}
+
+.reorderIcon {
+  color: var(--inverse-lighter);
+}


### PR DESCRIPTION
Current PR fixes the foll
owing:
- update draggable dropdown trigger background color on open state.
- update reorder icon color to #868686(night-lighter).
- update apply button to be disabled by default.
- update overflow behaviour of draggable dropdown options.
- update Table with header pattern.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
