### PR TITLE
feature(chat-input): allow capability to add custom submit trigger

### DIFF
--- a/core/components/molecules/chat/chatInput/ChatInput.tsx
+++ b/core/components/molecules/chat/chatInput/ChatInput.tsx
@@ -22,6 +22,13 @@ export interface ChatInputProps extends BaseProps {
    */
   showStopButton?: boolean;
   /**
+   * Custom submit button renderer. If provided, it will be rendered instead of the default send button.
+   * After the custom button's onClick is executed, ChatInput will clear the textarea.
+   */
+  customSubmitRenderer?: React.ComponentType<{
+    onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  }>;
+  /**
    * Action renderer for the `ChatInput`
    */
   actionRenderer?: () => JSX.Element;
@@ -64,6 +71,7 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
     disabled,
     actionRenderer,
     onStopGenerating,
+    customSubmitRenderer: CustomSubmitRenderer,
     className,
     ...rest
   } = props;
@@ -132,6 +140,14 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
   };
 
   const sendButtonRenderer = () => {
+    if (CustomSubmitRenderer) {
+      return (
+        <div className={actionRenderer ? 'ml-3' : ''}>
+          <CustomSubmitRenderer onClick={clearChatInput} />
+        </div>
+      );
+    }
+
     if (showStopButton) {
       return (
         <Button

--- a/core/components/molecules/chat/chatInput/__stories__/withCustomSubmitTrigger.story.jsx
+++ b/core/components/molecules/chat/chatInput/__stories__/withCustomSubmitTrigger.story.jsx
@@ -1,0 +1,89 @@
+/* global console */
+import * as React from 'react';
+import { Chat, Button } from '@/index';
+
+export const withCustomSubmitRenderer = () => {
+  const CustomSubmitRenderer = ({ onClick }) => {
+    const handleCustomSubmit = () => {
+      // Custom logic here - e.g. analytics, validation put logs for testing
+      console.log('Message sent via custom handler');
+      // After custom logic is done, ChatInput will clear the textarea
+      onClick();
+    };
+
+    return <Button size="tiny" appearance="alert" icon="send" onClick={handleCustomSubmit} />;
+  };
+
+  return (
+    <div>
+      <h3>With Custom Submit Renderer (no onSend needed)</h3>
+      <Chat>
+        <Chat.ChatInput
+          customSubmitRenderer={CustomSubmitRenderer}
+          placeholder="Type and click custom send button..."
+        />
+      </Chat>
+    </div>
+  );
+};
+
+const customCode = `() => {
+  const CustomSubmitRenderer = ({ onClick }) => {
+    const handleCustomSubmit = () => {
+      // Custom logic here - e.g. analytics, validation, API calls
+      console.log('Message sent via custom handler');
+      
+      // After custom logic is done, ChatInput will clear the textarea
+      onClick();
+    };
+
+    return (
+      <Button
+        size="tiny"
+        appearance="alert"
+        icon="send"
+        onClick={handleCustomSubmit}
+      />
+    );
+  };
+
+  return (
+    <div>
+      <h3>With Custom Submit Renderer</h3>
+      <Chat>
+        <Chat.ChatInput 
+          customSubmitRenderer={CustomSubmitRenderer}
+          placeholder="Type and click custom send button..."
+        />
+      </Chat>
+    </div>
+  );
+}`;
+
+export default {
+  title: 'Components/Chat/Chat Input/With Custom Submit Renderer',
+  component: Chat,
+  subcomponents: {
+    'Chat.ChatInput': Chat.ChatInput,
+    'Chat.ChatBubble': Chat.ChatBubble,
+    'Chat.DateSeparator': Chat.DateSeparator,
+    'Chat.NewMessage': Chat.NewMessage,
+    'Chat.UnreadMessage': Chat.UnreadMessage,
+    'Chat.TypingIndicator': Chat.TypingIndicator,
+  },
+  parameters: {
+    docs: {
+      docPage: {
+        title: 'Chat',
+        description: `
+Custom Submit Renderer Behavior:
+   - onSend prop is optional (not used)
+   - Custom submit renderer handles its own send logic
+   - ChatInput only handles clearing the textarea
+   - Gives full control over the submit behavior
+        `,
+        customCode,
+      },
+    },
+  },
+};

--- a/core/components/molecules/chat/chatInput/__tests__/ChatInput.test.tsx
+++ b/core/components/molecules/chat/chatInput/__tests__/ChatInput.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Button } from '@/index';
 import { render, fireEvent } from '@testing-library/react';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
 import ChatInput, { ChatInputProps as Props } from '../ChatInput';
@@ -99,6 +100,71 @@ describe('ChatInput component', () => {
     fireEvent.change(input, { target: { value: 'Test message' } });
     fireEvent.click(sendButton);
     expect(input).toHaveValue('');
+  });
+
+  describe('customSubmitRenderer', () => {
+    it('Should render custom submit renderer when provided', () => {
+      const CustomSubmitRenderer = ({ onClick }: { onClick: (e: React.MouseEvent<HTMLButtonElement>) => void }) => (
+        <button data-test="DesignSystem-CustomSubmit" onClick={onClick}>
+          Custom Submit
+        </button>
+      );
+
+      const { getByTestId, queryByTestId } = render(<ChatInput customSubmitRenderer={CustomSubmitRenderer} />);
+
+      expect(getByTestId('DesignSystem-CustomSubmit')).toBeInTheDocument();
+      expect(queryByTestId('DesignSystem-SendButton')).not.toBeInTheDocument();
+    });
+
+    it('Should clear input when custom submit renderer is clicked', () => {
+      const CustomSubmitRenderer = ({ onClick }: { onClick: (e: React.MouseEvent<HTMLButtonElement>) => void }) => (
+        <Button data-test="DesignSystem-CustomSubmit" onClick={onClick}>
+          Custom Submit
+        </Button>
+      );
+
+      const { getByTestId, getByPlaceholderText } = render(<ChatInput customSubmitRenderer={CustomSubmitRenderer} />);
+
+      const input = getByPlaceholderText('Start typing...');
+      const customButton = getByTestId('DesignSystem-CustomSubmit');
+
+      fireEvent.change(input, { target: { value: 'Test message' } });
+      expect(input).toHaveValue('Test message');
+
+      fireEvent.click(customButton);
+      expect(input).toHaveValue('');
+    });
+
+    it('Should maintain proper spacing with actionRenderer', () => {
+      const CustomSubmitRenderer = ({ onClick }: { onClick: (e: React.MouseEvent<HTMLButtonElement>) => void }) => (
+        <button data-test="DesignSystem-CustomSubmit" onClick={onClick}>
+          Custom Submit
+        </button>
+      );
+
+      const actionRenderer = () => <button data-test="DesignSystem-CustomAction">Action</button>;
+
+      const { container } = render(
+        <ChatInput customSubmitRenderer={CustomSubmitRenderer} actionRenderer={actionRenderer} />
+      );
+
+      const customSubmitWrapper = container.querySelector('.ml-3');
+      expect(customSubmitWrapper).toBeInTheDocument();
+    });
+
+    it('Should take precedence over showStopButton', () => {
+      const CustomSubmitRenderer = ({ onClick }: { onClick: (e: React.MouseEvent<HTMLButtonElement>) => void }) => (
+        <button data-test="DesignSystem-CustomSubmit" onClick={onClick}>
+          Custom Submit
+        </button>
+      );
+
+      const { queryByTestId } = render(<ChatInput customSubmitRenderer={CustomSubmitRenderer} showStopButton={true} />);
+
+      expect(queryByTestId('DesignSystem-CustomSubmit')).toBeInTheDocument();
+      expect(queryByTestId('DesignSystem-StopButton')).not.toBeInTheDocument();
+      expect(queryByTestId('DesignSystem-SendButton')).not.toBeInTheDocument();
+    });
   });
 
   describe('className and data-test attributes', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@innovaccer/design-system",
-  "version": "4.0.0",
+  "version": "4.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innovaccer/design-system",
-      "version": "4.0.0",
+      "version": "4.11.0",
       "license": "MIT",
       "dependencies": {
         "@lottiefiles/react-lottie-player": "^3.5.3",
         "classnames": "^2.3.1",
         "core-js": "^3.9.1",
         "react-dom": "^16.8.6",
-        "react-dynamic-virtual-scroll": "^1.3.2",
         "react-popper": "^1.3.7",
         "throttle-debounce": "^2.1.0",
         "utility-types": "^3.10.0"
@@ -40422,11 +40421,6 @@
       "peerDependencies": {
         "react": "^16.14.0"
       }
-    },
-    "node_modules/react-dynamic-virtual-scroll": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-dynamic-virtual-scroll/-/react-dynamic-virtual-scroll-1.4.0.tgz",
-      "integrity": "sha512-agw3/kpcP2L5M/2hf7AKsIwxsJ+9RiVedh8vFTsxqvLVYj2pxzSY087et0kMfWnWfAP+m4ns39be7fsRr3okOg=="
     },
     "node_modules/react-element-to-jsx-string": {
       "version": "14.3.4",


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adds a prop called `withCustomSubmitRenderer` which allows the users to provide their own implementation for submit trigger. The users can put any component in future probably Icon, Text or any other trigger they want to use for submitting the value, it doesn't restrict the users to only use the default Send button.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
