### PR TITLE
feat(table): add support for custom label in table header

### DIFF
--- a/core/components/organisms/table/Header.tsx
+++ b/core/components/organisms/table/Header.tsx
@@ -26,6 +26,8 @@ export interface ExternalHeaderProps {
   customSelectionLabel?: string;
   globalActionRenderer?: (data: Data) => React.ReactNode;
   selectionActionRenderer?: (selectedRows: RowData[], selectAll?: boolean) => React.ReactNode;
+  selectedLabelRenderer?: (context: Record<string, any>) => string;
+  unSelectedLabelRenderer?: (context: Record<string, any>) => string;
 }
 
 export type updateSearchTermFunction = (newSearchTerm: string) => void;
@@ -97,6 +99,8 @@ export const Header = (props: HeaderProps) => {
     uniqueColumnName,
     totalRowsCount,
     enableInfiniteScroll,
+    selectedLabelRenderer,
+    unSelectedLabelRenderer,
   } = props;
 
   const [selectAllRecords, setSelectAllRecords] = React.useState<boolean>(false);
@@ -106,6 +110,31 @@ export const Header = (props: HeaderProps) => {
   const startIndex = (page - 1) * pageSize + 1;
   const endIndex = Math.min(page * pageSize, totalRecords);
   const selectedRowsCount = selectedAllRef?.current === true ? totalRecords : selectedRowsRef?.current?.length || 0;
+
+  const customSelectedRowLabel = selectedLabelRenderer
+    ? selectedLabelRenderer({
+        selectedRowsCount,
+        uniqueColumnName,
+        withCheckbox,
+        selectedCount,
+        withPagination,
+        startIndex,
+        endIndex,
+        totalRecords,
+      })
+    : undefined;
+
+  const customUnSelectedRowLabel = unSelectedLabelRenderer
+    ? unSelectedLabelRenderer({
+        error,
+        withPagination,
+        enableInfiniteScroll,
+        startIndex,
+        endIndex,
+        totalRecords,
+        totalRowsCount,
+      })
+    : undefined;
 
   const showSelectedRowLabel = withCheckbox && (selectedCount || selectedRowsCount > 0);
 
@@ -293,11 +322,11 @@ export const Header = (props: HeaderProps) => {
             <>
               {showSelectedLabel ? (
                 <span className={selectedRowLabelClass} onAnimationEnd={onSelectAnimationEnd}>
-                  <Label>{getSelectedRowLabel()}</Label>
+                  <Label>{customSelectedRowLabel ?? getSelectedRowLabel()}</Label>
                 </span>
               ) : (
                 <span className={unselectedRowLabelClass} onAnimationEnd={onUnSelectAnimationEnd}>
-                  <Label>{getUnSelectedRowLabel()}</Label>
+                  <Label>{customUnSelectedRowLabel ?? getUnSelectedRowLabel()}</Label>
                 </span>
               )}
 

--- a/core/components/organisms/table/Table.tsx
+++ b/core/components/organisms/table/Table.tsx
@@ -232,6 +232,8 @@ interface SharedTableProps extends BaseProps {
    *    customSelectionLabel?: string;
    *    globalActionRenderer?: (data: Data) => React.ReactNode;
    *    selectionActionRenderer?: (selectedRows: RowData[], selectAll?: boolean) => React.ReactNode;
+   *    selectedLabelRenderer?: (context: Record<string, any>) => string;
+   *    unSelectedLabelRenderer?: (context: Record<string, any>) => string;
    * }
    * </pre>
    *

--- a/core/components/organisms/table/__tests__/Table.test.tsx
+++ b/core/components/organisms/table/__tests__/Table.test.tsx
@@ -889,3 +889,56 @@ describe('render table with highlightCell feature', () => {
     expect(highlightedMarks).not.toBeInTheDocument();
   });
 });
+
+describe('render table with custom selection/unselection label renderers', () => {
+  it('uses selectedLabelRenderer when rows are selected', () => {
+    const schema = [{ name: 'name', displayName: 'Name', width: '50%' }];
+
+    const selectedLabelRenderer = (context: Record<string, any>) => {
+      return `Picked ${context.selectedRowsCount} rows`;
+    };
+
+    const { getAllByTestId, getByTestId } = render(
+      <Table
+        withHeader={true}
+        withCheckbox={true}
+        withPagination={true}
+        data={tableData}
+        schema={schema}
+        headerOptions={{ allowSelectAll: true, selectedLabelRenderer }}
+      />
+    );
+
+    const checkbox = getAllByTestId('DesignSystem-Checkbox-InputBox')[0];
+    fireEvent.click(checkbox);
+
+    const selectionLabel = getByTestId('DesignSystem-Label--Text');
+    expect(selectionLabel).toHaveTextContent('Picked 2 rows');
+  });
+
+  it('uses unSelectedLabelRenderer when no rows are selected', () => {
+    const schema = [{ name: 'name', displayName: 'Name', width: '50%' }];
+
+    const unSelectedLabelRenderer = () => {
+      return 'Custom unselected label';
+    };
+
+    const { getByTestId } = render(
+      <Table
+        withHeader={true}
+        withCheckbox={true}
+        withPagination={true}
+        data={tableData}
+        schema={schema}
+        headerOptions={{ allowSelectAll: true, unSelectedLabelRenderer }}
+      />
+    );
+
+    const selectionLabel = getByTestId('DesignSystem-Label--Text');
+
+    // Trigger animation end to switch to unselected label span
+    fireEvent.animationEnd(selectionLabel);
+
+    expect(selectionLabel).toHaveTextContent('Custom unselected label');
+  });
+});


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Added support for custom label headers in the MDS table, allowing users to define their own labels in the table header based on their needs — a capability not previously supported.

Two new functions have been introduced in headerOptions for this purpose:

**setSelectedSummaryLabel** – returns the custom label when rows are selected.

**setUnSelectedSummaryLabel** – returns the custom label when no rows are selected.

**These additions are fully backward compatible and do not break existing functionality.**
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
