### PR TITLE
fix(input): update left right spacing and stories

### DIFF
--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -192,6 +192,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
       [`Input--${size}`]: size,
       ['Input--disabled']: disabled || readOnly,
       ['Input--error']: error,
+      ['Input--leftIcon']: size !== 'tiny' && icon,
+      ['Input--rightIcon']: !disabled && (info || ((actionIcon || onClear) && (value || defaultValue))),
     },
     className
   );

--- a/core/components/atoms/input/__stories__/InputWithHelpText.story.jsx
+++ b/core/components/atoms/input/__stories__/InputWithHelpText.story.jsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { Input, Label, HelpText } from '@/index';
+import { Input, Label, HelpText, Row, Column } from '@/index';
 import ActionButton from '../actionButton';
 
 export const inputWithHelpText = () => {
   const [visibility, setVisibility] = React.useState(false);
   const [visibility2, setVisibility2] = React.useState(false);
   return (
-    <div className="d-flex">
-      <div>
+    <Row>
+      <Column size={4}>
         <Label htmlFor="password-1" withInput={true}>
           Password
         </Label>
@@ -25,8 +25,8 @@ export const inputWithHelpText = () => {
           }
         />
         <HelpText message={'Create a string, unique password'} />
-      </div>
-      <div className="ml-6">
+      </Column>
+      <Column size={4} className="ml-7">
         <Label htmlFor="password-2" withInput={true}>
           Password
         </Label>
@@ -44,8 +44,8 @@ export const inputWithHelpText = () => {
           }
         />
         <HelpText error={true} message={'Create a password with at least 8 characters'} />
-      </div>
-    </div>
+      </Column>
+    </Row>
   );
 };
 
@@ -55,8 +55,8 @@ const customCode = `() => {
   const [inputValue, setInputValue] = React.useState('Value');
   const [secondInputValue, setSecondInputValue] = React.useState('Value');
   return (
-    <div className="d-flex">
-      <div>
+    <Row>
+      <Column size={4}>
         <Label htmlFor="password-1" withInput={true}>
           Password
         </Label>
@@ -79,8 +79,8 @@ const customCode = `() => {
           }
         />
         <HelpText message={'Create a string, unique password'} />
-      </div>
-      <div className="ml-6">
+      </Column>
+      <Column size={4} className="ml-7">
         <Label htmlFor="password-2" withInput={true}>
           Password
         </Label>
@@ -103,8 +103,8 @@ const customCode = `() => {
           }
         />
         <HelpText error={true} message={'Create a password with at least 8 characters'} />
-      </div>
-    </div>
+      </Column>
+    </Row>
   );
 };`;
 

--- a/core/components/atoms/input/__stories__/variants/types/IconLeft.story.jsx
+++ b/core/components/atoms/input/__stories__/variants/types/IconLeft.story.jsx
@@ -4,18 +4,18 @@ import { action } from '@/utils/action';
 
 // CSF format story
 export const iconLeft = () => {
-  const icon = 'search';
+  const icon = 'event';
   return (
     <div className="Row">
       <div className="mr-9 mb-8 w-25">
-        <Input name="input" placeholder="Search" onChange={action('on-change')} icon={icon} />
+        <Input name="input" placeholder="Placeholder" onChange={action('on-change')} icon={icon} />
         <br />
         <Text weight="strong">Default</Text>
       </div>
       <div className="mr-9 mb-8 w-25">
         <Input
           name="input"
-          placeholder="Search"
+          placeholder="Placeholder"
           onChange={action('on-change')}
           info="sample info tooltip"
           icon={icon}
@@ -24,12 +24,12 @@ export const iconLeft = () => {
         <Text weight="strong">Placeholder</Text>
       </div>
       <div className="mr-9 mb-8 w-25">
-        <Input name="input" placeholder="Search" onChange={action('on-change')} error={true} icon={icon} />
+        <Input name="input" placeholder="Placeholder" onChange={action('on-change')} error={true} icon={icon} />
         <br />
         <Text weight="strong">Error</Text>
       </div>
       <div className="mr-9 w-25">
-        <Input name="input" placeholder="Search" disabled={true} icon={icon} />
+        <Input name="input" placeholder="Placeholder" disabled={true} icon={icon} />
         <br />
         <Text weight="strong">Disabled</Text>
       </div>

--- a/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Input component
 <body>
   <div>
     <div
-      class="Input Input--regular"
+      class="Input Input--regular Input--leftIcon"
       data-test="DesignSystem-InputWrapper"
       role="presentation"
       style="min-width: 256px;"
@@ -89,7 +89,7 @@ exports[`Input component
 <body>
   <div>
     <div
-      class="Input Input--regular"
+      class="Input Input--regular Input--leftIcon"
       data-test="DesignSystem-InputWrapper"
       role="presentation"
       style="min-width: 256px;"
@@ -382,7 +382,7 @@ exports[`Input component
 <body>
   <div>
     <div
-      class="Input Input--regular Input--disabled"
+      class="Input Input--regular Input--disabled Input--leftIcon"
       data-test="DesignSystem-InputWrapper"
       role="presentation"
       style="min-width: 256px;"
@@ -443,7 +443,7 @@ exports[`Input component
 <body>
   <div>
     <div
-      class="Input Input--regular Input--disabled"
+      class="Input Input--regular Input--disabled Input--leftIcon"
       data-test="DesignSystem-InputWrapper"
       role="presentation"
       style="min-width: 256px;"
@@ -502,7 +502,7 @@ exports[`Input component
 <body>
   <div>
     <div
-      class="Input Input--regular Input--error"
+      class="Input Input--regular Input--error Input--leftIcon"
       data-test="DesignSystem-InputWrapper"
       role="presentation"
       style="min-width: 256px;"
@@ -561,7 +561,7 @@ exports[`Input component
 <body>
   <div>
     <div
-      class="Input Input--regular Input--disabled"
+      class="Input Input--regular Input--disabled Input--leftIcon"
       data-test="DesignSystem-InputWrapper"
       role="presentation"
       style="min-width: 256px;"

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -5157,7 +5157,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
         data-test="DesignSystem-InputMask--Wrapper"
       >
         <div
-          class="Input Input--regular"
+          class="Input Input--regular Input--leftIcon Input--rightIcon"
           data-test="DesignSystem-InputWrapper"
           role="presentation"
           style="min-width: 256px;"

--- a/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
@@ -38608,7 +38608,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -38669,7 +38669,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -38749,7 +38749,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -38810,7 +38810,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -38890,7 +38890,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -38951,7 +38951,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -40110,7 +40110,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -40171,7 +40171,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -40251,7 +40251,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -40312,7 +40312,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -40392,7 +40392,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -40453,7 +40453,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -41612,7 +41612,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -41673,7 +41673,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -42739,7 +42739,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -42800,7 +42800,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -43866,7 +43866,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -43927,7 +43927,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -46072,7 +46072,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -46133,7 +46133,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -47199,7 +47199,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -47260,7 +47260,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -48326,7 +48326,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"
@@ -48387,7 +48387,7 @@ exports[`DateRangePicker component
             data-test="DesignSystem-InputMask--Wrapper"
           >
             <div
-              class="Input Input--regular"
+              class="Input Input--regular Input--leftIcon Input--rightIcon"
               data-test="DesignSystem-InputWrapper"
               role="presentation"
               style="min-width: 256px;"

--- a/core/components/organisms/timePicker/__tests__/__snapshots__/TimePicker.test.tsx.snap
+++ b/core/components/organisms/timePicker/__tests__/__snapshots__/TimePicker.test.tsx.snap
@@ -126,7 +126,7 @@ exports[`TimePicker component prop:time snapshot
       data-test="DesignSystem-InputMask--Wrapper"
     >
       <div
-        class="Input Input--regular"
+        class="Input Input--regular Input--rightIcon"
         data-test="DesignSystem-InputWrapper"
         role="presentation"
         style="min-width: 256px;"
@@ -168,7 +168,7 @@ exports[`TimePicker component prop:time snapshot
       data-test="DesignSystem-InputMask--Wrapper"
     >
       <div
-        class="Input Input--regular"
+        class="Input Input--regular Input--rightIcon"
         data-test="DesignSystem-InputWrapper"
         role="presentation"
         style="min-width: 256px;"

--- a/css/src/components/input.css
+++ b/css/src/components/input.css
@@ -36,6 +36,14 @@
   padding-bottom: var(--spacing);
 }
 
+.Input--leftIcon {
+  padding-left: var(--spacing);
+}
+
+.Input--rightIcon {
+  padding-right: var(--spacing);
+}
+
 .Input:hover {
   background: var(--secondary-lighter);
   border-color: var(--secondary-dark);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Current PR fixes followings:
- Update left and right padding to 8px when icon is present
- Update help text story to wrap help text to next line. Earlier large single line help text led to increase in input width as well.
- Update placeholder and left icon on Left Icon story inside types

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
