### PR TITLE
fix: rename select option key identifier to id

### DIFF
--- a/core/common.type.tsx
+++ b/core/common.type.tsx
@@ -117,6 +117,10 @@ export type PositionType =
 export type OptionType = {
   label: string;
   value: any;
+  /**
+   * Optional unique identifier for distinguishing options when labels repeat.
+   */
+  id?: string | number;
   isSelectedOption?: boolean;
 };
 

--- a/core/components/organisms/select/Select.tsx
+++ b/core/components/organisms/select/Select.tsx
@@ -25,6 +25,7 @@ export interface SelectProps extends BaseProps {
    * OptionType: {
    *   label: string;
    *   value: any;
+   *   id?: string | number;
    * }
    * </pre>
    */
@@ -60,6 +61,7 @@ export interface SelectProps extends BaseProps {
    * OptionType: {
    *   label: string;
    *   value: any;
+   *   id?: string | number;
    * }
    * </pre>
    */

--- a/core/components/organisms/select/SelectOption.tsx
+++ b/core/components/organisms/select/SelectOption.tsx
@@ -16,6 +16,13 @@ export interface SelectOptionProps extends BaseProps {
   children: React.ReactNode;
   /**
    * The data associated with the option.
+   * <pre style="font-family: monospace; font-size: 13px; background: #f8f8f8">
+   * OptionType: {
+   *   label: string;
+   *   value: any;
+   *   id?: string | number;
+   * }
+   * </pre>
    */
   option: OptionType;
   /**

--- a/core/components/organisms/select/__stories__/multiselect/multiselect.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/multiselect.story.jsx
@@ -5,16 +5,16 @@ import { action } from '@/utils/action';
 // CSF format story
 export const multiSelect = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const onSelectHandler = (selectedOption) => {
@@ -30,9 +30,9 @@ export const multiSelect = () => {
   return (
     <Select triggerOptions={{ setLabel: setLableHandler }} onSelect={onSelectHandler} multiSelect={true}>
       <Select.List>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );
@@ -44,16 +44,16 @@ export const multiSelect = () => {
 
 const customCode = `() => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
   
 
@@ -70,14 +70,14 @@ const customCode = `() => {
   return (
     <Select triggerOptions={{ setLabel: setLableHandler }} onSelect={onSelectHandler} multiSelect={true} >
         <Select.List>
-          {medicineList.map((item, key) => {
-            return (
-              <Select.Option key={key} option={{ label: item.label, value: item.value }}>
-                {item.label}
-              </Select.Option>
-            );
-          })}
-        </Select.List>
+        {medicineList.map((item) => {
+          return (
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
+              {item.label}
+            </Select.Option>
+          );
+        })}
+      </Select.List>
     </Select>
   );
 }`;

--- a/core/components/organisms/select/__stories__/multiselect/preFilledValue.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/preFilledValue.story.jsx
@@ -5,16 +5,16 @@ import { action } from '@/utils/action';
 // CSF format story
 export const preFilledValue = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const onSelectHandler = (selectedOption) => {
@@ -31,16 +31,16 @@ export const preFilledValue = () => {
     <Select
       triggerOptions={{ setLabel: setLableHandler }}
       value={[
-        { label: 'Aspirin', value: 'Aspirin' },
-        { label: 'Paracetamol', value: 'Paracetamol' },
+        { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+        { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
       ]}
       onSelect={onSelectHandler}
       multiSelect={true}
     >
       <Select.List>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );
@@ -52,16 +52,16 @@ export const preFilledValue = () => {
 
 const customCode = `() => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
   
 
@@ -79,16 +79,16 @@ const customCode = `() => {
   <Select
     triggerOptions={{ setLabel: setLableHandler }}
     value={[
-      { label: 'Aspirin', value: 'Aspirin' },
-      { label: 'Paracetamol', value: 'Paracetamol' }
+      { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+      { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' }
     ]}
     onSelect={onSelectHandler}
     multiSelect={true}
   >
         <Select.List>
-          {medicineList.map((item, key) => {
+          {medicineList.map((item) => {
             return (
-              <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+              <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
                 {item.label}
               </Select.Option>
             );

--- a/core/components/organisms/select/__stories__/multiselect/selectedItem.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/selectedItem.story.jsx
@@ -5,22 +5,24 @@ import { action } from '@/utils/action';
 // CSF format story
 export const selectedItem = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
-    { label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
-    { label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
-    { label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
-    { label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
-    { label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
-    { label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
-    { label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
-    { label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
-    { label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
-    { label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
+    { id: 'ibuprofen', label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
+    { id: 'prednisone', label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
+    { id: 'metoprolol', label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
   ];
 
   const [selectedOptions, setSelectedOptions] = React.useState([]);
   const selectRef = React.useRef(null);
+
+  const getOptionIdentifier = (option) => option?.id ?? option?.value;
 
   const handleSelect = (selectedOption) => {
     action('selectedOption', selectedOption);
@@ -33,7 +35,10 @@ export const selectedItem = () => {
   };
 
   const groupedMedicine = medicineList.reduce((acc, item) => {
-    const groupKey = selectedOptions.find((opt) => opt.value === item.value) ? 'Selected Items' : item.group;
+    const itemIdentifier = getOptionIdentifier(item);
+    const groupKey = selectedOptions.find((opt) => getOptionIdentifier(opt) === itemIdentifier)
+      ? 'Selected Items'
+      : item.group;
     if (!acc[groupKey]) {
       acc[groupKey] = [];
     }
@@ -56,7 +61,7 @@ export const selectedItem = () => {
               Selected Items
             </Text>
             {selectedOptions.map((option) => (
-              <Select.Option key={option.value} option={option}>
+              <Select.Option key={getOptionIdentifier(option)} option={option}>
                 {option.label}
               </Select.Option>
             ))}
@@ -71,7 +76,10 @@ export const selectedItem = () => {
                   {group}
                 </Text>
                 {groupedMedicine[group].map((item) => (
-                  <Select.Option key={item.value} option={{ label: item.label, value: item.value }}>
+                  <Select.Option
+                    key={getOptionIdentifier(item)}
+                    option={{ label: item.label, value: item.value, id: item.id }}
+                  >
                     {item.label}
                   </Select.Option>
                 ))}
@@ -85,18 +93,18 @@ export const selectedItem = () => {
 
 const customCode = `() => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
-    { label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
-    { label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
-    { label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
-    { label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
-    { label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
-    { label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
-    { label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
-    { label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
-    { label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
-    { label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
+    { id: 'ibuprofen', label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
+    { id: 'prednisone', label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
+    { id: 'metoprolol', label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
   ];
 
   const [selectedOptions, setSelectedOptions] = React.useState([]);
@@ -112,8 +120,13 @@ const customCode = `() => {
     setSelectedOptions([]);
   };
 
+  const getOptionIdentifier = (option) => option?.id ?? option?.value;
+
   const groupedMedicine = medicineList.reduce((acc, item) => {
-    const groupKey = selectedOptions.find((opt) => opt.value === item.value) ? 'Selected Items' : item.group;
+    const itemIdentifier = getOptionIdentifier(item);
+    const groupKey = selectedOptions.find((opt) => getOptionIdentifier(opt) === itemIdentifier)
+      ? 'Selected Items'
+      : item.group;
     if (!acc[groupKey]) {
       acc[groupKey] = [];
     }
@@ -136,7 +149,7 @@ const customCode = `() => {
               Selected Items
             </Text>
             {selectedOptions.map((option) => (
-              <Select.Option key={option.value} option={option}>
+              <Select.Option key={getOptionIdentifier(option)} option={option}>
                 {option.label}
               </Select.Option>
             ))}
@@ -155,7 +168,10 @@ const customCode = `() => {
                   {group}
                 </Text>
                 {groupedMedicine[group].map((item) => (
-                  <Select.Option key={item.value} option={{ label: item.label, value: item.value }}>
+                  <Select.Option
+                    key={getOptionIdentifier(item)}
+                    option={{ label: item.label, value: item.value, id: item.id }}
+                  >
                     {item.label}
                   </Select.Option>
                 ))}

--- a/core/components/organisms/select/__stories__/multiselect/withActionButton.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/withActionButton.story.jsx
@@ -5,16 +5,16 @@ import { action } from '@/utils/action';
 // CSF format story
 export const withActionButton = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const selectRef = React.useRef(null);
@@ -63,9 +63,9 @@ export const withActionButton = () => {
       triggerOptions={{ onClear: onClearHandler }}
     >
       <Select.List>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );
@@ -99,16 +99,16 @@ export const withActionButton = () => {
 
 const customCode = `() => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const selectRef = React.useRef(null);
@@ -157,9 +157,9 @@ const customCode = `() => {
       triggerOptions={{ onClear: onClearHandler }}
     >
       <Select.List>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );

--- a/core/components/organisms/select/__stories__/multiselect/withSections.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/withSections.story.jsx
@@ -5,18 +5,18 @@ import { action } from '@/utils/action';
 // CSF format story
 export const withSections = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
-    { label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
-    { label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
-    { label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
-    { label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
-    { label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
-    { label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
-    { label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
-    { label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
-    { label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
-    { label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
+    { id: 'ibuprofen', label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
+    { id: 'prednisone', label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
+    { id: 'metoprolol', label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
   ];
 
   const [selectedOptions, setSelectedOptions] = React.useState([]);
@@ -53,7 +53,7 @@ export const withSections = () => {
               {group}
             </Text>
             {groupedMedicine[group].map((item) => (
-              <Select.Option key={item.value} option={{ label: item.label, value: item.value }}>
+              <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
                 {item.label}
               </Select.Option>
             ))}
@@ -66,18 +66,18 @@ export const withSections = () => {
 
 const customCode = `() => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
-    { label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
-    { label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
-    { label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
-    { label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
-    { label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
-    { label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
-    { label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
-    { label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
-    { label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
-    { label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin', group: 'Painkillers' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol', group: 'Painkillers' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril', group: 'Hypertension' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin', group: 'Antibiotics' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin', group: 'Antibiotics' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin', group: 'Antibiotics' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole', group: 'Painkillers' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam', group: 'Antibiotics' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine', group: 'Antibiotics' },
+    { id: 'ibuprofen', label: 'Ibuprofen', value: 'Ibuprofen', group: 'Painkillers' },
+    { id: 'prednisone', label: 'Prednisone', value: 'Prednisone', group: 'Painkillers' },
+    { id: 'metoprolol', label: 'Metoprolol', value: 'Metoprolol', group: 'Hypertension' },
   ];
 
   const [selectedOptions, setSelectedOptions] = React.useState([]);
@@ -113,7 +113,7 @@ const customCode = `() => {
               {group}
             </Text>
             {groupedMedicine[group].map((item) => (
-              <Select.Option key={item.value} option={{ label: item.label, value: item.value }}>
+              <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
                 {item.label}
               </Select.Option>
             ))}

--- a/core/components/organisms/select/__stories__/multiselect/withSelectAll.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/withSelectAll.story.jsx
@@ -5,16 +5,16 @@ import { action } from '@/utils/action';
 // CSF format story
 export const withSelectAll = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const [selectedValue, setSelectedValue] = React.useState([]);
@@ -63,13 +63,13 @@ export const withSelectAll = () => {
         <Select.Option
           checkedState={checkedState}
           onClick={onClickHandler}
-          option={{ label: 'SelectAll', value: 'SelectAll' }}
+          option={{ id: 'select-all', label: 'SelectAll', value: 'SelectAll' }}
         >
           Select All
         </Select.Option>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );
@@ -81,16 +81,16 @@ export const withSelectAll = () => {
 
 const customCode = `() => {
     const medicineList = [
-        { label: 'Aspirin', value: 'Aspirin' },
-        { label: 'Paracetamol', value: 'Paracetamol' },
-        { label: 'Lisinopril', value: 'Lisinopril' },
-        { label: 'Simvastatin', value: 'Simvastatin' },
-        { label: 'Amoxicillin', value: 'Amoxicillin' },
-        { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-        { label: 'Metformin', value: 'Metformin' },
-        { label: 'Omeprazole', value: 'Omeprazole' },
-        { label: 'Diazepam', value: 'Diazepam' },
-        { label: 'Levothyroxine', value: 'Levothyroxine' },
+        { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+        { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+        { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+        { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+        { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+        { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+        { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+        { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+        { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+        { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
     ];
 
     const [selectedValue, setSelectedValue] = React.useState([]);
@@ -136,12 +136,12 @@ const customCode = `() => {
         triggerOptions={{ onClear: onClearHandler }}
         >
             <Select.List>
-                <Select.Option checkedState={checkedState} onClick={onClickHandler} option={{ label: 'SelectAll', value: 'SelectAll' }}>
+                <Select.Option checkedState={checkedState} onClick={onClickHandler} option={{ id: 'select-all', label: 'SelectAll', value: 'SelectAll' }}>
                     Select All
                 </Select.Option>
-            {medicineList.map((item, key) => {
+            {medicineList.map((item) => {
                 return (
-                <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+                <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
                     {item.label}
                 </Select.Option>
                 );

--- a/core/components/organisms/select/__stories__/multiselect/withSelectAllAndActionButton.story.jsx
+++ b/core/components/organisms/select/__stories__/multiselect/withSelectAllAndActionButton.story.jsx
@@ -5,16 +5,16 @@ import { action } from '@/utils/action';
 // CSF format story
 export const withSelectAllAndActionButton = () => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const selectRef = React.useRef(null);
@@ -90,13 +90,13 @@ export const withSelectAllAndActionButton = () => {
         <Select.Option
           checkedState={checkedState}
           onClick={handleSelectAllClick}
-          option={{ label: 'SelectAll', value: 'SelectAll' }}
+          option={{ id: 'select-all', label: 'SelectAll', value: 'SelectAll' }}
         >
           Select All
         </Select.Option>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );
@@ -130,16 +130,16 @@ export const withSelectAllAndActionButton = () => {
 
 const customCode = `() => {
   const medicineList = [
-    { label: 'Aspirin', value: 'Aspirin' },
-    { label: 'Paracetamol', value: 'Paracetamol' },
-    { label: 'Lisinopril', value: 'Lisinopril' },
-    { label: 'Simvastatin', value: 'Simvastatin' },
-    { label: 'Amoxicillin', value: 'Amoxicillin' },
-    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
-    { label: 'Metformin', value: 'Metformin' },
-    { label: 'Omeprazole', value: 'Omeprazole' },
-    { label: 'Diazepam', value: 'Diazepam' },
-    { label: 'Levothyroxine', value: 'Levothyroxine' },
+    { id: 'aspirin', label: 'Aspirin', value: 'Aspirin' },
+    { id: 'paracetamol', label: 'Paracetamol', value: 'Paracetamol' },
+    { id: 'lisinopril', label: 'Lisinopril', value: 'Lisinopril' },
+    { id: 'simvastatin', label: 'Simvastatin', value: 'Simvastatin' },
+    { id: 'amoxicillin', label: 'Amoxicillin', value: 'Amoxicillin' },
+    { id: 'ciprofloxacin', label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+    { id: 'metformin', label: 'Metformin', value: 'Metformin' },
+    { id: 'omeprazole', label: 'Omeprazole', value: 'Omeprazole' },
+    { id: 'diazepam', label: 'Diazepam', value: 'Diazepam' },
+    { id: 'levothyroxine', label: 'Levothyroxine', value: 'Levothyroxine' },
   ];
 
   const selectRef = React.useRef(null);
@@ -215,13 +215,13 @@ const customCode = `() => {
         <Select.Option
           checkedState={checkedState}
           onClick={handleSelectAllClick}
-          option={{ label: 'SelectAll', value: 'SelectAll' }}
+          option={{ id: 'select-all', label: 'SelectAll', value: 'SelectAll' }}
         >
           Select All
         </Select.Option>
-        {medicineList.map((item, key) => {
+        {medicineList.map((item) => {
           return (
-            <Select.Option key={key} option={{ label: item.label, value: item.value }}>
+            <Select.Option key={item.id} option={{ label: item.label, value: item.value, id: item.id }}>
               {item.label}
             </Select.Option>
           );

--- a/core/components/organisms/select/__test__/utils.test.tsx
+++ b/core/components/organisms/select/__test__/utils.test.tsx
@@ -56,6 +56,54 @@ describe('elementExist function', () => {
     const newOption = { label: 'Option 3', value: '3' };
     expect(elementExist(newOption, dummyOption)).toBe(-1);
   });
+
+  it('should use the id when provided to distinguish options with the same label', () => {
+    const duplicateLabelOption: OptionType = { label: 'Option 1', value: 'alternate', id: 'option-1b' };
+    const options: OptionType[] = [dummyOption, duplicateLabelOption];
+
+    expect(elementExist(duplicateLabelOption, options)).toBe(0);
+  });
+
+  it('should fall back to the label when optionIDs are not provided', () => {
+    const duplicateWithoutId: OptionType = { label: 'Option 1', value: 'alternate' };
+    const options: OptionType[] = [dummyOption, duplicateWithoutId];
+
+    expect(elementExist(duplicateWithoutId, options)).toBe(0);
+  });
+
+  it('should prioritize id comparison when both options have optionIDs, otherwise compare by label', () => {
+    // Case 1: Both have optionIDs - should compare by id
+    const option1: OptionType = { label: 'Aspirin', value: 'aspirin', id: 'asp-123' };
+    const option2: OptionType = { label: 'Different Label', value: 'aspirin', id: 'asp-123' };
+    const optionsWithIds: OptionType[] = [option2];
+
+    expect(elementExist(option1, optionsWithIds)).toBe(0); // Match by id despite different labels
+
+    // Case 2: Target has id, option in list doesn't - should compare by label
+    const targetWithId: OptionType = { label: 'Aspirin', value: 'aspirin', id: 'asp-123' };
+    const optionWithoutId: OptionType = { label: 'Aspirin', value: 'aspirin' };
+    const optionsArray: OptionType[] = [optionWithoutId];
+
+    expect(elementExist(targetWithId, optionsArray)).toBe(0); // Match by label
+
+    // Case 3: Target doesn't have id, option in list does - should compare by label
+    const targetWithoutId: OptionType = { label: 'Aspirin', value: 'aspirin' };
+    const optionWithId: OptionType = { label: 'Aspirin', value: 'aspirin', id: 'asp-123' };
+    const optionsArrayWithId: OptionType[] = [optionWithId];
+
+    expect(elementExist(targetWithoutId, optionsArrayWithId)).toBe(0); // Match by label
+
+    // Case 4: Different labels should not match even if one has id
+    const targetDifferentLabel: OptionType = { label: 'Ibuprofen', value: 'ibuprofen', id: 'ibu-123' };
+    expect(elementExist(targetDifferentLabel, optionsArray)).toBe(-1); // No match
+
+    // Case 5: Same optionIDs should match even with different labels
+    const sameIdOption1: OptionType = { label: 'Label A', value: 'value1', id: 'same-id' };
+    const sameIdOption2: OptionType = { label: 'Label B', value: 'value2', id: 'same-id' };
+    const sameIdArray: OptionType[] = [sameIdOption2];
+
+    expect(elementExist(sameIdOption1, sameIdArray)).toBe(0); // Match by id
+  });
 });
 
 describe('removeOrAddToList function', () => {

--- a/core/components/organisms/select/utils.tsx
+++ b/core/components/organisms/select/utils.tsx
@@ -9,11 +9,29 @@ export const mapInitialValue = (multiSelect: boolean, selectedValue: OptionType 
   }
 };
 
+const compareOptions = (option1?: OptionType, option2?: OptionType): boolean => {
+  if (!option1 || !option2) {
+    return false;
+  }
+
+  // If both options have optionIDs, compare by id
+  if (option1.id && option2.id) {
+    return option1.id === option2.id;
+  }
+
+  // Otherwise, always compare by label for backward compatibility
+  // This handles cases where:
+  // - Both have no id (legacy behavior)
+  // - One has id and other doesn't (mixed legacy/new code)
+  return option1.label === option2.label;
+};
+
 export const elementExist = (targetObject: OptionType, mainList: OptionType | OptionType[] | undefined) => {
   if (!Array.isArray(mainList)) {
-    return targetObject.label === mainList?.label ? 0 : -1;
+    return compareOptions(targetObject, mainList) ? 0 : -1;
   }
-  return mainList.findIndex((item) => item.label === targetObject.label);
+
+  return mainList.findIndex((item) => compareOptions(targetObject, item));
 };
 
 export const removeOrAddToList = (targetObject: OptionType, prevList: OptionType[]) => {


### PR DESCRIPTION
## Summary
- rename the optional OptionType identifier from `key` to `id`
- update the select utilities to respect the new `id` field when comparing options
- adjust the select utility tests to cover `id`-based duplicate label handling

## Testing
- npm test -- --runTestsByPath core/components/organisms/select/__test__/utils.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_690b1d756190832d8816103bf9e255d8