### PR TITLE
fix(popover): fix popover moves when the page scrolls

### DIFF
--- a/.storybook/docPage.css
+++ b/.storybook/docPage.css
@@ -1,6 +1,5 @@
 html, body {
   height: 100%;
-  overflow-y: auto;
 }
 
 .DocPage-editorTabs .TabsWrapper-header {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR fixes the issue where the popover in the table component triggered by the three-dots button moves with the page scroll instead of staying fixed in its intended position.

### Does this close any currently open issues?

#2485

### Any other comments?
No

### Dependent PRs/Commits

NA


### Describe breaking changes, if any.
No breaking changes introduced. 

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
