### PR TITLE
fix: collapse nested rows after table sorting

### DIFF
--- a/core/components/organisms/grid/GridRow.tsx
+++ b/core/components/organisms/grid/GridRow.tsx
@@ -19,7 +19,8 @@ export interface GridRowProps {
 export const GridRow = (props: GridRowProps) => {
   const context = React.useContext(GridContext);
 
-  const { type, onRowClick, loading, withCheckbox, nestedRows, checkboxAlignment, showNestedRowTrigger } = context;
+  const { type, onRowClick, loading, withCheckbox, nestedRows, checkboxAlignment, showNestedRowTrigger, sortingList } =
+    context;
 
   const { schema, data, rowIndex: rI, onSelect, className } = props;
 
@@ -41,7 +42,7 @@ export const GridRow = (props: GridRowProps) => {
     } else {
       setExpanded(_expandNestedRow || false);
     }
-  }, [_expandNestedRow]);
+  }, [_expandNestedRow, showNestedRowTrigger, sortingList]);
 
   const rowClasses = classNames(styles['Grid-row'], styles['Grid-row--body'], {
     [styles['Grid-row--selected']]: data._selected,

--- a/core/components/organisms/grid/__tests__/Grid.test.tsx
+++ b/core/components/organisms/grid/__tests__/Grid.test.tsx
@@ -631,5 +631,40 @@ describe('showNestedRowTrigger flag behavior', () => {
       // Should not render trigger during loading
       expect(queryByTestId('DesignSystem-Grid-nestedRowTrigger')).not.toBeInTheDocument();
     });
+
+    it('collapses expanded nested rows when sorting changes', () => {
+      const data = [{ name: 'Zara' }];
+      const { getByTestId, rerender } = render(
+        <Grid
+          schema={schema}
+          data={data}
+          nestedRows={true}
+          nestedRowRenderer={mockNestedRowRenderer}
+          showNestedRowTrigger={true}
+        />
+      );
+
+      const trigger = getByTestId('DesignSystem-Grid-nestedRowTrigger');
+      fireEvent.click(trigger);
+
+      let lastCall = mockNestedRowRenderer.mock.calls[mockNestedRowRenderer.mock.calls.length - 1][0];
+      expect(lastCall.expanded).toBe(true);
+
+      mockNestedRowRenderer.mockClear();
+
+      rerender(
+        <Grid
+          schema={schema}
+          data={data}
+          nestedRows={true}
+          nestedRowRenderer={mockNestedRowRenderer}
+          showNestedRowTrigger={true}
+          sortingList={[{ name: 'name', type: 'asc' }]}
+        />
+      );
+
+      lastCall = mockNestedRowRenderer.mock.calls[mockNestedRowRenderer.mock.calls.length - 1][0];
+      expect(lastCall.expanded).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- reset nested row expansion state when the sorting list changes so nested rows collapse after resorting
- add a regression test to ensure sorting collapses expanded nested rows

## Testing
- npm test -- Grid.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68f9dbdb3f38832fa3e590e23b44db26