### PR TITLE
Fix hover popover closing when interacting with its content

### DIFF
--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -246,10 +246,18 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     }
   }
 
-  handleMouseLeave() {
+  handleMouseLeave(event?: React.MouseEvent<HTMLElement> | React.FocusEvent<HTMLElement>) {
     const { on } = this.props;
     if (on === 'hover') {
       const { hoverable, onToggle } = this.props;
+      const relatedTarget = (event?.relatedTarget as HTMLElement | null) || null;
+
+      if (
+        relatedTarget &&
+        (this.popupRef.current?.contains(relatedTarget) || this.triggerRef.current?.contains(relatedTarget))
+      ) {
+        return;
+      }
       if (hoverable) {
         this.mouseMoveHandler();
       } else {

--- a/core/components/molecules/popover/__tests__/Popover.test.tsx
+++ b/core/components/molecules/popover/__tests__/Popover.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, cleanup, act } from '@testing-library/react';
 import { Button, Popover } from '@/index';
 import { PopoverProps as Props } from '@/index.type';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
@@ -119,6 +119,36 @@ describe('renders Popover component with prop: on', () => {
     fireEvent.mouseEnter(popoverTrigger);
 
     expect(getByTestId('DesignSystem-Popover')).toBeInTheDocument();
+  });
+});
+
+describe('hover Popover interactions', () => {
+  it('keeps hover popover open when interacting with its content', () => {
+    jest.useFakeTimers();
+    try {
+      const onToggle = jest.fn();
+      const { getByTestId, queryByTestId } = render(
+        <Popover trigger={trigger} on="hover" hoverable={true} appendToBody={false} onToggle={onToggle}>
+          <button data-test="DesignSystem-PopoverContentButton">Content action</button>
+        </Popover>
+      );
+
+      const popoverTrigger = getByTestId('DesignSystem-PopoverTrigger');
+      fireEvent.mouseEnter(popoverTrigger);
+
+      const contentButton = getByTestId('DesignSystem-PopoverContentButton');
+      fireEvent.blur(popoverTrigger, { relatedTarget: contentButton });
+      fireEvent.click(contentButton);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(onToggle).not.toHaveBeenCalledWith(false, 'mouseLeave');
+      expect(queryByTestId('DesignSystem-Popover')).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- prevent hover-triggered popovers from closing when focus shifts to elements inside the popover
- ensure hover popovers remain open while navigating between the trigger and popup content
- add a regression test that keeps hover popovers open while moving focus into their content

## Testing
- npm test -- Popover

------
https://chatgpt.com/codex/tasks/task_b_68f9dd54fd1c832faa6c426df0e846dc