### PR TITLE
fix: replace deprecated 'dropdown' with Select and Menu in Stepper

### DIFF
--- a/core/components/molecules/stepper/__stories__/StepperInPageHeader.story.jsx
+++ b/core/components/molecules/stepper/__stories__/StepperInPageHeader.story.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stepper, Button, Breadcrumbs, Badge, Text, MetaList, Avatar, PageHeader, Dropdown } from '@/index';
+import { Stepper, Button, Breadcrumbs, Badge, Text, MetaList, Avatar, PageHeader, Menu } from '@/index';
 import { action } from '@/utils/action';
 
 export const stepperInPageHeader = () => {
@@ -18,21 +18,6 @@ export const stepperInPageHeader = () => {
     },
   ];
 
-  const options = [
-    {
-      label: 'Option 1',
-      value: 'Option 1',
-    },
-    {
-      label: 'Option 2',
-      value: 'Option 2',
-    },
-    {
-      label: 'Option 3',
-      value: 'Option 3',
-    },
-  ];
-
   const [active, setActive] = React.useState(2);
 
   const onChangeHandler = (activeStep) => {
@@ -48,7 +33,13 @@ export const stepperInPageHeader = () => {
       </Text>
       <Avatar className="mr-4" firstName="John" lastName="Doe" appearance="accent2" />
       <div className="mr-4">
-        <Dropdown menu={true} icon="more_horiz" options={options} />
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            <Menu.Item>Option 1</Menu.Item>
+            <Menu.Item>Option 2</Menu.Item>
+            <Menu.Item>Option 3</Menu.Item>
+          </Menu.List>
+        </Menu>
       </div>
       <Button className="mr-4">Finish later</Button>
     </div>
@@ -102,21 +93,6 @@ const customCode = `() => {
     }
   ];
 
-  const options = [
-    {
-      label: 'Option 1',
-      value: 'Option 1',
-    },
-    {
-      label: 'Option 2',
-      value: 'Option 2',
-    },
-    {
-      label: 'Option 3',
-      value: 'Option 3',
-    }
-  ];
-
   const [active, setActive] = React.useState(2);
 
   const onChangeHandler = (activeStep) => {
@@ -130,11 +106,13 @@ const customCode = `() => {
       <Text className="mr-4" appearance="subtle" >Few minutes ago</Text>
       <Avatar className="mr-4" firstName="John" lastName="Doe" appearance="accent2"/>
       <div className="mr-4">
-        <Dropdown
-          menu={true}
-          icon="more_horiz"
-          options={options}
-        />
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            <Menu.Item>Option 1</Menu.Item>
+            <Menu.Item>Option 2</Menu.Item>
+            <Menu.Item>Option 3</Menu.Item>
+          </Menu.List>
+        </Menu>
       </div>
       <Button className="mr-4">Finish later</Button>
     </div>

--- a/core/components/molecules/stepper/__stories__/StepperWithAnimation.story.jsx
+++ b/core/components/molecules/stepper/__stories__/StepperWithAnimation.story.jsx
@@ -6,7 +6,7 @@ import {
   Card,
   Heading,
   Text,
-  Dropdown,
+  Select,
   Label,
   DateRangePicker,
   Row,
@@ -83,11 +83,31 @@ export const stepperWithAnimation = () => {
             <Column size={6} className="d-flex">
               <div className="mr-6 w-100">
                 <Label withInput={true}>Region</Label>
-                <Dropdown options={options} />
+                <Select triggerOptions={{ withClearButton: false }}>
+                  <Select.List>
+                    {options.map((item, key) => {
+                      return (
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                          {item.label}
+                        </Select.Option>
+                      );
+                    })}
+                  </Select.List>
+                </Select>
               </div>
               <div className="w-100">
                 <Label withInput={true}>Organization</Label>
-                <Dropdown options={options} />
+                <Select triggerOptions={{ withClearButton: false }}>
+                  <Select.List>
+                    {options.map((item, key) => {
+                      return (
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                          {item.label}
+                        </Select.Option>
+                      );
+                    })}
+                  </Select.List>
+                </Select>
               </div>
             </Column>
           </Row>
@@ -154,7 +174,21 @@ export const stepperWithAnimation = () => {
               </Column>
               <Column size={8} className="d-flex align-items-center">
                 <div className="mr-5 w-25 align-items-center">
-                  <Dropdown options={languages} />
+                  <Select
+                    width
+                    value={{ label: 'English', value: 'English' }}
+                    triggerOptions={{ withClearButton: false }}
+                  >
+                    <Select.List>
+                      {languages.map((item, key) => {
+                        return (
+                          <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                            {item.label}
+                          </Select.Option>
+                        );
+                      })}
+                    </Select.List>
+                  </Select>
                 </div>
                 <Checkbox className="align-items-center" name="defaultLanguage" label="Set as Default" />
               </Column>
@@ -165,7 +199,17 @@ export const stepperWithAnimation = () => {
                 <Text>Preferred Method of Contact</Text>
               </Column>
               <Column size={8} className="d-flex align-items-center">
-                <Dropdown options={method} />
+                <Select value={{ label: 'Message', value: 'Message' }} triggerOptions={{ withClearButton: false }}>
+                  <Select.List>
+                    {method.map((item, key) => {
+                      return (
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                          {item.label}
+                        </Select.Option>
+                      );
+                    })}
+                  </Select.List>
+                </Select>
               </Column>
             </Row>
             <Row className="mt-6">
@@ -475,11 +519,31 @@ const customCode = `() => {
             <Column size={6} className="d-flex">
               <div className="mr-6 w-100">
                 <Label withInput={true}>Region</Label>
-                <Dropdown options={options} />
+                <Select triggerOptions={{ withClearButton: false }}>
+                  <Select.List>
+                    {options.map((item, key) => {
+                      return (
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                          {item.label}
+                        </Select.Option>
+                      );
+                    })}
+                  </Select.List>
+                </Select>
               </div>
               <div className="w-100">
                 <Label withInput={true}>Organization</Label>
-                <Dropdown options={options} />
+                <Select triggerOptions={{ withClearButton: false }}>
+                  <Select.List>
+                    {options.map((item, key) => {
+                      return (
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                          {item.label}
+                        </Select.Option>
+                      );
+                    })}
+                  </Select.List>
+                </Select>
               </div>
             </Column>
           </Row>
@@ -544,7 +608,21 @@ const customCode = `() => {
               </Column>
               <Column size={8} className="d-flex align-items-center">
                 <div className="mr-5 w-25 align-items-center">
-                  <Dropdown options={languages} />
+                  <Select
+                    width
+                    value={{ label: 'English', value: 'English' }}
+                    triggerOptions={{ withClearButton: false }}
+                  >
+                    <Select.List>
+                      {languages.map((item, key) => {
+                        return (
+                          <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                            {item.label}
+                          </Select.Option>
+                        );
+                      })}
+                    </Select.List>
+                  </Select>
                 </div>
                 <Checkbox className="align-items-center" name="defaultLanguage" label="Set as Default" />
               </Column>
@@ -555,7 +633,17 @@ const customCode = `() => {
                 <Text>Preferred Method of Contact</Text>
               </Column>
               <Column size={8} className="d-flex align-items-center">
-                <Dropdown options={method} />
+                <Select value={{ label: 'Message', value: 'Message' }} triggerOptions={{ withClearButton: false }}>
+                  <Select.List>
+                    {method.map((item, key) => {
+                      return (
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                          {item.label}
+                        </Select.Option>
+                      );
+                    })}
+                  </Select.List>
+                </Select>
               </Column>
             </Row>
             <Row className="mt-6">


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Replaces the deprecated "Dropdown" component with Select and Menu components in Stepper sections (specifically Stepper in Page Header and Stepper with Animation)

### Does this close any currently open issues?

Closes #2384 

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
