### PR TITLE
chore(react-lottie-player): moved react-lottie-player to externals for esm builds only

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -100,6 +100,8 @@ const jsUmdConfig = {
 
 const jsEsmConfig = {
   ...baseConfig,
+  // react-lottie-player was marked external in esm build to prevent the build from including code that actually required Web APIs like document.getElementsByTagName, etc.
+  external: [...baseConfig.external, '@lottiefiles/react-lottie-player'],
   // Slice is used here to remove uglify compression during esm builds
   plugins: commonJsPlugins.slice(0,-1),
   output: {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This makes the ESM build to be able to run on server layer for stuff like generating templates, etc.
...

### Does this close any currently open issues?
Yes, PDFs downloading were failing for the InCare product.
...

### Any other comments?
Check and communicate if the other teams are using the UMD builds and still be able to use the AI components which rely on animations from react-lottie-player
...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.
However, we have ensured that only the ESM build are affected by this change. We will communicate this update to the team.
...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
