### PR TITLE
fix(pagination): update table pagination while searching and page change

### DIFF
--- a/core/components/organisms/table/__stories__/asyncTable.story.jsx
+++ b/core/components/organisms/table/__stories__/asyncTable.story.jsx
@@ -20,7 +20,7 @@ export const asyncTable = () => {
   };
 
   return (
-    <div>
+    <div className="vh-75">
       <Card className="h-100 overflow-hidden">
         <Table
           loaderSchema={loaderSchema}
@@ -292,7 +292,7 @@ const customCode = `
   }
 
   return (
-    <div>
+    <div className="vh-75">
       <Card className="h-100 overflow-hidden">
         <Table
           loaderSchema={loaderSchema}

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -2455,12 +2455,28 @@ exports[`TS renders children 1`] = `
         class="Grid Grid--data Grid--standard"
         data-test="DesignSystem-Grid"
       >
-        <h4
-          class="Heading Heading--m Heading--default"
-          data-test="DesignSystem-Heading"
+        <div
+          class="d-flex justify-content-center align-item-center w-100 h-100"
         >
-          No results found
-        </h4>
+          <div
+            class="EmptyState-Wrapper"
+            data-test="DesignSystem-EmptyState--Wrapper"
+            style="max-width: 480px;"
+          >
+            <h4
+              class="Heading Heading--m Heading--default EmptyState-text EmptyState-title--standard"
+              data-test="DesignSystem-EmptyState--Heading"
+            >
+              No results found
+            </h4>
+            <span
+              class="Text Text--subtle Text--regular EmptyState-text mt-3"
+              data-test="DesignSystem-EmptyState--Text"
+            >
+              Try adjusting your search or filters to find what you are looking for.
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -2483,12 +2499,28 @@ exports[`TS renders children 1`] = `
             class="Grid-row Grid-row--head"
           />
         </div>
-        <h4
-          class="Heading Heading--m Heading--default"
-          data-test="DesignSystem-Heading"
+        <div
+          class="d-flex justify-content-center align-item-center w-100 h-100"
         >
-          No results found
-        </h4>
+          <div
+            class="EmptyState-Wrapper"
+            data-test="DesignSystem-EmptyState--Wrapper"
+            style="max-width: 480px;"
+          >
+            <h4
+              class="Heading Heading--m Heading--default EmptyState-text EmptyState-title--standard"
+              data-test="DesignSystem-EmptyState--Heading"
+            >
+              No results found
+            </h4>
+            <span
+              class="Text Text--subtle Text--regular EmptyState-text mt-3"
+              data-test="DesignSystem-EmptyState--Text"
+            >
+              Try adjusting your search or filters to find what you are looking for.
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/css/src/components/table.module.css
+++ b/css/src/components/table.module.css
@@ -9,8 +9,10 @@
 
 .Table-grid {
   height: 100%;
+  min-height: 0;
   overflow: hidden;
   z-index: 1;
+  flex: 1 1 auto;
 }
 
 .Table-pagination {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.
- This update the table pagination while searching and page change
- When the page change gets triggered the pagination component was getting vanished. 
- While searching the pagination component is expected to be not there but in the case of the page change the pagination component should not be vanished
...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
