### PR TITLE
fix: add compatible support for metric input and textarea for firefox

### DIFF
--- a/css/src/components/metricInput.css
+++ b/css/src/components/metricInput.css
@@ -76,6 +76,7 @@
   padding: 0;
   border: none;
   background: transparent;
+  -webkit-appearance: textfield;
 }
 
 .MetricInput-input--large {

--- a/css/src/components/textarea.css
+++ b/css/src/components/textarea.css
@@ -47,5 +47,5 @@
 }
 
 .Textarea--resize {
-  resize: auto;
+  resize: both;
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This contain the fix  for  #1404 , the issue of having double increment and decrement sign in firefox and resize by default not available in Textarea
...

### Does this close any currently open issues?
yes 
...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
