### PR TITLE
fix: show TextField error when below min length

### DIFF
--- a/core/components/organisms/textField/TextFieldWithInput.tsx
+++ b/core/components/organisms/textField/TextFieldWithInput.tsx
@@ -20,7 +20,20 @@ export interface TextFieldWithInputProps extends BaseProps {
 export type TextFieldInputProps = TextFieldWithInputProps & InputProps;
 
 export const TextFieldWithInput = (props: TextFieldInputProps) => {
-  const { label, minWidth, required, error, onChange, value = '', max = 200, helpText = ' ', size = 'regular' } = props;
+  const {
+    label,
+    minWidth,
+    required,
+    error,
+    onChange,
+    value = '',
+    max = 200,
+    helpText = ' ',
+    size = 'regular',
+    min,
+    minLength,
+    type = 'text',
+  } = props;
 
   const [inputText, setInputText] = React.useState<string>(value);
 
@@ -29,7 +42,11 @@ export const TextFieldWithInput = (props: TextFieldInputProps) => {
     if (onChange) onChange(event);
   };
 
-  const inputError = error || inputText.length > max;
+  const minCharacterLimit =
+    minLength !== undefined ? minLength : typeof min === 'number' && type !== 'number' ? min : undefined;
+
+  const inputError =
+    error || inputText.length > max || (minCharacterLimit !== undefined && inputText.length < minCharacterLimit);
 
   const labelSize = size === 'tiny' ? 'small' : 'regular';
 

--- a/core/components/organisms/textField/TextFieldWithTextarea.tsx
+++ b/core/components/organisms/textField/TextFieldWithTextarea.tsx
@@ -42,6 +42,7 @@ export const TextFieldWithTextarea = (props: TextFieldTextareaProps) => {
     max = 200,
     helpText = ' ',
     size = 'regular',
+    minLength,
   } = props;
 
   const textareaRef = React.useRef(null);
@@ -53,7 +54,7 @@ export const TextFieldWithTextarea = (props: TextFieldTextareaProps) => {
     if (onChange) onChange(e);
   };
 
-  const inputError = error || inputText.length > max;
+  const inputError = error || inputText.length > max || (minLength !== undefined && inputText.length < minLength);
 
   React.useEffect(() => {
     const textarea = textareaRef.current;

--- a/core/components/organisms/textField/__test__/Textarea.test.tsx
+++ b/core/components/organisms/textField/__test__/Textarea.test.tsx
@@ -280,6 +280,47 @@ describe('TextField Component', () => {
     const searchError = getByTestId('DesignSystem-InlineMessage--Icon');
     expect(searchError).toBeInTheDocument();
   });
+
+  test('shows error when input text is shorter than the minimum characters', () => {
+    const onChangeMock = jest.fn();
+    const { getByTestId } = render(
+      <TextField
+        label="Test Label"
+        name="test-name"
+        placeholder="Test Placeholder"
+        helpText="here is the helptext"
+        min={5}
+        onChange={onChangeMock}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('Test Placeholder');
+    fireEvent.change(input, { target: { value: 'abc' } });
+
+    const searchError = getByTestId('DesignSystem-InlineMessage--Icon');
+    expect(searchError).toBeInTheDocument();
+  });
+
+  test('shows error when textarea text is shorter than the minimum characters', () => {
+    const onChangeMock = jest.fn();
+    const { getByTestId } = render(
+      <TextField
+        label="Test Label"
+        name="test-name"
+        placeholder="Test Placeholder"
+        helpText="here is the helptext"
+        withTextarea={true}
+        minLength={5}
+        onChange={onChangeMock}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText('Test Placeholder');
+    fireEvent.change(textarea, { target: { value: 'abc' } });
+
+    const searchError = getByTestId('DesignSystem-InlineMessage--Icon');
+    expect(searchError).toBeInTheDocument();
+  });
 });
 
 describe('TextField Components - Size Functionality Tests', () => {


### PR DESCRIPTION
## Summary
- ensure the TextField input variant marks the field as errored when the text is shorter than the configured minimum
- extend the textarea variant to respect `minLength` while computing the error state
- add regression tests that cover minimum length validation for both input and textarea flows

## Testing
- npm test -- TextField

------
https://chatgpt.com/codex/tasks/task_b_68f89d4673b4832fbe006e3bc594e0b7