### PR TITLE
fix(verticalnav): update tab focus and transition durations

### DIFF
--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { Text, Icon, Pills, Tooltip } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { getNavItemColor, getPillsAppearance, Menu } from '@/utils/navigationHelper';
-import Link from '@/components/atoms/_text';
 import { TextColor } from '@/common.type';
 export interface MenuItemProps extends BaseProps {
   menu: Menu;
@@ -88,6 +87,12 @@ export const MenuItem = (props: MenuItemProps) => {
     if (onClick) onClick(menu);
   };
 
+  const onKeyDownHandler = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      onClickHandler(event);
+    }
+  };
+
   const baseProps = {
     onClick: onClickHandler,
     href: menu.link,
@@ -138,7 +143,13 @@ export const MenuItem = (props: MenuItemProps) => {
     // TODO(a11y)
     // eslint-disable-next-line
     <Tooltip showTooltip={expanded ? isTextTruncated : true} tooltip={menu.label} position="right">
-      <Link componentType="a" className={ItemClass} {...baseProps}>
+      <a
+        className={ItemClass}
+        {...baseProps}
+        onKeyDown={onKeyDownHandler}
+        role="button"
+        tabIndex={menu.disabled ? -1 : 0}
+      >
         <div className="d-flex align-items-center overflow-hidden">
           {menu.icon && (
             <Icon
@@ -151,7 +162,7 @@ export const MenuItem = (props: MenuItemProps) => {
           {expanded && <MenuLabel label={menu.label} labelColor={itemColor} />}
         </div>
         {expanded && renderSubMenu()}
-      </Link>
+      </a>
     </Tooltip>
   );
 };

--- a/core/components/organisms/verticalNav/__stories__/HoverableVerticalNav.story.jsx
+++ b/core/components/organisms/verticalNav/__stories__/HoverableVerticalNav.story.jsx
@@ -143,7 +143,7 @@ const customCode = `() => {
     {
       name: 'name',
       displayName: 'Name',
-      width: '40%',
+      width: '35%',
       resizable: true,
       separator: true,
       tooltip: true,
@@ -178,7 +178,7 @@ const customCode = `() => {
     {
       name: 'email',
       displayName: 'Email',
-      width: 350,
+      width: '35%',
       resizable: true,
       sorting: false,
       cellType: 'WITH_META_LIST'
@@ -186,7 +186,7 @@ const customCode = `() => {
     {
       name: 'gender',
       displayName: 'Gender',
-      width: 200,
+      width: '30%',
       resizable: true,
       comparator: (a, b) => a.gender.localeCompare(b.gender),
       cellType: 'STATUS_HINT',
@@ -317,7 +317,7 @@ const customCode = `() => {
           onClick={setActive}
         />
       </Collapsible>
-      <div className="ml-6 d-flex flex-column">
+      <Column size={8} className="ml-6 d-flex flex-column">
         <Heading className="my-5">Assessments</Heading>
         <Card className="h-100 overflow-hidden">
           <Table
@@ -338,7 +338,7 @@ const customCode = `() => {
             pageSize={5}
           />
         </Card>
-      </div>
+      </Column>
     </div>
   );
 }`;

--- a/core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx
+++ b/core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx
@@ -209,6 +209,20 @@ describe('Vertical Navigation component with prop: menus', () => {
     expect(childItems[2].textContent).toMatch('Timeline');
     expect(childItems[3].textContent).toMatch('Care Plans');
   });
+
+  it('renders child items when parent item has focus, enter key is pressed and panel is expanded', () => {
+    const menuFocus = 1;
+    const { getAllByTestId } = render(
+      <VerticalNav expanded={true} menus={menus} active={{ name: 'patient_360' }} onClick={onClick} />
+    );
+
+    const activeMenu = getAllByTestId('DesignSystem-VerticalNav--Item')[menuFocus];
+    fireEvent.keyDown(activeMenu, { key: 'Enter', code: 'Enter', charCode: 13 });
+
+    const childItems = getAllByTestId('DesignSystem-VerticalNav--Text');
+    expect(childItems[2].textContent).toMatch('Timeline');
+    expect(childItems[3].textContent).toMatch('Care Plans');
+  });
 });
 
 describe('Vertical Navigation component active menu', () => {

--- a/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
+++ b/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Vertical Navigation component
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-test="DesignSystem-VerticalNav--Item"
           href="/patient360"
+          role="button"
           tabindex="0"
         >
           <div
@@ -39,6 +40,7 @@ exports[`Vertical Navigation component
         <a
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-test="DesignSystem-VerticalNav--Item"
+          role="button"
           tabindex="0"
         >
           <div
@@ -61,6 +63,7 @@ exports[`Vertical Navigation component
       >
         <a
           class="MenuItem MenuItem--vertical MenuItem--collapsed MenuItem--active color-primary-dark"
+          role="button"
           tabindex="0"
         >
           <div
@@ -83,6 +86,7 @@ exports[`Vertical Navigation component
       >
         <a
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
+          role="button"
           tabindex="0"
         >
           <div
@@ -106,7 +110,8 @@ exports[`Vertical Navigation component
         <a
           class="MenuItem MenuItem--vertical MenuItem--collapsed MenuItem--disabled color-inverse-lightest"
           data-test="DesignSystem-VerticalNav--Item"
-          tabindex="0"
+          role="button"
+          tabindex="-1"
         >
           <div
             class="d-flex align-items-center overflow-hidden"
@@ -129,6 +134,7 @@ exports[`Vertical Navigation component
         <a
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-test="DesignSystem-VerticalNav--Item"
+          role="button"
           tabindex="0"
         >
           <div
@@ -172,6 +178,7 @@ exports[`Vertical Navigation component
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--rounded color-inverse"
         data-test="DesignSystem-VerticalNav--Item"
         href="/patient360"
+        role="button"
         tabindex="0"
       >
         <div
@@ -212,6 +219,7 @@ exports[`Vertical Navigation component
       <a
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--rounded color-inverse"
         data-test="DesignSystem-VerticalNav--Item"
+        role="button"
         tabindex="0"
       >
         <div
@@ -243,6 +251,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--active MenuItem--subMenu MenuItem--rounded color-primary-dark"
+        role="button"
         tabindex="0"
       >
         <div
@@ -266,6 +275,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--subMenu MenuItem--rounded color-inverse"
+        role="button"
         tabindex="0"
       >
         <div
@@ -290,7 +300,8 @@ exports[`Vertical Navigation component
       <a
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--disabled MenuItem--rounded color-inverse-lightest"
         data-test="DesignSystem-VerticalNav--Item"
-        tabindex="0"
+        role="button"
+        tabindex="-1"
       >
         <div
           class="d-flex align-items-center overflow-hidden"
@@ -320,6 +331,7 @@ exports[`Vertical Navigation component
       <a
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--rounded color-inverse"
         data-test="DesignSystem-VerticalNav--Item"
+        role="button"
         tabindex="0"
       >
         <div

--- a/css/src/components/verticalNav.css
+++ b/css/src/components/verticalNav.css
@@ -25,7 +25,7 @@
   display: flex;
   align-items: center;
   cursor: pointer;
-  transition: var(--duration--fast-01) var(--standard-productive-curve);
+  transition: var(--duration--moderate-02) var(--standard-productive-curve);
   width: 232px;
 }
 


### PR DESCRIPTION
Current PR changes followings:
- Update MenuItem transition duration to 240ms.
- Update Hoverabe Vertical Navigation story.
- Update MenuItems to become active through keyboard focus

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
