### PR TITLE
fix(select): make title description optional in empty template

### DIFF
--- a/core/components/organisms/select/SearchInput.tsx
+++ b/core/components/organisms/select/SearchInput.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Input } from '@/index';
 import { SelectContext } from './SelectContext';
-import { BaseProps } from '@/utils/types';
 import { handleInputKeyDown } from './utils';
+import { InputProps } from '@/index.type';
 
-export interface SelectInputProps extends BaseProps {
+export interface SelectInputProps extends InputProps {
   /**
    * Callback function when user clicks the clear button
    */

--- a/core/components/organisms/select/SelectEmptyTemplate.tsx
+++ b/core/components/organisms/select/SelectEmptyTemplate.tsx
@@ -7,11 +7,11 @@ interface SelectEmptyTemplateProps extends BaseProps {
   /**
    * Heading of `EmptyState`
    */
-  title: string;
+  title?: string;
   /**
    * Description of `EmptyState`
    */
-  description: string;
+  description?: string;
   /**
    * Button / ButtonGroups to be added inside `EmptyState`
    */


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

1. make title and description optional in emptyTemplate.
2. extend all props of input in search input in prop table.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
