### PR TITLE
feat(tabs): add reorder support for dismissing tabs

### DIFF
--- a/core/components/molecules/tabs/Tabs.tsx
+++ b/core/components/molecules/tabs/Tabs.tsx
@@ -27,6 +27,12 @@ export interface TabsProps extends BaseProps {
    * Index of desired selected `Tab`
    */
   activeIndex?: number;
+
+  /**
+   * Draggable  `Tab`
+   */
+  draggable?: boolean;
+
   /**
    * Shows border at bottom of  `Tabs`
    */
@@ -97,12 +103,14 @@ const filterInlineComponent = (children: SingleOrArray<React.ReactElement>) => {
 };
 
 export const Tabs = (props: TabsProps) => {
-  const { children, withSeparator, onTabChange, className, headerClassName } = props;
+  const { children, withSeparator, draggable, onTabChange, className, headerClassName } = props;
 
   const baseProps = extractBaseProps(props);
   const tabRefs: HTMLDivElement[] = [];
 
-  const tabs: Tab[] = children ? filterTabs(children) : props.tabs;
+  const tabsList = children ? filterTabs(children) : props.tabs;
+  const [tabs, setTabs] = React.useState(tabsList);
+
   const inlineComponent = children ? filterInlineComponent(children) : <></>;
   const totalTabs = tabs.length;
 
@@ -110,9 +118,33 @@ export const Tabs = (props: TabsProps) => {
     props.activeIndex && props.activeIndex < totalTabs ? props.activeIndex : 0
   );
 
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [isDragActiveIndex, setIsDragActiveIndex] = React.useState(-1);
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const newchild = children && filterTabs(children);
+    if (draggable) {
+      const newchildLabel = newchild.map((item) => ('props' in item ? item.props.label : item.label));
+      const newArray = tabs.filter((item) => item && newchildLabel?.includes(item.props.label));
+      setTabs(newArray);
+    }
+  }, [children]);
+
+  const detectLeftButton = (e) => {
+    e = e || window.event;
+    if ('buttons' in e) {
+      return e.buttons === 1;
+    }
+    const button = e.which || e.button;
+    return button === 1;
+  };
+
   React.useEffect(() => {
     if (props.activeIndex !== undefined && props.activeIndex < totalTabs) {
       setActiveTab(props.activeIndex);
+      if (!draggable) setTabs(tabsList);
     }
   }, [props.activeIndex]);
 
@@ -166,6 +198,9 @@ export const Tabs = (props: TabsProps) => {
       if (!isKeyboard) tabRefs[tabIndex]?.blur();
     }
     if (onTabChange) onTabChange(tabIndex);
+    if (typeof props.activeIndex !== 'undefined' && props.activeIndex !== activeIndex) {
+      setActiveTab(props.activeIndex);
+    }
   };
 
   const tabKeyDownHandler = (event: React.KeyboardEvent, tabIndex: number) => {
@@ -231,6 +266,10 @@ export const Tabs = (props: TabsProps) => {
 
     const tabInfo = { label: label, activeIndex: activeIndex, currentTabIndex: index };
     const onCloseHandler = (e: React.MouseEvent) => {
+      if (index < activeIndex) {
+        const item = activeIndex - 1;
+        setActiveTab(item);
+      }
       e.stopPropagation();
       if (onDismiss) onDismiss(tabInfo);
     };
@@ -266,6 +305,120 @@ export const Tabs = (props: TabsProps) => {
     );
   };
 
+  const dragStart = (e: any, index: any) => {
+    if (!detectLeftButton(e)) return; //only use left mouse click
+
+    setIsDragActiveIndex(index);
+
+    const container = containerRef.current; // propery of the outer container
+    const items = [...container.childNodes]; // items present in the container
+
+    const activeItem = tabs[activeIndex];
+
+    const dragItem = items[index]; // draggable item html
+
+    const itemsBelowDragItem = items.slice(index + 1); // items below the draggable items [0, 1, 2, 3] index =1 then return [2,3]
+
+    const notDragItems = items.filter((_, i) => i !== index); // all the items other than draggable item
+
+    const dragData = tabs[index]; // data info of draggable component
+
+    let newData = [...tabs]; // clone of the data
+
+    // getBoundingClientRect of dragItem
+    const dragBoundingRect = dragItem.getBoundingClientRect();
+
+    //distance between two card
+    const space = items[1].getBoundingClientRect().left - items[0].getBoundingClientRect().right;
+
+    // set style for dragItem when mouse down
+    dragItem.style.position = 'fixed';
+    dragItem.style.zIndex = '5000';
+    dragItem.style.backgroundColor = '#ffffff';
+    dragItem.style.left = dragBoundingRect.left + 'px';
+    dragItem.style.cursor = 'grabbing';
+    dragItem.style.listStyleType = 'none';
+    dragItem.style.boxSizing = 'border-box';
+    dragItem.style.boxShadow = '0 4px 16px 0 rgba(0, 0, 0, 0.16)';
+
+    // create alternate div element when dragItem position is fixed
+    const div = document.createElement('div');
+    div.id = 'div-temp';
+    div.style.width = dragBoundingRect.width + 'px';
+    div.style.height = dragBoundingRect.height + 'px';
+    div.style.pointerEvents = 'none';
+    container?.appendChild(div);
+
+    //move the elements below dragitem
+    // distance to be moved
+    const distance = dragBoundingRect.width + space;
+
+    itemsBelowDragItem.forEach((item) => {
+      item.style.transform = `translateX(${distance}px)`;
+    });
+    // get the original coordinates of the mouse pointer
+
+    const x = e.clientX;
+    document.onpointermove = dragMove;
+
+    function dragMove(e) {
+      // calculate the distance the mouse pointer has traveled.
+      // original coordinates minus current coordinates.
+      setIsDragging(true); // store the index of draggable item
+      const posX = e.clientX - x;
+
+      //move item
+      dragItem.style.transform = `translateX(${posX}px)`;
+
+      //swap position and data
+      notDragItems.forEach((item) => {
+        //check two elements is overlapping
+        const rect1 = dragItem.getBoundingClientRect();
+        const rect2 = item.getBoundingClientRect();
+
+        const isoverlapping = rect1.x < rect2.x + rect2.width / 2 && rect1.x + rect1.width / 2 > rect2.x;
+        if (isoverlapping) {
+          // swap postion card
+
+          if (item.getAttribute('style')) {
+            item.style.transform = '';
+            index++;
+          } else {
+            item.style.transform = `translateX(${distance}px)`;
+            index--;
+          }
+
+          // swap data
+          newData = tabs.filter((item) => item !== dragData);
+          newData.splice(index, 0, dragData);
+        }
+      });
+    }
+
+    // finish onPointerDown event
+    document.onpointerup = dragEnd;
+
+    function dragEnd() {
+      document.onpointerup = null;
+      document.onpointermove = null;
+      dragItem.style = '';
+      container?.removeChild(div);
+
+      setTabs(newData);
+      setIsDragging(false);
+
+      const swapTab = newData.findIndex((x) => x === activeItem);
+      setActiveTab(swapTab);
+
+      items.forEach((item) => (item.style = null));
+
+      const draggedItem = items[index];
+      draggedItem.focus();
+      setIsDragActiveIndex(-1);
+    }
+  };
+  const [isHovered, setIsHovered] = React.useState(-1);
+
   const renderTabs = tabs.map((tab: Tab, index) => {
     const currentTabProp = children && 'props' in tab ? tab.props : tab;
     const { disabled } = currentTabProp;
@@ -276,12 +429,22 @@ export const Tabs = (props: TabsProps) => {
       ['Tab--active']: !disabled && activeIndex === index,
       ['Tab-selected']: !disabled && activeIndex === index,
       ['align-items-center']: true,
+      ['Tab-dragging']: isDragging,
+      ['Tab-draggable']: draggable,
+      ['Tab-drag']: isDragActiveIndex === index && !(activeIndex === index),
+    });
+
+    const draggableIconClass = classNames({
+      ['draggable-icon']: true,
+      ['draggable-active']: isHovered === index || isDragActiveIndex === index,
+      ['DraggableTab-icon']: true,
     });
 
     return (
       // TODO(a11y)
       //  eslint-disable-next-line
       <div
+        onPointerDown={draggable && !disabled ? (e) => dragStart(e, index) : () => {}}
         ref={(element) => element && !disabled && tabRefs.push(element)}
         data-test="DesignSystem-Tabs--Tab"
         key={index}
@@ -289,14 +452,23 @@ export const Tabs = (props: TabsProps) => {
         onClick={() => !disabled && tabClickHandler(index)}
         onKeyDown={(event: React.KeyboardEvent) => tabKeyDownHandler(event, index)}
         tabIndex={disabled ? -1 : 0}
+        onMouseEnter={() => setIsHovered(index)}
+        onMouseLeave={() => setIsHovered(-1)}
       >
+        {draggable && (
+          <Icon
+            className={draggableIconClass}
+            name="drag_indicator"
+            appearance={isDragActiveIndex === index ? 'primary' : 'subtle'}
+          />
+        )}
         {renderTab(currentTabProp, index)}
       </div>
     );
   });
   return (
     <div data-test="DesignSystem-Tabs" {...baseProps} className={wrapperClass}>
-      <div className={headerClass} data-test="DesignSystem-Tabs--Header">
+      <div className={headerClass} data-test="DesignSystem-Tabs--Header" ref={containerRef}>
         {renderTabs}
         {inlineComponent}
       </div>

--- a/core/components/molecules/tabs/__stories__/ReorderableTab.story.jsx
+++ b/core/components/molecules/tabs/__stories__/ReorderableTab.story.jsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import { action } from '@/utils/action';
+import { Tabs, Tab } from '@/index';
+
+// CSF format story
+export const reorderableTab = () => {
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [dismissList, setDismissList] = React.useState([]);
+
+  const onTabChangeHandler = (tabIndex) => {
+    setActiveIndex(tabIndex);
+    return action(`tab-change: ${tabIndex}`)();
+  };
+
+  const onDismissHandler = (tabInfo) => {
+    action(`tab-change: ${tabInfo}`)();
+    let newList = [...dismissList];
+    newList.push(tabInfo.label);
+    setDismissList(newList);
+  };
+
+  return (
+    <Tabs activeIndex={activeIndex} onTabChange={onTabChangeHandler} className="mb-6">
+      {!dismissList.includes('All') && (
+        <Tab label="All" count={15} className="pl-5">
+          <div>All</div>
+        </Tab>
+      )}
+      {!dismissList.includes('Pending') && (
+        <Tab
+          label="Pending"
+          className="pl-5"
+          count={10}
+          isDismissible={true}
+          onDismiss={(tabInfo) => onDismissHandler(tabInfo)}
+        >
+          <div>Pending</div>
+        </Tab>
+      )}
+      {!dismissList.includes('Declined') && (
+        <Tab
+          label="Declined"
+          className="pl-5"
+          count={4}
+          isDismissible={true}
+          onDismiss={(tabInfo) => onDismissHandler(tabInfo)}
+        >
+          <div>Declined</div>
+        </Tab>
+      )}
+      <Tab label="Extras" disabled={true} count={1}>
+        <div>Extras</div>
+      </Tab>
+    </Tabs>
+  );
+};
+
+const customCode = `() => {
+  
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const [dismissList, setDismissList] = React.useState([]);
+
+  const onTabChangeHandler = (tabIndex) => {
+    setActiveIndex(tabIndex);
+  };
+
+  const onDismissHandler = (tabInfo) => {
+    let newList = [...dismissList];
+    newList.push(tabInfo.label);
+    setDismissList(newList);
+  };
+
+  return (
+    <Tabs activeIndex={activeIndex} draggable={true} onTabChange={onTabChangeHandler} className="mb-6">
+      {!dismissList.includes('All') && (
+        <Tab label="All" count={15} className="pl-5">
+          <div>All</div>
+        </Tab>
+      )}
+      {!dismissList.includes('Pending') && (
+        <Tab
+          label="Pending"
+          className="pl-5"
+          count={10}
+          isDismissible={true}
+          onDismiss={(tabInfo) => onDismissHandler(tabInfo)}
+        >
+          <div>Pending</div>
+        </Tab>
+      )}
+      {!dismissList.includes('Declined') && (
+        <Tab
+          label="Declined"
+          className="pl-5"
+          count={4}
+          isDismissible={true}
+          onDismiss={(tabInfo) => onDismissHandler(tabInfo)}
+        >
+          <div>Declined</div>
+        </Tab>
+      )}
+      <Tab label="Extras" disabled={true} count={1}>
+        <div>Extras</div>
+      </Tab>
+      <Tab label="Extras1" className="pl-5" count={1}>
+      <div>Extras1</div>
+    </Tab>
+    <Tab label="Extras2" className="pl-5" count={1}>
+      <div>Extras2</div>
+    </Tab>
+    </Tabs>
+  );
+}`;
+
+export default {
+  title: 'Navigation/Tabs/Reorderable Tab ',
+  component: Tabs,
+  parameters: {
+    docs: {
+      docPage: {
+        customCode,
+      },
+    },
+  },
+};

--- a/css/src/components/tabs.css
+++ b/css/src/components/tabs.css
@@ -21,7 +21,7 @@
   position: relative;
   display: flex;
   flex-direction: row;
-  cursor: pointer;
+  cursor: grab;
   min-width: 40px;
   padding: var(--spacing-l) var(--spacing-l) var(--spacing-2);
   margin-bottom: calc(-1 * var(--spacing-xs));
@@ -45,6 +45,11 @@
   border-top-right-radius: var(--spacing-xs);
 }
 
+.Tab-draggable::after{
+  width: calc(100% - 3.5 * var(--spacing-l));
+  margin-left: var(--spacing-3);
+}
+
 .Tab:hover::after {
   background-color: var(--inverse-lighter);
 }
@@ -54,7 +59,7 @@
 }
 
 .Tab--active::after {
-  background-color: var(--primary);
+  background-color: var(--primary) !important;
 }
 
 .Tab:focus {
@@ -69,7 +74,7 @@
 }
 
 .Tab-selected:hover::after {
-  background-color: var(--primary-dark);
+  background-color: var(--primary-dark) !important;
 }
 
 .Tab:active:focus {
@@ -154,3 +159,17 @@
 .DismissibleTab-icon--selected:active {
   background-color: var(--primary-light);
 }
+.Tab-dragging{
+  pointer-events: none;
+}
+
+.Tab-drag:active:after{
+  background-color: transparent;
+}
+ .draggable-icon{
+  padding: 2px;
+  visibility: hidden
+ }
+ .draggable-active{
+  visibility: visible;
+ }


### PR DESCRIPTION
Current PR introduces following changes:
- Add reorder support for dismissing tabs
- Moves moveToIndex function into common utility

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
