### PR TITLE
fix: replace deprecated Dropdown with Menu in Button

### DIFF
--- a/core/components/atoms/button/__stories__/SplitButton.story.jsx
+++ b/core/components/atoms/button/__stories__/SplitButton.story.jsx
@@ -1,26 +1,19 @@
 import * as React from 'react';
-import Button from '@/components/atoms/button';
-import Dropdown from '@/components/atoms/dropdown';
+import { Button, Menu } from '@/index';
 
 export const splitButton = () => {
-  const options = [
-    {
-      label: 'Download All',
-      value: 'Download All',
-    },
-    {
-      label: 'Download Selected',
-      value: 'Download Selected',
-    },
-  ];
-
   return (
     <div className="d-flex">
       <Button className="mr-2" aria-label="Request review">
         Request review
       </Button>
       <div className="mb-10">
-        <Dropdown menu={true} icon="expand_more" options={options} width={150} />
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            <Menu.Item>Download All</Menu.Item>
+            <Menu.Item>Download Selected</Menu.Item>
+          </Menu.List>
+        </Menu>
       </div>
     </div>
   );


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

It replaces the Dropdown component to Menu component in Split Button Story

### Does this close any currently open issues?

This PR closes: https://github.com/innovaccer/design-system/issues/2380

![split-button](https://github.com/user-attachments/assets/fd1104f4-cf7c-4514-a446-61e34ca49357)

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
