### PR TITLE
fix: add compatibility for metric input in Firefox

### DIFF
--- a/css/src/components/metricInput.css
+++ b/css/src/components/metricInput.css
@@ -76,6 +76,7 @@
   padding: 0;
   border: none;
   background: transparent;
+  -webkit-appearance: textfield;
 }
 
 .MetricInput-input--large {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This fixes the issue of metric input having duplicate arrow for increment and decrement of value in firefox browser
...

### Does this close any currently open issues?
yes it closes #1404
...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
