### PR TITLE
feat(Navigation): add extended support for count prop in VerticalNav …

### DIFF
--- a/core/components/organisms/horizontalNav/HorizontalNav.tsx
+++ b/core/components/organisms/horizontalNav/HorizontalNav.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Text, Icon, Pills } from '@/index';
 import { VerticalNavProps } from '@/index.type';
 import { extractBaseProps, BaseProps } from '@/utils/types';
-import { getNavItemColor, getPillsAppearance, isMenuActive, Menu } from '@/utils/navigationHelper';
+import { getNavItemColor, getPillsAppearance, isMenuActive, Menu, formatCount } from '@/utils/navigationHelper';
 import styles from '@css/components/horizontalNav.module.css';
 
 export type HorizontalNavProps = BaseProps & Pick<VerticalNavProps, 'menus' | 'active' | 'onClick'>;
@@ -34,7 +34,7 @@ export const HorizontalNav = (props: HorizontalNavProps) => {
 
   const renderIcon = (menu: Menu, isActive: boolean) => {
     if (menu.count !== undefined) {
-      const count = menu.count > 99 ? '99+' : menu.count;
+      const count = formatCount(menu.count);
       return (
         <Pills
           subtle={menu.disabled}

--- a/core/components/organisms/horizontalNav/__tests__/HorizontalNav.test.tsx
+++ b/core/components/organisms/horizontalNav/__tests__/HorizontalNav.test.tsx
@@ -62,6 +62,11 @@ export const countMenus = [
   {
     name: 'tab3',
     label: 'Tab #3',
+    count: '...',
+  },
+  {
+    name: 'tab3',
+    label: 'Tab #3',
     count: 100,
     disabled: true,
   },
@@ -90,8 +95,6 @@ describe('Horizontal Navigation component', () => {
 });
 
 describe('Horizontal Navigation component with prop: menus', () => {
-  const disabledIndex = 2;
-
   it('renders menus', () => {
     const { getAllByTestId } = render(<HorizontalNav menus={menus} />);
     expect(getAllByTestId(HorizontalNavDataKey)).toHaveLength(menus.length);
@@ -120,27 +123,38 @@ describe('Horizontal Navigation component with prop: menus', () => {
   });
 
   it('renders disabled menu', () => {
+    const disabledIndex = menus.findIndex((menu) => menu.disabled);
     const { getAllByTestId } = render(<HorizontalNav menus={menus} />);
     const disabledMenu = getAllByTestId('DesignSystem-HorizontalNav')[disabledIndex];
     expect(disabledMenu).toHaveClass('color-inverse-lightest');
   });
 
   it('renders menus with disabled menu', () => {
+    const disabledIndex = menus.findIndex((menu) => menu.disabled);
     const { getAllByTestId } = render(<HorizontalNav menus={menus} />);
     const disabledMenu = getAllByTestId('DesignSystem-HorizontalNav--Text')[disabledIndex];
     expect(disabledMenu).toHaveClass('color-inverse-lightest');
   });
 
   it('renders iconMenus with disabled menu', () => {
+    const disabledIndex = iconMenus.findIndex((menu) => menu.disabled);
     const { getAllByTestId } = render(<HorizontalNav menus={iconMenus} />);
     const disabledMenu = getAllByTestId('DesignSystem-HorizontalNav--Icon')[disabledIndex];
     expect(disabledMenu).toHaveStyle('color: var(--inverse-lightest)');
   });
 
   it('renders countMenus with disabled menu', () => {
+    const disabledIndex = countMenus.findIndex((menu) => menu.disabled);
     const { getAllByTestId } = render(<HorizontalNav menus={countMenus} />);
     const disabledMenu = getAllByTestId('DesignSystem-HorizontalNav--Pills')[disabledIndex];
     expect(disabledMenu).toHaveClass('Badge--subtle-secondary');
+  });
+
+  it('renders countMenus with a string count menu item', () => {
+    const stringCountMenuItemIndex = countMenus.findIndex((menu) => typeof menu.count === 'string');
+    const { getAllByTestId } = render(<HorizontalNav menus={countMenus} />);
+    const menuItemWithStringCount = getAllByTestId('DesignSystem-HorizontalNav--Pills')[stringCountMenuItemIndex];
+    expect(menuItemWithStringCount).toHaveTextContent(countMenus[stringCountMenuItemIndex].count as string);
   });
 });
 

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { Text, Icon, Pills, Tooltip } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
-import { getNavItemColor, getPillsAppearance, Menu } from '@/utils/navigationHelper';
+import { getNavItemColor, getPillsAppearance, Menu, formatCount } from '@/utils/navigationHelper';
 import Link from '@/components/atoms/_text';
 import { TextColor } from '@/common.type';
 import styles from '@css/components/verticalNav.module.css';
@@ -121,7 +121,7 @@ export const MenuItem = (props: MenuItemProps) => {
     }
 
     if (menu.count !== undefined) {
-      const count = menu.count && typeof menu.count === 'number' && menu.count > 99 ? '99+' : menu.count;
+      const count = formatCount(menu.count);
       return <MenuPills disabled={menu.disabled} isActive={isActive} count={count} />;
     }
     return null;

--- a/core/utils/navigationHelper.tsx
+++ b/core/utils/navigationHelper.tsx
@@ -73,3 +73,15 @@ export const isMenuActive = (menus: Menu[], menu: Menu, active?: ActiveMenu): bo
 export const getNavItemColor = (isActive: boolean, disabled?: boolean) => {
   return disabled ? 'inverse-lightest' : isActive ? 'primary-dark' : 'inverse';
 };
+
+export const formatCount = (count: number | string): string => {
+  if (typeof count === 'string') {
+    return count;
+  }
+
+  if (typeof count === 'number') {
+    return count > 99 ? '99+' : count.toString();
+  }
+
+  return '';
+};


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Adds extended support for count prop in horizontal nav and vertical nav components.

If the count is string, it is shown as it is, otherwise the count logic falls back to the old implementation of showing 99+ if count is greater than 99.

### Does this close any currently open issues?
No

### Any other comments?
No

### Dependent PRs/Commits
No


### Describe breaking changes, if any.
No

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
