### PR TITLE
feat(chatInput): add readOnly prop for chatInput

### DIFF
--- a/core/components/molecules/chat/chatInput/ChatInput.tsx
+++ b/core/components/molecules/chat/chatInput/ChatInput.tsx
@@ -18,6 +18,10 @@ export interface ChatInputProps extends BaseProps {
    */
   disabled?: boolean;
   /**
+   * Makes the `ChatInput` read-only
+   */
+  readOnly?: boolean;
+  /**
    * Show stop generating button instead of send button
    */
   showStopButton?: boolean;
@@ -62,6 +66,7 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
     onChange,
     onSend,
     disabled,
+    readOnly,
     actionRenderer,
     onStopGenerating,
     className,
@@ -164,7 +169,7 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
   };
 
   const onChangeHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (!disabled) {
+    if (!disabled && !readOnly) {
       setValue(e.target.value);
       onChange && onChange(e);
       resizeTextarea(e.target.value);
@@ -179,6 +184,7 @@ const ChatInput: React.FC<ChatInputProps> = (props) => {
         onChange={onChangeHandler}
         className={textareaClassNames}
         disabled={disabled}
+        readOnly={readOnly}
         data-test="DesignSystem-ChatInput-textarea"
         {...rest}
       />

--- a/core/components/molecules/chat/chatInput/__stories__/readonly.story.jsx
+++ b/core/components/molecules/chat/chatInput/__stories__/readonly.story.jsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Chat } from '@/index';
+
+export const readOnlyState = () => {
+  return (
+    <Chat>
+      <Chat.ChatInput readOnly defaultValue="This is a read-only message that can be sent but not edited." />
+    </Chat>
+  );
+};
+
+const customCode = `() => {
+  return (
+    <Chat>
+      <Chat.ChatInput readOnly defaultValue="This is a read-only message that can be sent but not edited." />
+    </Chat>
+  )
+}`;
+
+export default {
+  title: 'Components/Chat/Chat Input/State/Read Only State',
+  component: Chat,
+  subcomponents: {
+    'Chat.ChatInput': Chat.ChatInput,
+    'Chat.ChatBubble': Chat.ChatBubble,
+    'Chat.DateSeparator': Chat.DateSeparator,
+    'Chat.NewMessage': Chat.NewMessage,
+    'Chat.UnreadMessage': Chat.UnreadMessage,
+    'Chat.TypingIndicator': Chat.TypingIndicator,
+  },
+  parameters: {
+    docs: {
+      docPage: {
+        title: 'Chat',
+        customCode,
+      },
+    },
+  },
+};

--- a/core/components/molecules/chat/chatInput/__tests__/ChatInput.test.tsx
+++ b/core/components/molecules/chat/chatInput/__tests__/ChatInput.test.tsx
@@ -12,6 +12,7 @@ describe('ChatInput component', () => {
     placeholder: valueHelper('Custom placeholder', { required: true }),
     defaultValue: valueHelper(StringValue, { required: true }),
     disabled: valueHelper(BooleanValue, { required: true, iterate: true }),
+    readOnly: valueHelper(BooleanValue, { required: true, iterate: true }),
     showStopButton: valueHelper(BooleanValue, { required: true, iterate: true }),
     onChange: valueHelper(FunctionValue, { required: true }),
     onClick: valueHelper(FunctionValue, { required: true }),
@@ -101,6 +102,34 @@ describe('ChatInput component', () => {
     expect(input).toHaveValue('');
   });
 
+  it('Should make input read-only when readOnly prop is true', () => {
+    const defaultValue = 'Read only text';
+    const { getByPlaceholderText } = render(<ChatInput readOnly={true} defaultValue={defaultValue} />);
+    const input = getByPlaceholderText('Start typing...');
+
+    expect(input).toHaveAttribute('readOnly');
+    expect(input).toHaveValue(defaultValue);
+
+    fireEvent.change(input, { target: { value: 'New message' } });
+    expect(input).toHaveValue(defaultValue);
+  });
+
+  it('Should allow sending message when readOnly but prevent editing', () => {
+    const onSend = jest.fn();
+    const defaultValue = 'Read only message';
+    const { getByPlaceholderText, getByTestId } = render(
+      <ChatInput readOnly={true} defaultValue={defaultValue} onSend={onSend} />
+    );
+    const input = getByPlaceholderText('Start typing...');
+    const sendButton = getByTestId('DesignSystem-SendButton');
+
+    fireEvent.change(input, { target: { value: 'New message' } });
+    expect(input).toHaveValue(defaultValue);
+
+    fireEvent.click(sendButton);
+    expect(onSend).toHaveBeenCalledWith(expect.any(Object), defaultValue);
+  });
+
   describe('className and data-test attributes', () => {
     it('applies custom className to the container', () => {
       const customClass = 'custom-chat-input';
@@ -119,11 +148,8 @@ describe('ChatInput component', () => {
       const { getByTestId } = render(<ChatInput />);
 
       expect(getByTestId('DesignSystem-ChatInput')).toBeInTheDocument();
-
       expect(getByTestId('DesignSystem-ChatInput-textarea')).toBeInTheDocument();
-
       expect(getByTestId('DesignSystem-ChatInput-actions')).toBeInTheDocument();
-
       expect(getByTestId('DesignSystem-SendButton')).toBeInTheDocument();
 
       const { getByTestId: getByTestIdWithStop } = render(<ChatInput showStopButton={true} />);

--- a/core/components/molecules/chat/chatInput/__tests__/__snapshots__/ChatInput.test.tsx.snap
+++ b/core/components/molecules/chat/chatInput/__tests__/__snapshots__/ChatInput.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ChatInput component 
-  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: false, showStopButton: false, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: false, readOnly: false, showStopButton: false, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
  1`] = `
 <body>
   <div>
@@ -47,7 +47,7 @@ exports[`ChatInput component
 `;
 
 exports[`ChatInput component 
-  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: false, showStopButton: true, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: false, readOnly: false, showStopButton: true, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
  1`] = `
 <body>
   <div>
@@ -93,7 +93,101 @@ exports[`ChatInput component
 `;
 
 exports[`ChatInput component 
-  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: true, showStopButton: false, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: false, readOnly: true, showStopButton: false, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="ChatInput"
+      data-test="DesignSystem-ChatInput"
+    >
+      <textarea
+        class="ChatInput-textarea"
+        data-test="DesignSystem-ChatInput-textarea"
+        placeholder="Custom placeholder"
+        readonly=""
+      >
+        Sample message
+      </textarea>
+      <div
+        class="ChatInput-actions"
+        data-test="DesignSystem-ChatInput-actions"
+      >
+        <button
+          aria-label="Send"
+          class="Button Button--tiny Button--tinySquare Button--primary"
+          data-test="DesignSystem-SendButton"
+          tabindex="0"
+        >
+          <div
+            class="Button-icon"
+            data-test="DesignSystem-Button--Icon-Wrapper"
+          >
+            <i
+              class="material-symbols material-symbols-rounded Icon"
+              data-test="DesignSystem-Button--Icon"
+              role="button"
+              style="font-size: 16px; width: 16px;"
+            >
+              arrow_upward_alt
+            </i>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ChatInput component 
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: false, readOnly: true, showStopButton: true, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="ChatInput"
+      data-test="DesignSystem-ChatInput"
+    >
+      <textarea
+        class="ChatInput-textarea"
+        data-test="DesignSystem-ChatInput-textarea"
+        placeholder="Custom placeholder"
+        readonly=""
+      >
+        Sample message
+      </textarea>
+      <div
+        class="ChatInput-actions"
+        data-test="DesignSystem-ChatInput-actions"
+      >
+        <button
+          aria-label="Stop Generating"
+          class="Button Button--tiny Button--tinySquare Button--alert"
+          data-test="DesignSystem-StopButton"
+          tabindex="0"
+        >
+          <div
+            class="Button-icon"
+            data-test="DesignSystem-Button--Icon-Wrapper"
+          >
+            <i
+              class="material-symbols material-symbols-rounded Icon"
+              data-test="DesignSystem-Button--Icon"
+              role="button"
+              style="font-size: 16px; width: 16px;"
+            >
+              stop
+            </i>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ChatInput component 
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: true, readOnly: false, showStopButton: false, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
  1`] = `
 <body>
   <div>
@@ -141,7 +235,7 @@ exports[`ChatInput component
 `;
 
 exports[`ChatInput component 
-  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: true, showStopButton: true, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: true, readOnly: false, showStopButton: true, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
  1`] = `
 <body>
   <div>
@@ -154,6 +248,104 @@ exports[`ChatInput component
         data-test="DesignSystem-ChatInput-textarea"
         disabled=""
         placeholder="Custom placeholder"
+      >
+        Sample message
+      </textarea>
+      <div
+        class="ChatInput-actions"
+        data-test="DesignSystem-ChatInput-actions"
+      >
+        <button
+          aria-label="Stop Generating"
+          class="Button Button--tiny Button--tinySquare Button--alert"
+          data-test="DesignSystem-StopButton"
+          disabled=""
+          tabindex="0"
+        >
+          <div
+            class="Button-icon"
+            data-test="DesignSystem-Button--Icon-Wrapper"
+          >
+            <i
+              class="material-symbols material-symbols-rounded Icon"
+              data-test="DesignSystem-Button--Icon"
+              role="button"
+              style="font-size: 16px; width: 16px;"
+            >
+              stop
+            </i>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ChatInput component 
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: true, readOnly: true, showStopButton: false, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="ChatInput ChatInput--disabled"
+      data-test="DesignSystem-ChatInput"
+    >
+      <textarea
+        class="ChatInput-textarea"
+        data-test="DesignSystem-ChatInput-textarea"
+        disabled=""
+        placeholder="Custom placeholder"
+        readonly=""
+      >
+        Sample message
+      </textarea>
+      <div
+        class="ChatInput-actions"
+        data-test="DesignSystem-ChatInput-actions"
+      >
+        <button
+          aria-label="Send"
+          class="Button Button--tiny Button--tinySquare Button--primary"
+          data-test="DesignSystem-SendButton"
+          disabled=""
+          tabindex="0"
+        >
+          <div
+            class="Button-icon"
+            data-test="DesignSystem-Button--Icon-Wrapper"
+          >
+            <i
+              class="material-symbols material-symbols-rounded Icon"
+              data-test="DesignSystem-Button--Icon"
+              role="button"
+              style="font-size: 16px; width: 16px;"
+            >
+              arrow_upward_alt
+            </i>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`ChatInput component 
+  placeholder: "Custom placeholder", defaultValue: "Sample message", disabled: true, readOnly: true, showStopButton: true, onChange: "[Function]", onClick: "[Function]", onBlur: "[Function]", onFocus: "[Function]", onKeyDown: "[Function]", onSend: "[Function]", onStopGenerating: "[Function]"
+ 1`] = `
+<body>
+  <div>
+    <div
+      class="ChatInput ChatInput--disabled"
+      data-test="DesignSystem-ChatInput"
+    >
+      <textarea
+        class="ChatInput-textarea"
+        data-test="DesignSystem-ChatInput-textarea"
+        disabled=""
+        placeholder="Custom placeholder"
+        readonly=""
       >
         Sample message
       </textarea>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adds a prop `readOnly` for ChatInput component.
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
