### PR TITLE
fix(metric-input): arrow button causes form to submit

### DIFF
--- a/core/components/atoms/metricInput/MetricInput.tsx
+++ b/core/components/atoms/metricInput/MetricInput.tsx
@@ -305,6 +305,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
       {showActionButton && (
         <div className="MetricInput-arrowIcons">
           <Button
+            type="button"
             icon="keyboard_arrow_up"
             size={actionButtonSize}
             className={`${actionButton} mb-2`}
@@ -312,6 +313,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
             data-test="DesignSystem-MetricInput--upIcon"
           />
           <Button
+            type="button"
             icon="keyboard_arrow_down"
             size={actionButtonSize}
             className={actionButton}

--- a/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
+++ b/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
@@ -31,6 +31,7 @@ exports[`MetricInput component
           class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3 mb-2"
           data-test="DesignSystem-MetricInput--upIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -49,6 +50,7 @@ exports[`MetricInput component
           class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3"
           data-test="DesignSystem-MetricInput--downIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -100,6 +102,7 @@ exports[`MetricInput component
           class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3 mb-2"
           data-test="DesignSystem-MetricInput--upIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -118,6 +121,7 @@ exports[`MetricInput component
           class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3"
           data-test="DesignSystem-MetricInput--downIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -174,6 +178,7 @@ exports[`MetricInput component
           class="Button Button--regular Button--regularSquare Button--basic p-0 MetricInput-arrowIcon--large ml-3 mb-2"
           data-test="DesignSystem-MetricInput--upIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -192,6 +197,7 @@ exports[`MetricInput component
           class="Button Button--regular Button--regularSquare Button--basic p-0 MetricInput-arrowIcon--large ml-3"
           data-test="DesignSystem-MetricInput--downIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -248,6 +254,7 @@ exports[`MetricInput component
           class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3 mb-2"
           data-test="DesignSystem-MetricInput--upIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"
@@ -266,6 +273,7 @@ exports[`MetricInput component
           class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3"
           data-test="DesignSystem-MetricInput--downIcon"
           tabindex="0"
+          type="button"
         >
           <div
             class="Button-icon"

--- a/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -162,6 +162,7 @@ exports[`Pagination component
             class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3 mb-2"
             data-test="DesignSystem-MetricInput--upIcon"
             tabindex="0"
+            type="button"
           >
             <div
               class="Button-icon"
@@ -180,6 +181,7 @@ exports[`Pagination component
             class="Button Button--tiny Button--tinySquare Button--basic p-0 MetricInput-arrowIcon--regular ml-3"
             data-test="DesignSystem-MetricInput--downIcon"
             tabindex="0"
+            type="button"
           >
             <div
               class="Button-icon"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

metric input's arrow button causes form to submit on click due to the default attribute of button `type="submit"`

set the type as button for arrow buttons

issue replicated in this sandbox
[sandbox](https://codesandbox.io/p/sandbox/youthful-mccarthy-wfnnfx?file=%2Findex.js)

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
