### PR TITLE
feat(Choicelist): add wrapLabel prop

### DIFF
--- a/core/components/atoms/checkbox/Checkbox.tsx
+++ b/core/components/atoms/checkbox/Checkbox.tsx
@@ -70,6 +70,10 @@ export interface CheckboxProps extends BaseProps, OmitNativeProps<HTMLInputEleme
    * Pass ref to the checkbox text
    */
   labelRef?: React.Ref<HTMLSpanElement>;
+  /**
+   *  Wrap checkbox label to the next line
+   */
+  wrapLabel?: boolean;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props, forwardedRef) => {
@@ -89,6 +93,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
     helpText,
     id = `${name}-${label}-${uidGenerator()}`,
     labelRef,
+    wrapLabel,
     ...rest
   } = props;
 
@@ -143,6 +148,12 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
     [styles['Checkbox-label--tiny']]: size === 'tiny',
   });
 
+  const LabelTextClass = classNames({
+    [styles['mw-100']]: true,
+    [styles['ellipsis']]: wrapLabel,
+    [styles['ellipsis--noWrap']]: !wrapLabel,
+  });
+
   const setIndeterminate = (indeterminateValue: any) => {
     ref.current!.indeterminate = indeterminateValue;
   };
@@ -191,7 +202,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
               <Text
                 size={size === 'tiny' ? 'small' : 'regular'}
                 appearance={disabled ? 'disabled' : 'default'}
-                className="ellipsis--noWrap mw-100"
+                className={LabelTextClass}
                 ref={labelRef}
               >
                 {label.trim()}

--- a/core/components/atoms/checkbox/__tests__/Checkbox.test.tsx
+++ b/core/components/atoms/checkbox/__tests__/Checkbox.test.tsx
@@ -60,6 +60,7 @@ describe('Checkbox component', () => {
     name: valueHelper(StringValue, { required: true }),
     value: valueHelper(StringValue, { required: true }),
     onChange: valueHelper(FunctionValue, { required: true }),
+    wrapLabel: valueHelper(BooleanValue, { required: true, iterate: true }),
   };
   const testFunc = (props: Record<string, any>): void => {
     const attr = filterUndefined(props) as Props;
@@ -89,6 +90,16 @@ describe('Checkbox component', () => {
     expect(getByTestId('DesignSystem-Checkbox-InputBox')).toBeInTheDocument();
     expect(getByTestId('DesignSystem-Checkbox-Label')).toBeInTheDocument();
     expect(getByTestId('DesignSystem-Checkbox-Label').textContent).toMatch(StringValue);
+  });
+
+  it('renders label with wrapLabel applied', () => {
+    const { getByTestId } = render(<Checkbox label={StringValue} wrapLabel={true} />);
+    expect(getByTestId('DesignSystem-Checkbox-Label').querySelector('span')).toHaveClass('ellipsis');
+  });
+
+  it('renders label without wrapLabel applied', () => {
+    const { getByTestId } = render(<Checkbox label={StringValue} wrapLabel={false} />);
+    expect(getByTestId('DesignSystem-Checkbox-Label').querySelector('span')).toHaveClass('ellipsis--noWrap');
   });
 
   it('renders children with helpText prop', () => {

--- a/core/components/atoms/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/core/components/atoms/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -90,7 +90,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -145,7 +145,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -200,7 +200,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -270,7 +270,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -340,7 +340,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -411,7 +411,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -482,7 +482,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -501,7 +501,7 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: false, size: "regular", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: false, size: "regular", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -536,7 +536,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -555,7 +555,61 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: false, size: "regular", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: false, size: "regular", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--regular"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input"
+          data-test="DesignSystem-Checkbox-InputBox"
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        />
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--default Text--regular mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--subtle Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: false, size: "regular", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -591,7 +645,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -610,7 +664,62 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: false, size: "tiny", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: false, size: "regular", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox Checkbox--disabled"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--regular"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input"
+          data-test="DesignSystem-Checkbox-InputBox"
+          disabled=""
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        />
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--disabled Text--regular mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--disabled Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: false, size: "tiny", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -645,7 +754,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--small ellipsis--noWrap mw-100"
+            class="Text Text--default Text--small mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -664,7 +773,61 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: false, size: "tiny", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: false, size: "tiny", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--tiny"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input"
+          data-test="DesignSystem-Checkbox-InputBox"
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        />
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label Checkbox-label--tiny"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--default Text--small mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--subtle Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: false, size: "tiny", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -700,7 +863,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -719,7 +882,62 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: true, size: "regular", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: false, size: "tiny", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox Checkbox--disabled"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--tiny"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input"
+          data-test="DesignSystem-Checkbox-InputBox"
+          disabled=""
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        />
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label Checkbox-label--tiny"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--disabled Text--small mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--disabled Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: true, size: "regular", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -767,7 +985,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -786,7 +1004,74 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: true, size: "regular", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: true, size: "regular", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--regular"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input Checkbox-input--indeterminate"
+          data-test="DesignSystem-Checkbox-InputBox"
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        >
+          <svg
+            fill="none"
+            height="2"
+            viewBox="0 0 10 2"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0 0H10V2H0V0Z"
+              fill="white"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--default Text--regular mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--subtle Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: true, size: "regular", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -835,7 +1120,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -854,7 +1139,75 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: true, size: "tiny", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: true, size: "regular", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox Checkbox--disabled"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--regular"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input Checkbox-input--indeterminate"
+          data-test="DesignSystem-Checkbox-InputBox"
+          disabled=""
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        >
+          <svg
+            fill="none"
+            height="2"
+            viewBox="0 0 10 2"
+            width="10"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M0 0H10V2H0V0Z"
+              fill="white"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--disabled Text--regular mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--disabled Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: true, size: "tiny", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -904,7 +1257,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--small ellipsis--noWrap mw-100"
+            class="Text Text--default Text--small mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -923,7 +1276,76 @@ exports[`Checkbox component
 `;
 
 exports[`Checkbox component 
-  indeterminate: true, size: "tiny", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]"
+  indeterminate: true, size: "tiny", disabled: false, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--tiny"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input Checkbox-input--indeterminate"
+          data-test="DesignSystem-Checkbox-InputBox"
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        >
+          <svg
+            fill="none"
+            height="2"
+            viewBox="0 0 8 2"
+            width="8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M8 0H0V2H8V0Z"
+              fill="white"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label Checkbox-label--tiny"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--default Text--small mw-100 ellipsis"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--subtle Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: true, size: "tiny", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: false
  1`] = `
 <body>
   <div>
@@ -974,7 +1396,77 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+            class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
+            data-test="DesignSystem-Text"
+          >
+            Checkbox
+          </span>
+        </label>
+        <span
+          class="Text Text--disabled Text--small"
+          data-test="DesignSystem-Checkbox-HelpText"
+        >
+          Checkbox
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`Checkbox component 
+  indeterminate: true, size: "tiny", disabled: true, label: "Checkbox", helpText: "Checkbox", name: "Checkbox", value: "Checkbox", onChange: "[Function]", wrapLabel: true
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="Checkbox Checkbox--disabled"
+      data-test="DesignSystem-Checkbox"
+    >
+      <div
+        class="Checkbox-outerWrapper Checkbox-outerWrapper--tiny"
+        data-test="DesignSystem-Checkbox-OuterWrapper"
+      >
+        <input
+          class="Checkbox-input Checkbox-input--indeterminate"
+          data-test="DesignSystem-Checkbox-InputBox"
+          disabled=""
+          id="Checkbox-Checkbox-Test-uid"
+          name="Checkbox"
+          tabindex="0"
+          type="checkbox"
+          value="Checkbox"
+        />
+        <span
+          class="Checkbox-wrapper Checkbox-wrapper--default"
+          data-test="DesignSystem-Checkbox-Icon"
+        >
+          <svg
+            fill="none"
+            height="2"
+            viewBox="0 0 8 2"
+            width="8"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M8 0H0V2H8V0Z"
+              fill="white"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </span>
+      </div>
+      <div
+        class="Checkbox-labelWrapper"
+      >
+        <label
+          class="Checkbox-label Checkbox-label--tiny"
+          data-test="DesignSystem-Checkbox-Label"
+          for="Checkbox-Checkbox-Test-uid"
+        >
+          <span
+            class="Text Text--disabled Text--small mw-100 ellipsis"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -1044,7 +1536,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+            class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox
@@ -1112,7 +1604,7 @@ exports[`Checkbox component
           for="Checkbox-Checkbox-Test-uid"
         >
           <span
-            class="Text Text--default Text--small ellipsis--noWrap mw-100"
+            class="Text Text--default Text--small mw-100 ellipsis--noWrap"
             data-test="DesignSystem-Text"
           >
             Checkbox

--- a/core/components/organisms/choiceList/ChoiceList.tsx
+++ b/core/components/organisms/choiceList/ChoiceList.tsx
@@ -77,6 +77,11 @@ export interface ChoiceListProps extends BaseProps {
    * Callback when the selected choices change
    */
   onChange?: (event: ChangeEvent, selected: string[]) => void;
+
+  /**
+   * Wrap checkbox label to the next line
+   */
+  wrapLabel?: boolean;
 }
 
 const renderCheckbox = (
@@ -85,7 +90,8 @@ const renderCheckbox = (
   ChoiceListDisabled: boolean,
   size: ChoiceListSize,
   alignment: ChoiceListAlignment,
-  selected: string[]
+  selected: string[],
+  wrapLabel: boolean | undefined
 ) => {
   return list.map((item: Choice, checkboxIndex: number) => {
     const { name, value, helpText, disabled, label } = item;
@@ -101,6 +107,7 @@ const renderCheckbox = (
         value={value}
         defaultChecked={selected.length !== 0 && selected.includes(value)}
         className={getCheckboxClassName(alignment, checkboxIndex)}
+        wrapLabel={wrapLabel}
       />
     );
   });
@@ -161,8 +168,8 @@ export const ChoiceList = (props: ChoiceListProps) => {
     disabled = false,
     size = 'regular',
     className,
+    wrapLabel,
   } = props;
-
   const { selected = [] } = props;
   let selectedChoiceValue = (selected && selected) || [];
   const ChoiceListClass = classNames(
@@ -203,7 +210,7 @@ export const ChoiceList = (props: ChoiceListProps) => {
         {title && title.trim() && <Label withInput={true}>{title.trim()}</Label>}
         {allowMultiple ? (
           <div className={`${alignment === 'horizontal' ? ChoiceHorizontalClass : ChoiceListVerticalClass}`}>
-            {renderCheckbox(choices, handleOnChange, disabled, size, alignment, selected)}
+            {renderCheckbox(choices, handleOnChange, disabled, size, alignment, selected, wrapLabel)}
           </div>
         ) : (
           <div className={`${alignment === 'horizontal' ? ChoiceHorizontalClass : ChoiceListVerticalClass}`}>

--- a/core/components/organisms/choiceList/__tests__/__snapshots__/ChoiceList.test.tsx.snap
+++ b/core/components/organisms/choiceList/__tests__/__snapshots__/ChoiceList.test.tsx.snap
@@ -486,7 +486,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -525,7 +525,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -593,7 +593,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -632,7 +632,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -701,7 +701,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -741,7 +741,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -810,7 +810,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -850,7 +850,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1350,7 +1350,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1389,7 +1389,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1457,7 +1457,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1496,7 +1496,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--default Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1565,7 +1565,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1605,7 +1605,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1674,7 +1674,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -1714,7 +1714,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--regular ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--regular mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2214,7 +2214,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2253,7 +2253,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2321,7 +2321,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2360,7 +2360,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2429,7 +2429,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2469,7 +2469,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2538,7 +2538,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -2578,7 +2578,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3078,7 +3078,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3117,7 +3117,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3185,7 +3185,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3224,7 +3224,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--default Text--small ellipsis--noWrap mw-100"
+                class="Text Text--default Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3293,7 +3293,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3333,7 +3333,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3402,7 +3402,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio
@@ -3442,7 +3442,7 @@ exports[`ChoiceList component
               for="choiceList-radio-Test-uid"
             >
               <span
-                class="Text Text--disabled Text--small ellipsis--noWrap mw-100"
+                class="Text Text--disabled Text--small mw-100 ellipsis--noWrap"
                 data-test="DesignSystem-Text"
               >
                 radio


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Updated the ChoiceList component to allow long labels to wrap to the next line instead of being truncated
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
