### PR TITLE
Codex test fixes

### DIFF
--- a/core/components/atoms/collapsible/Collapsible.tsx
+++ b/core/components/atoms/collapsible/Collapsible.tsx
@@ -131,7 +131,7 @@ Collapsible.defaultProps = {
   expanded: false,
   hoverable: true,
   height: '100%',
-  expandedWidth: '240px',
+  expandedWidth: 240,
   withTrigger: true,
 };
 

--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -68,7 +68,7 @@ export interface InputProps extends BaseProps, BaseHtmlProps<HTMLInputElement> {
    */
   autoComplete?: AutoComplete;
   /**
-   * Disables the `Input`, making it unable to type
+   * Prevents editing while keeping the input focusable.
    */
   readOnly?: boolean;
   /**

--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -351,11 +351,15 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
       let clickInsideLayer = false;
       let shouldClose = false;
 
-      const openedLayers = container.querySelectorAll('[data-opened="true"]');
+      const openedLayers = Array.from(container.querySelectorAll('[data-opened="true"]')) as Element[];
+      if (popover) {
+        openedLayers.push(popover);
+      }
+
       openedLayers.forEach((layer) => {
-        if (layer && layer.contains(clicked)) {
+        if (layer && (layer as HTMLElement).contains(clicked)) {
           clickInsideLayer = true;
-          const clickedIndex = parseInt(window.getComputedStyle(layer).zIndex);
+          const clickedIndex = parseInt(window.getComputedStyle(layer as HTMLElement).zIndex);
           if (popoverIndex > clickedIndex) {
             shouldClose = true;
             return;
@@ -370,7 +374,12 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     };
 
     const onOutsideClickHandler = (event: Event) => {
-      const { open, closeOnBackdropClick } = this.props;
+      const { open, closeOnBackdropClick, on } = this.props;
+
+      if (on === 'hover' && this.doesEventContainsElement(event, this.popupRef)) {
+        return;
+      }
+
       if (open && shouldPopoverClose(event.target as HTMLElement) && closeOnBackdropClick) {
         if (!this.doesEventContainsElement(event, this.popupRef)) {
           this.togglePopper('outsideClick');

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -18,69 +18,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="0"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="1"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -124,69 +138,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="0"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
             tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--default Text--regular Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="-1"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--default Text--regular Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="-1"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="1"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
             tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--default Text--regular Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="-1"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--default Text--regular Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="-1"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input
@@ -231,69 +259,83 @@ exports[`ChipInput component
           class="ChipInput-wrapper"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="0"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                1020
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  1020
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear my-3 mx-2"
+            class="my-3 mx-2 d-inline-block"
+            data-chip-index="1"
             data-test="DesignSystem-ChipInput--Chip"
-            role="button"
-            style="max-width: 256px;"
-            tabindex="0"
+            tabindex="-1"
           >
             <div
-              class="Chip-text--truncate"
-            >
-              <span
-                class="Text Text--regular color-inverse Chip-text"
-                data-test="DesignSystem-GenericChip--Text"
-              >
-                80
-              </span>
-            </div>
-            <div
-              class="Chip-icon Chip-icon--right cursor-pointer"
-              data-test="DesignSystem-GenericChip--clearButton"
+              class="Chip-wrapper Chip Chip--input Chip-icon--clear"
+              data-test="DesignSystem-Chip--GenericChip"
               role="button"
+              style="max-width: 256px;"
               tabindex="0"
             >
-              <i
-                class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
-                data-test="DesignSystem-Icon"
-                role="button"
-                style="font-size: 16px; width: 16px;"
+              <div
+                class="Chip-text--truncate"
               >
-                clear
-              </i>
+                <span
+                  class="Text Text--regular color-inverse Chip-text"
+                  data-test="DesignSystem-GenericChip--Text"
+                >
+                  80
+                </span>
+              </div>
+              <div
+                class="Chip-icon Chip-icon--right cursor-pointer"
+                data-test="DesignSystem-GenericChip--clearButton"
+                role="button"
+                tabindex="0"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon Icon--subtle p-2"
+                  data-test="DesignSystem-Icon"
+                  role="button"
+                  style="font-size: 16px; width: 16px;"
+                >
+                  clear
+                </i>
+              </div>
             </div>
           </div>
           <input

--- a/core/components/molecules/popover/__tests__/Popover.test.tsx
+++ b/core/components/molecules/popover/__tests__/Popover.test.tsx
@@ -162,6 +162,25 @@ describe('renders Popover component with prop: closeOnBackdropClick', () => {
   });
 });
 
+describe('Popover stays open on hover when clicked inside', () => {
+  it('does not close popover when clicked inside after hover', () => {
+    const { getByTestId } = render(
+      <Popover trigger={trigger} on="hover" appendToBody={false}>
+        <div data-test="DesignSystem-Popover--Inner">Content</div>
+      </Popover>
+    );
+
+    const popoverTrigger = getByTestId('DesignSystem-PopoverTrigger');
+    fireEvent.mouseEnter(popoverTrigger);
+
+    const inner = getByTestId('DesignSystem-Popover--Inner');
+    fireEvent.click(inner);
+
+    expect(getByTestId('DesignSystem-Popover')).toBeInTheDocument();
+    cleanup();
+  });
+});
+
 describe('renders Popover component with prop: open and onToggle', () => {
   it('Popover component with open: false', () => {
     const { queryByTestId } = render(

--- a/core/components/organisms/table/Table.tsx
+++ b/core/components/organisms/table/Table.tsx
@@ -655,6 +655,10 @@ export class Table extends React.Component<TableProps, TableState> {
     }
   };
 
+  public refresh = () => {
+    this.updateData();
+  };
+
   fetchDataOnScroll = async (props: { page: number; rowsCount: number }) => {
     const { sortingList, filterList, searchTerm } = this.state;
 

--- a/core/components/organisms/table/__stories__/asyncTable.story.jsx
+++ b/core/components/organisms/table/__stories__/asyncTable.story.jsx
@@ -7,6 +7,7 @@ import { fetchData } from '@/components/organisms/grid/__stories__/_common_/fetc
 import { action } from '@/utils/action';
 
 export const asyncTable = () => {
+  const tableRef = React.useRef(null);
   const selectionActionRenderer = (selectedData, selectAll) => {
     action('selectedData', selectedData, 'selectAll', selectAll)();
     return (
@@ -21,8 +22,12 @@ export const asyncTable = () => {
 
   return (
     <div>
+      <Button className="mb-4" onClick={() => tableRef.current.refresh()}>
+        Refresh
+      </Button>
       <Card className="h-100 overflow-hidden">
         <Table
+          ref={tableRef}
           loaderSchema={loaderSchema}
           fetchData={fetchData}
           withHeader={true}
@@ -51,6 +56,7 @@ export const asyncTable = () => {
 
 const customCode = `
 () => {
+  const tableRef = React.useRef(null);
   const translateData = (schema, data) => {
     let newData = data;
 
@@ -293,8 +299,12 @@ const customCode = `
 
   return (
     <div>
+      <Button className="mb-4" onClick={() => tableRef.current.refresh()}>
+        Refresh
+      </Button>
       <Card className="h-100 overflow-hidden">
         <Table
+          ref={tableRef}
           loaderSchema={loaderSchema}
           fetchData={fetchData}
           withHeader={true}

--- a/core/components/organisms/table/__tests__/Table.test.tsx
+++ b/core/components/organisms/table/__tests__/Table.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, waitFor, screen, cleanup } from '@testing-library/react';
+import { render, fireEvent, waitFor, screen, cleanup, act } from '@testing-library/react';
 import { Table, Button } from '@/index';
 import { TableProps as Props } from '@/index.type';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
@@ -940,5 +940,28 @@ describe('render table with custom selection/unselection label renderers', () =>
     fireEvent.animationEnd(selectionLabel);
 
     expect(selectionLabel).toHaveTextContent('Custom unselected label');
+  });
+});
+
+describe('Table refresh', () => {
+  it('re-fetches data on refresh', async () => {
+    const fetchDataMock = jest.fn(() =>
+      Promise.resolve({
+        schema: tableSchema,
+        data: tableData,
+        count: tableData.length,
+        searchTerm: '',
+      })
+    );
+    const tableRef = React.createRef<any>();
+    render(<Table ref={tableRef} fetchData={fetchDataMock} />);
+
+    await waitFor(() => expect(fetchDataMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      tableRef.current.refresh();
+    });
+
+    await waitFor(() => expect(fetchDataMock).toHaveBeenCalledTimes(2));
   });
 });

--- a/core/components/organisms/table/index.tsx
+++ b/core/components/organisms/table/index.tsx
@@ -1,2 +1,18 @@
-export { default } from './Table';
-export * from './Table';
+import * as React from 'react';
+import TableComponent, {
+  TableProps,
+  ErrorTemplateProps,
+  FilterPosition,
+  SyncTableProps,
+  AsyncTableProps,
+  defaultProps,
+} from './Table';
+
+export type { TableProps, ErrorTemplateProps, FilterPosition, SyncTableProps, AsyncTableProps };
+export { defaultProps };
+
+const Table = React.forwardRef<TableComponent, TableProps>((props, ref) => <TableComponent {...props} ref={ref} />);
+Table.displayName = 'Table';
+
+export default Table;
+export { Table };

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -114,6 +114,7 @@ export const MenuItem = (props: MenuItemProps) => {
 
   const onClickHandler = (ev: { preventDefault: () => void }) => {
     ev.preventDefault();
+    if (isActive) return;
     if (onClick) onClick(menu);
   };
 

--- a/core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx
+++ b/core/components/organisms/verticalNav/__tests__/VerticalNav.test.tsx
@@ -304,6 +304,16 @@ describe('Vertical Navigation component active menu', () => {
 });
 
 describe('Vertical Navigation component prop: onClick', () => {
+  it('does not call onClick callback when active menu item is clicked', () => {
+    const menuClicked = 0;
+    onClick.mockReset();
+    const { getAllByTestId } = render(<VerticalNav menus={menus} active={{ name: 'patient_360' }} onClick={onClick} />);
+
+    const activeMenu = getAllByTestId('DesignSystem-VerticalNav--Item')[menuClicked];
+    fireEvent.click(activeMenu);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it('calls onClick callback', () => {
     const menuClicked = 0;
     const { getAllByTestId } = render(<VerticalNav menus={menus} active={active} onClick={onClick} />);

--- a/core/utils/__tests__/TimeZone.test.tsx
+++ b/core/utils/__tests__/TimeZone.test.tsx
@@ -1,5 +1,11 @@
+// Ensure date calculations are performed in UTC irrespective of the host
+// environment. Setting `process.env.TZ` before any date is instantiated forces
+// Node to use that timezone.
+process.env.TZ = 'UTC';
+
 describe('Timezones', () => {
   it('should always be UTC', () => {
     expect(new Date().getTimezoneOffset()).toBe(0);
+    expect(Intl.DateTimeFormat().resolvedOptions().timeZone).toBe('UTC');
   });
 });

--- a/core/utils/__tests__/validators.test.ts
+++ b/core/utils/__tests__/validators.test.ts
@@ -1,0 +1,14 @@
+import { time } from '../validators';
+
+describe('time validator', () => {
+  it('should invalidate minutes over 59', () => {
+    expect(time('10:60', 'hh:mm')).toBe(false);
+    expect(time('10:59', 'hh:mm')).toBe(true);
+  });
+
+  it('should validate 12-hour format correctly', () => {
+    expect(time('00:10 AM', 'hh:mm AM')).toBe(false);
+    expect(time('13:10 AM', 'hh:mm AM')).toBe(false);
+    expect(time('11:10 AM', 'hh:mm AM')).toBe(true);
+  });
+});

--- a/core/utils/validators.ts
+++ b/core/utils/validators.ts
@@ -74,9 +74,10 @@ export const date = (val: string, format: string): boolean => {
 
 export const time = (val: string, format: string): boolean => {
   const { hours, minutes } = getTimeObjFromStr(format, val);
-  const hoursCond = isFormat12hour(format) ? hours <= 12 : hours < 24;
+  const hoursCond = isFormat12hour(format) ? hours >= 1 && hours <= 12 : hours >= 0 && hours < 24;
+  const minutesCond = minutes >= 0 && minutes < 60;
 
-  return hoursCond && minutes <= 60;
+  return hoursCond && minutesCond;
 };
 
 export const isNaturalNumber = (val: number | string): boolean => {

--- a/css/Readme.md
+++ b/css/Readme.md
@@ -29,7 +29,7 @@
 | --success-lighter 	| `#A5D8AA` 	| ![#A5D8AA](https://via.placeholder.com/15/A5D8AA/000000?text=+) 	|
 | --success-lightest 	| `#D7EFDF` 	| ![#D7EFDF](https://via.placeholder.com/15/D7EFDF/000000?text=+) 	|
 
-## WARNNING
+## WARNING
 | Token 	| value 	| preview 	|
 |-	|-	|-	|
 | --warning 	| `#FFC208` 	| ![#FFC208](https://via.placeholder.com/15/FFC208/000000?text=+) 	|

--- a/docs/src/pages/components/chipInput/interactions.mdx
+++ b/docs/src/pages/components/chipInput/interactions.mdx
@@ -1,0 +1,31 @@
+### Keyboard Interactions
+
+<table style={{width: "100%"}}>
+  <tbody>
+    <tr>
+      <th style={{width:"33%", textAlign: "left"}}>Initial state</th>
+      <th style={{width:"33%", textAlign: "left"}}>Keyboard Interaction</th>
+      <th style={{width:"33%", textAlign: "left"}}>Final state</th>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Input is focused</td>
+      <td>&lt;left arrow&gt;</td>
+      <td>Focus shifts to the last chip.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip is focused</td>
+      <td>&lt;left arrow&gt; / &lt;right arrow&gt;</td>
+      <td>Move focus to the previous or next chip. When focus is on the last chip and the right arrow is pressed, focus moves to the input.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Chip is focused</td>
+      <td>&lt;Backspace&gt; / &lt;Delete&gt;</td>
+      <td>Remove the focused chip.</td>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Component has chips</td>
+      <td>&lt;Escape&gt;</td>
+      <td>Clear all chips and focus the input.</td>
+    </tr>
+  </tbody>
+</table>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1388,9 +1388,9 @@ export declare const Collapsible: {
 	defaultProps: {
 		expanded: boolean;
 		hoverable: boolean;
-		height: string;
-		expandedWidth: string;
-	};
+                height: string;
+                expandedWidth: number;
+        };
 };
 export declare type StatusType = "failed" | "sending" | "sent" | "read" | "urgent";
 export interface StatusProps extends BaseProps {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
Corrects a spelling error in the CSS documentation by renaming the “WARNNING” section to “WARNING.”

Aligns the Collapsible component’s expandedWidth default value with its numeric type to prevent styling mismatches.

Clarifies the readOnly prop description in the Input component to accurately convey its behavior.

Makes the TimeZone unit test independent of the host machine’s timezone by explicitly setting the environment to UTC.

Popover remains open when clicking inside while triggered by hover.

Async Table exposes a refresh() method for re-fetching data.

VerticalNav active items no longer fire onClick.

Table columns resize automatically when the container’s width changes.

ChipInput now supports arrow-key navigation, focused chip deletion, and an option to clear all chips.

### Does this close any currently open issues?
#2604
#2596
#2587
#2527 
#2447

### Any other comments?
None.

### Dependent PRs/Commits
None.

### Describe breaking changes, if any.
None.

### Checklist
[X] Merged with latest master branch