### PR TITLE
Fix: docs site component overview page layout and cards style

### DIFF
--- a/.github/workflows/docs_pull_request.yml
+++ b/.github/workflows/docs_pull_request.yml
@@ -2,7 +2,7 @@ name: Docs pull request
 
 on: 
   pull_request:
-    paths: 'docs/**'
+    paths: ['docs/**']
 
 jobs:
   lint_test_build:
@@ -23,6 +23,14 @@ jobs:
 
       - name: lint
         run: npm run lint:check
+      
+      - name: extract stories
+        run: npm run extract
+        env:
+          STORYBOOK_HOST: 'https://mds-dev.innovaccer.com/iframe.html?id=components-avatar-avatargroup-all--all&args=&viewMode=story'
 
       - name: build
         run: npm run build
+
+      - name: test
+        run: npm run test

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,21 +2,27 @@
   "name": "docs",
   "version": "1.0.0",
   "description": "<p align=\"center\">   <a href=\"#\">     <img alt=\"\" src=\"https://innovaccer.com/static/image/site-logo/innovaccer-logo-black.svg\" width=\"20%\" />   </a> </p> <h1 align=\"center\">   Masala Design System </h1> <h3 align=\"center\">   Gatsby site for Masala Design system documentation. </h3>",
+  "author": "",
+  "license": "MIT",
   "main": "index.js",
+  "engineStrict": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
-    "dev": "./tools/develop.sh",
     "build": "./tools/build.sh",
-    "serve": "gatsby serve",
-    "deploy": "gatsby-plugin-s3 deploy --yes",
     "clean": "gatsby clean",
-    "extract:dev": "export STORYBOOK_HOST='http://localhost:5000/iframe.html?id=components-avatar-avatargroup-all--all&args=&viewMode=story' && node ./tools/extract.js",
-    "extract": "node ./tools/extract.js",
-    "cypress:open": "cypress open",
     "cypress": "cypress run",
-    "lint:check": "eslint ./src --ext .tsx,.ts,.js",
+    "cypress:open": "cypress open",
+    "deploy": "gatsby-plugin-s3 deploy --yes",
+    "dev": "./tools/develop.sh",
+    "extract": "node ./tools/extract.js",
+    "extract:dev": "export STORYBOOK_HOST='http://localhost:5000/iframe.html?id=components-avatar-avatargroup-all--all&args=&viewMode=story' && node ./tools/extract.js",
     "lint": "npm run lint:check -- --fix",
-    "prettier:check": "prettier --config ./.prettierrc --check",
+    "lint:check": "eslint ./src --ext .tsx,.ts,.js",
     "prettier": "prettier --config ./.prettierrc --write 'src/**/*.css'",
+    "prettier:check": "prettier --config ./.prettierrc --check",
+    "serve": "gatsby serve",
     "test": "CYPRESS_HOST_URL='http://localhost:9000' start-server-and-test serve http://localhost:9000 cypress"
   },
   "dependencies": {
@@ -63,9 +69,6 @@
     "remark-slug": "^6.1.0",
     "unist-util-visit": "^5.0.0"
   },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
     "cypress": "^13.8.1",
     "eslint": "^7.31.0",
@@ -74,5 +77,6 @@
     "prettier": "^2.3.2",
     "start-server-and-test": "^2.0.3",
     "typescript": "3.9.10"
-  }
+  },
+  "keywords": []
 }

--- a/docs/src/components/Container/ComponentsContainer.js
+++ b/docs/src/components/Container/ComponentsContainer.js
@@ -53,7 +53,7 @@ const ComponentsContainer = ({ children, pageTitle, relativePagePath, tabs, page
       </div>
       {tabsList && tabsList.length && (
         <div className="TabHeader mb-7 position-sticky bg-light" id='tab-container' data-test='Docs-Tab-Header'>
-          <div className="px-11 mt-4">
+          <div className="pl-11 pr-13 mt-4" style={{maxWidth: "964px"}}>
             <Tabs activeIndex={activeIndex} className={`${isTabPinned ? "border-bottom-0" : "TabBorder"}`} onTabChange={onTabChangeHandler}>
               {tabsList.map((tab, index) => (
                 <Tab label={tab} key={index} ></Tab>
@@ -63,7 +63,7 @@ const ComponentsContainer = ({ children, pageTitle, relativePagePath, tabs, page
           <div className={`${isTabPinned ? "TabBorder--sticky" : ""}`}></div>
         </div>
       )}
-      <div className='px-11'> 
+      <div className='pl-11 pr-13'> 
       {children}
       </div>
     </>

--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -61,9 +61,10 @@ const MDXPage = (props) => {
 const OverviewContainer = (props) => {
   return (
     <Row className="justify-content-center">
-      <Column data-test="Docs-content-wrapper" className="py-8 min-vh-100 overview-container" size={12}>
+      <Column data-test="Docs-content-wrapper" className="py-8 min-vh-100 inner-left-container" size={9}>
         <ComponentsPage {...props} />
       </Column>
+      <Column size={3}></Column>
     </Row>
   );
 };

--- a/docs/src/data/components/Overview.js
+++ b/docs/src/data/components/Overview.js
@@ -41,7 +41,7 @@ function Overview({ data, mode, path = 'components' }) {
           previewList.map(({ image = () => <img alt="" />, name, status, showOverview = true, link = '' }) => {
             if (showOverview) {
               return (
-                <div key={name} className="overview-container-card pb-6 mr-6">
+                <div key={name} className="overview-container-card mb-6 mr-6">
                   <Link
                     className="card-link"
                     disabled={!link.length}

--- a/docs/src/data/components/overview.css
+++ b/docs/src/data/components/overview.css
@@ -1,5 +1,5 @@
 .card-opacity {
-  opacity: var(--opacity-10);
+  opacity: var(--opacity-20);
 }
 
 .overview-card:hover .card-opacity {
@@ -35,5 +35,6 @@
 }
 
 .overview-container-card {
-  max-width: 220px;
+  width: 220px;
+  height: 184px;
 }

--- a/docs/tools/extract.js
+++ b/docs/tools/extract.js
@@ -8,7 +8,7 @@ const puppeteerCore = require('puppeteer-core');
 
 const STORYBOOK_HOST =
   process.env.STORYBOOK_HOST ||
-  'https://innovaccer.github.io/design-system/iframe.html?id=components-avatar-avatargroup-all--all&args=&viewMode=story';
+  'https://mds.innovaccer.com/iframe.html?id=components-avatar-avatargroup-all--all&args=&viewMode=story';
 
 const read = async (url) => {
     const browser = await usePuppeteerBrowser();


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

- Fix docs site component overview page content container width and cards width, height and opacity
- Update default storybook url in docs exporter script
- Structure package json and add engine restriction for node 20.x 

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
