### PR TITLE
fix(editableChipInput): fix overflow behavior of editableChipInput component

### DIFF
--- a/core/components/molecules/editableChipInput/__stories__/OverflowBehavior.story.jsx
+++ b/core/components/molecules/editableChipInput/__stories__/OverflowBehavior.story.jsx
@@ -13,7 +13,11 @@ export const overflowBehavior = () => {
   const onClick = (item) => action(`onClick: ${item}`);
 
   const placeholder = 'Add Value';
-  const chipOptions = { onClick, clearButton: true };
+  const chipOptions = {
+    onClick,
+    clearButton: true,
+    maxWidth: 'var(--spacing-8)',
+  };
   const chipInputOptions = {
     chipOptions,
     allowDuplicates: false,
@@ -44,7 +48,11 @@ const customCode = `() => {
   const onClick = (item) =>  console.log(item);
 
   const placeholder ='Add Value';
-  const chipOptions = { onClick, clearButton:true };
+  const chipOptions = {
+    onClick,
+    clearButton: true,
+    maxWidth: 'var(--spacing-8)',
+  };
   const chipInputOptions = {
     chipOptions,
     allowDuplicates:false,

--- a/core/components/molecules/editableChipInput/__stories__/Uncontrolled.story.jsx
+++ b/core/components/molecules/editableChipInput/__stories__/Uncontrolled.story.jsx
@@ -6,7 +6,11 @@ import { EditableChipInput } from '@/index';
 
 export const uncontrolled = () => {
   const onClick = (item) => action(`onClick: ${item}`);
-  const chipOptions = { onClick, clearButton: true };
+  const chipOptions = {
+    onClick,
+    clearButton: true,
+    maxWidth: 'var(--spacing-8)',
+  };
   const chipInputOptions = {
     chipOptions,
     allowDuplicates: false,
@@ -27,7 +31,11 @@ export const uncontrolled = () => {
 
 const customCode = `() => {
   const onClick = (item) => console.log(\`onClick: \${item}\`);
-  const chipOptions = { onClick, clearButton: true };
+  const chipOptions = {
+    onClick,
+    clearButton: true,
+    maxWidth: 'var(--spacing-8)',
+  };
   const chipInputOptions = {
     chipOptions,
     allowDuplicates: false,

--- a/core/components/molecules/editableChipInput/__stories__/index.story.jsx
+++ b/core/components/molecules/editableChipInput/__stories__/index.story.jsx
@@ -13,7 +13,11 @@ export const all = () => {
   const onClick = (item) => action(`onClick: ${item}`);
 
   const placeholder = 'Add Value';
-  const chipOptions = { onClick, clearButton: true };
+  const chipOptions = {
+    onClick,
+    clearButton: true,
+    maxWidth: 'var(--spacing-8)',
+  };
   const chipInputOptions = {
     chipOptions,
     allowDuplicates: false,
@@ -43,7 +47,11 @@ const customCode = `() => {
   const onClick = (item) =>  console.log(item);
 
   const placeholder ='Add Value';
-  const chipOptions = { onClick, clearButton:true };
+  const chipOptions = {
+    onClick,
+    clearButton: true,
+    maxWidth: 'var(--spacing-8)',
+  };
   const chipInputOptions = {
     chipOptions,
     allowDuplicates:false,


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR fix EditableChipInput bug that chip field was going out of the input filled width.

### Does this close any currently open issues?

This PR closes https://github.com/innovaccer/design-system/issues/2061

### Solution

Update maxWidth from `var(--spacing-9)` to `var(--spacing-8)`, by passing maxWidth props in ChipInput

### Difference

## Before

![before-error](https://github.com/user-attachments/assets/ab1bb0a3-dba4-47eb-ad14-f7899cfce72f)

## After

![after-solution](https://github.com/user-attachments/assets/f8dfc739-029c-47b8-9f29-6bd9c65616ce)

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
