### PR TITLE
feat(avatargroup): add disabled state in avatar group component

### DIFF
--- a/core/components/atoms/avatarGroup/AvatarCount.tsx
+++ b/core/components/atoms/avatarGroup/AvatarCount.tsx
@@ -20,7 +20,13 @@ const AvatarCount = (props: any) => {
   });
 
   return (
-    <div data-test="DesignSystem-AvatarGroup--TriggerAvatar" className="AvatarCount-wrapper" style={avatarStyle}>
+    <div
+      data-test="DesignSystem-AvatarGroup--TriggerAvatar"
+      className="AvatarCount-wrapper"
+      style={avatarStyle}
+      tabIndex={0}
+      role="button"
+    >
       <span data-test="DesignSystem-AvatarGroup--TriggerAvatarVariants" className={AvatarVariantsClass}>
         <Text appearance={'white'} className={ContentClass}>
           {`+${hiddenAvatarCount}`}

--- a/core/components/atoms/avatarGroup/AvatarGroup.tsx
+++ b/core/components/atoms/avatarGroup/AvatarGroup.tsx
@@ -14,6 +14,8 @@ interface AvatarData extends Record<string, any> {
   appearance?: AvatarProps['appearance'];
   icon?: React.ReactNode;
   image?: React.ReactNode;
+  disabled?: boolean;
+  tooltipSuffix?: string;
 }
 
 interface AvatarPopoverProps {
@@ -37,6 +39,8 @@ export interface AvatarGroupProps extends BaseProps {
    *  appearance?: Appearance;
    *  icon?: React.ReactNode;
    *  image?: React.ReactNode;
+   *  disabled?: boolean;
+   *  tooltipSuffix?: string;
    * }
    * </pre>
    *
@@ -77,7 +81,7 @@ export interface AvatarGroupProps extends BaseProps {
    * | position | Position to place `Popover` | bottom |
    * | on | Event triggering the `Popover` | hover |
    * | maxHeight | Max height of `Popover Text Wrapper` (does not work in case of custom popperRenderer) | 150 |
-   * | popperClassName | Custom classname added to `Popover` | |
+   * | popperClassName | Custom className added to `Popover` | |
    *
    */
   popoverOptions: AvatarPopoverProps;

--- a/core/components/atoms/avatarGroup/AvatarPopperBody.tsx
+++ b/core/components/atoms/avatarGroup/AvatarPopperBody.tsx
@@ -13,8 +13,8 @@ const AvatarPopperBody = (props: any) => {
     <div className="px-4 py-3">
       <div className="AvatarGroup-TextWrapper" style={{ maxHeight }}>
         {hiddenAvatarList.map((item: any, ind: any) => {
-          const { firstName = '', lastName = '' } = item;
-          const name = `${firstName} ${lastName}`;
+          const { firstName = '', lastName = '', tooltipSuffix = '' } = item;
+          const name = `${firstName} ${lastName} ${tooltipSuffix}`;
           const AvatarTextClass = classNames({
             [`mb-4`]: ind < hiddenAvatarList.length - 1,
           });

--- a/core/components/atoms/avatarGroup/Avatars.tsx
+++ b/core/components/atoms/avatarGroup/Avatars.tsx
@@ -12,7 +12,7 @@ const Avatars = (props: any) => {
   });
 
   const avatars = avatarList.map((item: any, index: any) => {
-    const { appearance, firstName, lastName, icon, image } = item;
+    const { appearance, firstName, lastName, icon, image, disabled, tooltipSuffix } = item;
     return (
       <div data-test="DesignSystem-AvatarGroup--Avatar" className={GroupClass} style={avatarStyle} key={index}>
         <Avatar
@@ -21,7 +21,9 @@ const Avatars = (props: any) => {
           firstName={firstName}
           lastName={lastName}
           withTooltip={true}
+          disabled={disabled}
           tooltipPosition={tooltipPosition}
+          tooltipSuffix={tooltipSuffix}
         >
           {image || icon}
         </Avatar>

--- a/core/components/atoms/avatarGroup/__stories__/AvatarList.tsx
+++ b/core/components/atoms/avatarGroup/__stories__/AvatarList.tsx
@@ -32,3 +32,43 @@ export const list = [
     lastName: 'Snow',
   },
 ];
+
+export const disabledList = [
+  {
+    firstName: 'John',
+    lastName: 'Doe',
+    disabled: true,
+    tooltipSuffix: '(Deactivated)',
+  },
+  {
+    firstName: 'Steven',
+    lastName: 'Packton',
+  },
+  {
+    firstName: 'Nancy',
+    lastName: 'Wheeler',
+  },
+  {
+    firstName: 'Monica',
+    lastName: 'Geller',
+    disabled: true,
+    tooltipSuffix: '(Deactivated)',
+  },
+  {
+    firstName: 'Arya',
+    lastName: 'Stark',
+  },
+  {
+    firstName: 'Rachel',
+    lastName: 'Green',
+  },
+  {
+    firstName: 'Walter',
+    lastName: 'Wheeler',
+    disabled: true,
+  },
+  {
+    firstName: 'Mark',
+    lastName: 'Snow',
+  },
+];

--- a/core/components/atoms/avatarGroup/__stories__/variants/State.story.jsx
+++ b/core/components/atoms/avatarGroup/__stories__/variants/State.story.jsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { AvatarGroup, Text } from '@/index';
+import { list, disabledList } from '../AvatarList';
+
+export const State = () => {
+  const popoverOptions = { on: 'hover' };
+
+  return (
+    <div className="d-flex">
+      <div className="flex-column mr-9 ">
+        <Text weight="strong">Default</Text>
+        <div className="mt-4">
+          <AvatarGroup size="regular" list={list.slice(0, 4)} popoverOptions={popoverOptions} />
+        </div>
+      </div>
+      <div className="flex-column">
+        <Text weight="strong">Disabled</Text>
+        <div className="mt-4">
+          <AvatarGroup list={disabledList.slice(0, 4)} popoverOptions={popoverOptions} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default {
+  title: 'Components/Avatar/AvatarGroup/Variants/State',
+  component: AvatarGroup,
+  parameters: {
+    docs: {
+      docPage: {},
+    },
+  },
+};

--- a/core/components/atoms/avatarGroup/__tests__/AvatarGroup.test.tsx
+++ b/core/components/atoms/avatarGroup/__tests__/AvatarGroup.test.tsx
@@ -205,3 +205,29 @@ describe('AvatarGroup Component with prop: icon', () => {
     expect(getAllByTestId('DesignSystem-Icon')).toHaveLength(defaultMax);
   });
 });
+
+describe('AvatarGroup Component with prop: tooltipSuffix', () => {
+  it('renders disabled avatar with tooltip suffix', () => {
+    const list = [
+      {
+        firstName: 'Nancy',
+        lastName: 'Wheeler',
+        disabled: true,
+        tooltipSuffix: '(Deactivated)',
+      },
+      {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    ];
+    const { getAllByTestId, getByTestId } = render(<AvatarGroup list={list} max={1} />);
+    const avatarEle = getAllByTestId('DesignSystem-AvatarWrapper')[0];
+    fireEvent.mouseEnter(avatarEle);
+    const tooltip = getByTestId('DesignSystem-Popover');
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent('Nancy Wheeler (Deactivated)');
+
+    const avatarItem = getByTestId('DesignSystem-Avatar');
+    expect(avatarItem).toHaveClass('Avatar--disabled');
+  });
+});

--- a/css/src/components/avatarGroup.css
+++ b/css/src/components/avatarGroup.css
@@ -1,5 +1,6 @@
 .AvatarGroup-item {
   border-radius: 50%;
+  position: relative;
 }
 
 .AvatarGroup-item--regular {
@@ -29,4 +30,11 @@
 
 .AvatarCount-wrapper {
   border-radius: 50%;
+  position: relative;
+}
+
+.AvatarCount-wrapper:focus,
+.AvatarCount-wrapper:focus-visible {
+  outline: 3px solid var(--primary-shadow);
+  outline-offset: 3px;
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR contains the following changes:
- add disabled state in avatar group
- add support for tooltip suffix
- add support to show tooltip on focus state   

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
