### PR TITLE
feat(grid): add custom header cell renderer with sorting support

### DIFF
--- a/core/components/organisms/grid/Cell.tsx
+++ b/core/components/organisms/grid/Cell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { RowData, ColumnSchema } from './Grid';
+import { RowData, ColumnSchema, SortType } from './Grid';
 import { Dropdown, Placeholder, PlaceholderParagraph, Text, Icon, Button, Tooltip, GridCell } from '@/index';
 import { DropdownProps, GridCellProps } from '@/index.type';
 import { resizeCol, hasSchema } from './utility';
@@ -30,7 +30,13 @@ type BodyCellProps = SharedCellProps & {
   expandedState: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
 };
 
-export type HeaderCellRendererProps = HeaderCellProps & SharedCellProps;
+export type HeaderCellRendererProps = HeaderCellProps &
+  SharedCellProps & {
+    sortingList: {
+      name: ColumnSchema['name'];
+      type: SortType;
+    }[];
+  };
 
 export type CellProps = Partial<HeaderCellProps> &
   Partial<BodyCellProps> &
@@ -41,6 +47,18 @@ export type CellProps = Partial<HeaderCellProps> &
 
 const HeaderCell = (props: HeaderCellProps) => {
   const context = React.useContext(GridContext);
+
+  const {
+    loading,
+    draggable,
+    showMenu,
+    sortingList,
+    filterList,
+    headCellTooltip,
+    showFilters,
+    schema: schemaProp,
+  } = context;
+
   const {
     schema,
     setIsDragged,
@@ -61,18 +79,8 @@ const HeaderCell = (props: HeaderCellProps) => {
     updateColumnSchema,
     reorderColumn,
     setIsDragged,
-  };
-
-  const {
-    loading,
-    draggable,
-    showMenu,
     sortingList,
-    filterList,
-    headCellTooltip,
-    showFilters,
-    schema: schemaProp,
-  } = context;
+  };
 
   const { sorting = true, name, filters, pinned } = schema;
 

--- a/core/components/organisms/table/__stories__/customCellRenderer/HeaderCell.story.jsx
+++ b/core/components/organisms/table/__stories__/customCellRenderer/HeaderCell.story.jsx
@@ -140,6 +140,36 @@ export const headerCell = () => {
       displayName: 'Plan Name',
       width: '15%',
       separator: true,
+      sorting: true,
+      headerCellRenderer: (props) => {
+        // eslint-disable-next-line react/prop-types
+        const { schema, sortingList = [] } = props;
+        // eslint-disable-next-line react/prop-types
+        const { sorting, name } = schema;
+
+        // Find current sort state
+        const listIndex = sortingList.findIndex((l) => l.name === name);
+        const sorted = listIndex !== -1 ? sortingList[listIndex].type : null;
+
+        return (
+          <>
+            <Badge>Plan</Badge>
+            {sorting && (
+              <div style={{ marginLeft: 'auto' }}>
+                {sorted ? (
+                  sorted === 'asc' ? (
+                    <Icon name="arrow_upward" />
+                  ) : (
+                    <Icon name="arrow_downward" />
+                  )
+                ) : (
+                  <Icon name="unfold_more" />
+                )}
+              </div>
+            )}
+          </>
+        );
+      },
     },
     {
       name: 'first_dos',
@@ -339,6 +369,36 @@ const customCode = `() => {
       displayName: 'Plan Name',
       width: '15%',
       separator: true,
+      sorting: true,
+      headerCellRenderer: (props) => {
+        // eslint-disable-next-line react/prop-types
+        const { schema, sortingList = [] } = props;
+        // eslint-disable-next-line react/prop-types
+        const { sorting, name } = schema;
+
+        // Find current sort state
+        const listIndex = sortingList.findIndex((l) => l.name === name);
+        const sorted = listIndex !== -1 ? sortingList[listIndex].type : null;
+
+        return (
+          <>
+            <Badge>Plan</Badge>
+            {sorting && (
+              <div style={{ marginLeft: 'auto' }}>
+                {sorted ? (
+                  sorted === 'asc' ? (
+                    <Icon name="arrow_upward" />
+                  ) : (
+                    <Icon name="arrow_downward" />
+                  )
+                ) : (
+                  <Icon name="unfold_more" />
+                )}
+              </div>
+            )}
+          </>
+        )
+      },
     },
     {
       name: 'first_dos',


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
This PR extend custom header cell renderer functionality for the Grid/Table component with  sorting state
We were passing only, header props  to headerCellRenderer but to show sorted state correctly we need sortingList
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
