### PR TITLE
fix(button): add accessible labels for icon-only and loading states

### DIFF
--- a/core/components/atoms/actionCard/allyTask.md
+++ b/core/components/atoms/actionCard/allyTask.md
@@ -1,0 +1,28 @@
+# Accessibility Audit: ActionCard
+
+## Summary
+The `ActionCard` is a clickable container that behaves like a link or button. It wraps content and provides a click handler. The current implementation uses `role="link"` and `tabIndex`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - While it handles `Enter` key, it does not handle `Space` key which is expected for button-like elements.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `role="link"` might be inappropriate if it performs an action rather than navigation. If it's a link, it should have an `href`. If it's an action, `role="button"` is better.
+    - It lacks an `aria-label` or `aria-labelledby` if the children don't provide a clear accessible name.
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - The disabled state is indicated by an overlay, but it should also use `aria-disabled="true"`.
+- **Success Criterion 2.4.7: Focus Visible (Level AA)**:
+    - Ensure the focus ring is clearly visible when the card is focused via keyboard.
+
+## Actionable Changes
+- [ ] **Role Management**: Allow the user to specify `role` (defaulting to `button` if `onClick` is present).
+- [ ] **Keyboard Support**: Add `Space` key support in `onKeyDownHandler`.
+- [ ] **ARIA Attributes**: Add `aria-disabled={disabled}` to the root element.
+- [ ] **Accessible Name**: Ensure the card has an accessible name, possibly by encouraging `aria-label` when children are complex.
+
+## WCAG 2.2 AA Success Criteria References
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)
+- [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)
+

--- a/core/components/atoms/avatar/allyTask.md
+++ b/core/components/atoms/avatar/allyTask.md
@@ -1,0 +1,24 @@
+# Accessibility Audit: Avatar
+
+## Summary
+The `Avatar` component displays user images or initials. It's often used for identification. The main accessibility concerns are around its role and the information it provides to screen readers.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.1.1: Non-text Content (Level A)**:
+    - If the avatar is purely decorative, it should have `aria-hidden="true"`.
+    - If it's used to identify a person, it needs a proper text alternative (e.g., the person's name).
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `role="presentation"` is used by default, which might be incorrect if the avatar is the only indicator of a user.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Initials against the background color must meet contrast requirements.
+
+## Actionable Changes
+- [ ] **Dynamic `aria-label`**: If `firstName` and `lastName` are provided, use them as an `aria-label` on the avatar.
+- [ ] **Presence/Status Announcement**: If `presence` or `status` is used, ensure this information is available to screen readers (e.g., "John Doe - Active").
+- [ ] **Role Review**: Allow the `role` to be more easily overridden or default to `img` if it's representing a person.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+

--- a/core/components/atoms/avatarGroup/allyTask.md
+++ b/core/components/atoms/avatarGroup/allyTask.md
@@ -1,0 +1,24 @@
+# Accessibility Audit: AvatarGroup
+
+## Summary
+The `AvatarGroup` component displays a group of avatars, often with a "+x" count that opens a popover for additional users.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The group of avatars should be identified as a group, possibly using `role="group"` and an `aria-label`.
+    - The "+x" count trigger should clearly communicate that it opens a list of additional users.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `Popover` trigger (the `AvatarCount`) needs `aria-haspopup="true"` and `aria-expanded` state.
+    - The list of users in the popover should be correctly structured (e.g., using a list role).
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Ensure the popover trigger is keyboard accessible (it uses `Popover` which generally handles this, but the trigger itself must be focusable).
+
+## Actionable Changes
+- [ ] **Group Labeling**: Add `role="group"` and `aria-label="User group"` to the root element.
+- [ ] **Popover Trigger**: Ensure the `AvatarCount` component is focusable and has appropriate ARIA attributes for a popover trigger.
+- [ ] **Search Accessibility**: If `withSearch` is enabled in the popover, ensure the search input is correctly labeled and focus is managed.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)

--- a/core/components/atoms/avatarSelection/allyTask.md
+++ b/core/components/atoms/avatarSelection/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: AvatarSelection
+
+## Summary
+The `AvatarSelection` component allows users to select one or more avatars from a group. It uses a popover to show additional avatars and supports search.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The selection state of each avatar should be clearly communicated to screen readers using `aria-selected` or `aria-checked`.
+    - The group of avatars should have a `role="listbox"` or `role="group"` depending on how the selection is handled.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The trigger for the popover needs appropriate ARIA attributes (`aria-haspopup`, `aria-expanded`).
+    - The search input inside the popover should be correctly labeled.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Keyboard navigation within the popover list (Up/Down arrows) must be robust.
+    - Focus should be managed correctly when the popover opens and closes.
+
+## Actionable Changes
+- [ ] **Selection State**: Ensure `aria-selected="true"` is applied to selected avatars.
+- [ ] **Aria Roles**: Use `role="listbox"` for the list of avatars and `role="option"` for each avatar item.
+- [ ] **Focus Management**: Ensure focus returns to the trigger when the popover is closed.
+- [ ] **Keyboard Support**: Verify that `Space` and `Enter` keys work for selection.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)

--- a/core/components/atoms/backdrop/allyTask.md
+++ b/core/components/atoms/backdrop/allyTask.md
@@ -1,0 +1,22 @@
+# Accessibility Audit: Backdrop
+
+## Summary
+The `Backdrop` component creates a dimmed layer over the application, usually to emphasize a modal or loader. It manages body overflow to prevent scrolling.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The backdrop is often purely decorative or a functional overlay. If it's purely decorative, it should have `aria-hidden="true"`.
+- **Success Criterion 2.4.3: Focus Order (Level A)**:
+    - When a backdrop is open (especially for modals), focus should be trapped within the content above the backdrop. The backdrop itself should not be focusable.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The backdrop lacks a role. If it's part of a modal, it should be associated with the modal's container.
+
+## Actionable Changes
+- [ ] **Aria Hidden**: Add `aria-hidden="true"` to the backdrop element as it's usually decorative and shouldn't be interacted with by screen readers directly.
+- [ ] **Focus Management**: Ensure that when the backdrop is active, focus is moved to the relevant content (this is usually handled by the parent component like Modal, but Backdrop should support it).
+- [ ] **Inert Attribute**: Consider using the `inert` attribute on the rest of the page when the backdrop is active to prevent interaction with background elements.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)

--- a/core/components/atoms/badge/allyTask.md
+++ b/core/components/atoms/badge/allyTask.md
@@ -1,0 +1,22 @@
+# Accessibility Audit: Badge
+
+## Summary
+The `Badge` component is used to highlight a status or a count. It's rendered as a `<span>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Depending on the `appearance` and `subtle` props, the text color against the background color must meet the 4.5:1 contrast ratio.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - If the badge conveys status (e.g., "Error", "Success"), this information should be available to screen readers, possibly via an `aria-label` or by ensuring the text content is descriptive.
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - Status should not be conveyed by color alone. The text content should also reflect the status.
+
+## Actionable Changes
+- [ ] **Contrast Verification**: Audit all `appearance` and `subtle` combinations in `badge.module.css` to ensure they meet WCAG AA contrast requirements.
+- [ ] **Aria Label Support**: Allow passing an `aria-label` to provide more context to screen readers (e.g., "Status: New" instead of just "New").
+- [ ] **Role**: Consider if `role="status"` or `role="img"` (with label) is appropriate depending on usage.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)

--- a/core/components/atoms/breadcrumbs/allyTask.md
+++ b/core/components/atoms/breadcrumbs/allyTask.md
@@ -1,0 +1,25 @@
+# Accessibility Audit: Breadcrumbs
+
+## Summary
+The `Breadcrumbs` component provides a navigation trail. It uses a list of links and may include a dropdown for long paths.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The breadcrumbs should be wrapped in a `<nav>` element to identify it as a navigation landmark.
+    - The separators (`/`) are currently rendered as `<span>` but should be hidden from screen readers using `aria-hidden="true"`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `<nav>` element should have an `aria-label="Breadcrumb"` to distinguish it from other navigation landmarks.
+    - The last item in the breadcrumb trail (the current page) should have `aria-current="page"`.
+- **Success Criterion 2.4.4: Link Purpose (In Context) (Level A)**:
+    - Ensure that the links have descriptive labels (already handled by `item.label`).
+
+## Actionable Changes
+- [ ] **Landmark Role**: Wrap the root element in a `<nav aria-label="Breadcrumb">`.
+- [ ] **Current Page Indicator**: Add `aria-current="page"` to the last link in the breadcrumb list.
+- [ ] **Hide Separators**: Add `aria-hidden="true"` to the `<span>` elements used for separators.
+- [ ] **List Structure**: Consider using an ordered list (`<ol>` and `<li>`) for the breadcrumb items to provide better structure for screen readers.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)

--- a/core/components/atoms/button/Button.tsx
+++ b/core/components/atoms/button/Button.tsx
@@ -128,6 +128,7 @@ const ButtonElement = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
     className,
     tooltip,
     iconType,
+    ['aria-label']: ariaLabel,
     ...rest
   } = props;
 
@@ -176,6 +177,9 @@ const ButtonElement = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
 
   const spinnerSize = size === 'large' && children ? 'small' : 'xsmall';
   const iconSize = size === 'tiny' ? 14 : largeIcon && !children ? sizeMapping[size] + 4 : sizeMapping[size];
+  const loadingLabel = children ? String(children) : tooltip || 'Loading';
+  const computedAriaLabel =
+    ariaLabel || (!children && icon ? tooltip : undefined) || (loading ? loadingLabel : undefined);
 
   return (
     <button
@@ -185,6 +189,8 @@ const ButtonElement = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
       className={buttonClass}
       disabled={disabled || loading}
       tabIndex={tabIndex}
+      aria-busy={loading}
+      aria-label={computedAriaLabel}
       {...rest}
     >
       {loading ? (

--- a/core/components/atoms/button/__tests__/Button.test.tsx
+++ b/core/components/atoms/button/__tests__/Button.test.tsx
@@ -502,3 +502,20 @@ describe('Button component with styleType prop', () => {
     });
   });
 });
+
+describe('Button component accessibility', () => {
+  it('sets aria-label from tooltip for icon-only button', () => {
+    const { getByTestId } = render(<Button icon="events" tooltip="Events" />);
+    expect(getByTestId('DesignSystem-Button')).toHaveAttribute('aria-label', 'Events');
+  });
+
+  it('sets aria-busy when loading', () => {
+    const { getByTestId } = render(<Button loading={true}>Loading</Button>);
+    expect(getByTestId('DesignSystem-Button')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('sets a loading aria-label when no children are provided', () => {
+    const { getByTestId } = render(<Button loading={true} />);
+    expect(getByTestId('DesignSystem-Button')).toHaveAttribute('aria-label', 'Loading');
+  });
+});

--- a/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -67,6 +67,8 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--alert Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -185,6 +187,8 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--basic Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -303,6 +307,8 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--primary Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -421,6 +427,8 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--transparent Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -898,6 +906,8 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Loading"
       class="Button Button--regular Button--regularSquare Button--alert"
       data-test="DesignSystem-Button"
       disabled=""
@@ -933,6 +943,8 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Loading"
       class="Button Button--regular Button--regularSquare Button--basic"
       data-test="DesignSystem-Button"
       disabled=""
@@ -968,6 +980,8 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Loading"
       class="Button Button--regular Button--regularSquare Button--primary"
       data-test="DesignSystem-Button"
       disabled=""
@@ -1003,6 +1017,8 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
+      aria-label="Loading"
       class="Button Button--regular Button--regularSquare Button--transparent"
       data-test="DesignSystem-Button"
       disabled=""

--- a/core/components/atoms/button/allyTask.md
+++ b/core/components/atoms/button/allyTask.md
@@ -1,0 +1,24 @@
+# Accessibility Audit: Button
+
+## Summary
+The `Button` component is a standard interactive element. It supports icons, loading states, and various appearances.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If a button only has an icon (no `children`), it MUST have an `aria-label`. The current implementation uses a `Tooltip` which might not always be sufficient or correctly associated with the button's accessible name.
+    - When `loading={true}`, the button is disabled, but it should also communicate the loading state to screen readers, e.g., using `aria-busy="true"`.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure all `ButtonAppearance` and `ButtonStyleType` combinations meet the 4.5:1 contrast ratio.
+- **Success Criterion 2.4.7: Focus Visible (Level AA)**:
+    - The focus state must be clearly visible.
+
+## Actionable Changes
+- [ ] **Aria Label for Icon-only Buttons**: Ensure `aria-label` is used when `children` is absent, even if `tooltip` is provided.
+- [ ] **Loading State**: Add `aria-busy="true"` when `loading` is true.
+- [ ] **Disabled State**: The `disabled` attribute is correctly used, but consider `aria-disabled="true"` if the button needs to remain focusable while disabled.
+- [ ] **Accessible Name for Spinner**: When loading, ensure the spinner or the button has a label like "Loading...".
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)

--- a/core/components/atoms/caption/allyTask.md
+++ b/core/components/atoms/caption/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: Caption
+
+## Summary
+The `Caption` component is used to provide additional information or error messages, typically below an input. It uses `Text` and optionally an `Icon`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - If used as an error message, it should be programmatically associated with the input using `aria-describedby`.
+    - The error icon should be hidden from screen readers if the text already communicates the error.
+- **Success Criterion 3.3.1: Error Identification (Level A)**:
+    - When `error` is true, the message should be clearly identified. Adding `role="alert"` can ensure it's announced by screen readers.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` appearance must meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="alert"` when `error` is true.
+- [ ] **Aria Describedby**: Ensure parent components link the `Caption` to the relevant input.
+- [ ] **Hide Redundant Icon**: Add `aria-hidden="true"` to the error icon.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/card/allyTask.md
+++ b/core/components/atoms/card/allyTask.md
@@ -1,0 +1,18 @@
+# Accessibility Audit: Card
+
+## Summary
+The `Card` component is a container for content. It's rendered as a `<div>` and supports different shadow levels.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `Card` itself doesn't have semantic meaning. However, if it's used to group related items, it might need a role like `region` or `article`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If the card has a title, it should be associated with the card's container using `aria-labelledby`.
+
+## Actionable Changes
+- [ ] **Semantic Role**: Allow passing a `role` prop (e.g., `role="region"` or `role="article"`).
+- [ ] **Aria Labeling**: Support `aria-labelledby` to link the card to its header/title.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)

--- a/core/components/atoms/cardBody/allyTask.md
+++ b/core/components/atoms/cardBody/allyTask.md
@@ -1,0 +1,16 @@
+# Accessibility Audit: CardBody
+
+## Summary
+The `CardBody` component is a simple wrapper for content within a `Card`. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `CardBody` itself doesn't have semantic meaning. It should ensure that the content within it is correctly structured.
+
+## Actionable Changes
+- [ ] **Semantic Role**: If the body contains a specific type of content (e.g., a list), ensure the appropriate roles are used.
+- [ ] **Polymorphic Component**: Consider allowing the `CardBody` to be rendered as different HTML elements (e.g., `section`) using an `as` prop.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/cardFooter/allyTask.md
+++ b/core/components/atoms/cardFooter/allyTask.md
@@ -1,0 +1,19 @@
+# Accessibility Audit: CardFooter
+
+## Summary
+The `CardFooter` component is a wrapper for actions or additional information at the bottom of a `Card`. It's rendered as a `<div>` and can include a separator.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The separator is purely visual and should be hidden from screen readers.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If the footer contains primary actions, it should be easily navigable.
+
+## Actionable Changes
+- [ ] **Hide Separator**: Ensure the separator (if implemented via a border or separate element) does not interfere with screen reader navigation.
+- [ ] **Semantic Role**: Consider using `<footer>` or `role="contentinfo"` if appropriate for the card's context.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+

--- a/core/components/atoms/cardHeader/allyTask.md
+++ b/core/components/atoms/cardHeader/allyTask.md
@@ -1,0 +1,20 @@
+# Accessibility Audit: CardHeader
+
+## Summary
+The `CardHeader` component is a wrapper for the title and other header content within a `Card`. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The header should ideally contain a heading element (`h1`-`h6`) to provide structure to the card.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The header should be linked to the card container using `aria-labelledby`.
+
+## Actionable Changes
+- [ ] **Heading Structure**: Encourage the use of a `Heading` component within the `CardHeader`.
+- [ ] **Aria Labeling**: Ensure the `Card` component can be labeled by the content within `CardHeader`.
+- [ ] **Semantic Role**: Consider using `<header>` or `role="banner"` if appropriate for the card's context.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+

--- a/core/components/atoms/cardSubdued/allyTask.md
+++ b/core/components/atoms/cardSubdued/allyTask.md
@@ -1,0 +1,19 @@
+# Accessibility Audit: CardSubdued
+
+## Summary
+The `CardSubdued` component is a variation of a card with a subdued appearance and optional borders. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `CardSubdued` itself doesn't have semantic meaning.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the subdued background and border colors meet contrast requirements against the main card background.
+
+## Actionable Changes
+- [ ] **Semantic Role**: Allow passing a `role` prop.
+- [ ] **Contrast Audit**: Verify that the subdued colors meet WCAG AA contrast requirements.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+

--- a/core/components/atoms/checkbox/allyTask.md
+++ b/core/components/atoms/checkbox/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: Checkbox
+
+## Summary
+The `Checkbox` component is a standard form element. It uses a hidden native input and a custom styled span for the checkbox icon.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The help text is not programmatically associated with the input. It should use `aria-describedby`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `indeterminate` state is set on the native input, which is correct, but ensure it's communicated correctly to screen readers.
+- **Success Criterion 3.3.2: Labels or Instructions (Level A)**:
+    - The label is correctly associated using `htmlFor` and `id`.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the checkbox border and checkmark have sufficient contrast against the background.
+
+## Actionable Changes
+- [ ] **Aria Describedby**: Link the `helpText` to the input using `aria-describedby`.
+- [ ] **Error State**: Use `aria-invalid="true"` when the `error` prop is true.
+- [ ] **Focus Management**: Ensure the focus ring on the custom checkbox icon is clearly visible when the hidden native input is focused.
+- [ ] **Indeterminate State**: Ensure screen readers announce the indeterminate state (most do this automatically for native inputs with `indeterminate` property).
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/chip/allyTask.md
+++ b/core/components/atoms/chip/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: Chip
+
+## Summary
+The `Chip` component is used for actions, selections, or input. It wraps a `GenericChip` which handles the layout, icons, and interactions.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `Chip` uses `role="button"`. If it's a selection chip, `role="checkbox"` or `role="option"` might be more appropriate depending on the context.
+    - The clear button inside the chip also uses `role="button"`, which creates a nested button structure. This is generally discouraged.
+    - It lacks `aria-pressed` or `aria-selected` for selection chips.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - The `onKeyDown` handler only supports `Enter`. It should also support `Space`.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the chip background and text/icon colors meet contrast requirements, especially for different types and states (selected, disabled).
+
+## Actionable Changes
+- [ ] **Role Management**: Adjust `role` based on the `type` prop (e.g., `role="button"` for action, `role="checkbox"` for selection).
+- [ ] **Aria Attributes**: Add `aria-pressed` or `aria-checked` for selection chips.
+- [ ] **Keyboard Support**: Add `Space` key support in `onKeyDownHandler` and `onChipKeyDownHandler`.
+- [ ] **Nested Interactivity**: Improve the structure of the clear button to avoid nested interactive elements if possible, or ensure they are correctly labeled and navigable.
+- [ ] **Accessible Name for Clear Button**: Add an `aria-label="Remove"` to the clear button icon.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/chipGroup/allyTask.md
+++ b/core/components/atoms/chipGroup/allyTask.md
@@ -1,0 +1,21 @@
+# Accessibility Audit: ChipGroup
+
+## Summary
+The `ChipGroup` component displays a list of `Chip` components. It's rendered as a `<div>` with `<span>` items.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The list of chips should be programmatically identified as a list, e.g., using `<ul>` and `<li>` or `role="list"` and `role="listitem"`.
+    - The group should have an accessible name if it represents a specific category of items.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If the chips are used for selection, the group should have `role="listbox"` or `role="group"`.
+
+## Actionable Changes
+- [ ] **List Structure**: Use `<ul>` and `<li>` elements or appropriate ARIA roles to define the list structure.
+- [ ] **Aria Labeling**: Add `aria-label` or `aria-labelledby` to the group.
+- [ ] **Selection Group**: If chips are selectable, ensure the group role reflects this (e.g., `role="listbox"`).
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+

--- a/core/components/atoms/collapsible/allyTask.md
+++ b/core/components/atoms/collapsible/allyTask.md
@@ -1,0 +1,25 @@
+# Accessibility Audit: Collapsible
+
+## Summary
+The `Collapsible` component allows content to be expanded or collapsed. It supports hover-based expansion and a manual trigger.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The trigger should have `aria-expanded` and `aria-controls` to communicate its state and the element it controls.
+    - The trigger lacks an accessible name (it only contains an icon).
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - While the trigger has `onKeyDown`, it should specifically handle `Enter` and `Space` keys.
+    - Hover-based expansion (`hoverable`) can be problematic for keyboard users if there's no way to trigger it via keyboard.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The relationship between the trigger and the collapsible content should be programmatically defined.
+
+## Actionable Changes
+- [ ] **Aria Attributes**: Add `aria-expanded={expanded}` and `aria-controls={contentId}` to the trigger.
+- [ ] **Accessible Name**: Add `aria-label` to the trigger (e.g., "Expand" or "Collapse").
+- [ ] **Keyboard Support**: Update `onKeyDown` to specifically check for `Enter` and `Space`.
+- [ ] **Hover Accessibility**: Ensure that if `hoverable` is true, the component is still fully usable for keyboard and screen reader users.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)

--- a/core/components/atoms/column/allyTask.md
+++ b/core/components/atoms/column/allyTask.md
@@ -1,0 +1,18 @@
+# Accessibility Audit: Column
+
+## Summary
+The `Column` component is a layout utility used within a grid system. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `Column` itself doesn't have semantic meaning. However, if it's used to group related items, it might need a role like `group` or `listitem`.
+- **Success Criterion 1.4.10: Reflow (Level AA)**:
+    - Ensure that the grid system (including `Column`) supports reflow and doesn't require two-dimensional scrolling at 400% zoom.
+
+## Actionable Changes
+- [ ] **Semantic Role**: Allow passing a `role` prop.
+- [ ] **Polymorphic Component**: Consider allowing the `Column` component to be rendered as different HTML elements (e.g., `li`, `section`) using an `as` prop.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.10 Reflow](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)

--- a/core/components/atoms/divider/allyTask.md
+++ b/core/components/atoms/divider/allyTask.md
@@ -1,0 +1,19 @@
+# Accessibility Audit: Divider
+
+## Summary
+The `Divider` component provides a visual separation between content. It uses the `<hr>` element.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - If the divider is purely decorative, it should have `role="presentation"` or `aria-hidden="true"` to prevent it from being announced by screen readers.
+    - If it's used to separate groups of items in a list or menu, it should have `role="separator"`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - For vertical dividers, the default `<hr>` might not be appropriate as it's semantically a horizontal rule. `role="separator"` with `aria-orientation="vertical"` should be used.
+
+## Actionable Changes
+- [ ] **Role and Orientation**: Add `role="separator"` and `aria-orientation={vertical ? 'vertical' : 'horizontal'}`.
+- [ ] **Decorative Dividers**: If the divider is purely for visual styling and doesn't separate semantic sections, add `aria-hidden="true"`.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)

--- a/core/components/atoms/dropdown/allyTask.md
+++ b/core/components/atoms/dropdown/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: Dropdown
+
+## Summary
+The `Dropdown` is a complex component (deprecated in favor of Select/Menu/Combobox, but still in use). It manages a list of options, search, and selection. It has significant accessibility challenges common to custom dropdowns, particularly around focus management and ARIA roles.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The component needs to follow the `combobox` or `listbox` pattern correctly.
+    - Missing `aria-expanded`, `aria-haspopup`, `aria-controls` on the trigger.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Complex keyboard navigation (Up/Down arrows, Enter/Space to select) must be fully implemented and robust.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - Selection state of options must be communicated via `aria-selected`.
+    - Grouping of options should use `role="group"` and `aria-labelledby`.
+
+## Actionable Changes
+- [ ] **Implement ARIA Pattern**: Ensure the trigger has `role="combobox"`, `aria-expanded`, and `aria-controls`.
+- [ ] **Listbox Roles**: The list of options should have `role="listbox"` and each option `role="option"`.
+- [ ] **Selection State**: Use `aria-selected` on each option.
+- [ ] **Focus Management**: Ensure `aria-activedescendant` is used to manage focus within the list while the cursor stays in the search input.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/editable/allyTask.md
+++ b/core/components/atoms/editable/allyTask.md
@@ -1,0 +1,24 @@
+# Accessibility Audit: Editable
+
+## Summary
+The `Editable` component provides a wrapper to make content editable. It handles click and hover events to trigger edit mode.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The clickable wrapper lacks a `role="button"` and `tabIndex`.
+    - It lacks an accessible name.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - The component is currently not keyboard accessible. There's no way to trigger "edit" mode using the keyboard.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The relationship between the static content and the editable state is not communicated to screen readers.
+
+## Actionable Changes
+- [ ] **Keyboard Accessibility**: Add `tabIndex={0}` and an `onKeyDown` handler to support `Enter` and `Space` keys for triggering edit mode.
+- [ ] **Aria Role**: Add `role="button"` to the clickable wrapper.
+- [ ] **Accessible Name**: Add an `aria-label` (e.g., "Edit [content]") to the wrapper.
+- [ ] **State Communication**: Use `aria-live` or other mechanisms to announce when the component enters or leaves edit mode.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)

--- a/core/components/atoms/flex/allyTask.md
+++ b/core/components/atoms/flex/allyTask.md
@@ -1,0 +1,20 @@
+# Accessibility Audit: Flex
+
+## Summary
+The `Flex` component is a layout utility that provides a flexbox container. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `Flex` itself doesn't have semantic meaning. However, if it's used to group related items, it might need a role like `group` or `list`.
+    - Ensure that the order of items in the flex container matches the logical reading order, especially when using `row-reverse` or `column-reverse`.
+- **Success Criterion 2.4.3: Focus Order (Level A)**:
+    - If `flex-direction: row-reverse` or `column-reverse` is used, the visual order might differ from the DOM order, which can confuse keyboard users.
+
+## Actionable Changes
+- [ ] **Semantic Role**: Allow passing a `role` prop to the `Flex` component (e.g., `role="list"` if it contains list items).
+- [ ] **Reading Order Warning**: Add documentation or a lint rule to warn developers about potential reading order issues when using `reverse` directions.
+- [ ] **Polymorphic Component**: Consider allowing the `Flex` component to be rendered as different HTML elements (e.g., `section`, `nav`, `ul`) using an `as` prop to improve semantics.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)

--- a/core/components/atoms/heading/allyTask.md
+++ b/core/components/atoms/heading/allyTask.md
@@ -1,0 +1,21 @@
+# Accessibility Audit: Heading
+
+## Summary
+The `Heading` component renders heading elements (`h1` to `h5`) based on the `size` prop. It uses a `GenericText` component for rendering.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The mapping between `size` and heading level (`s` -> `h5`, `xxl` -> `h1`) is fixed. This can lead to skipped heading levels if not used carefully, which violates the principle of a logical heading hierarchy.
+- **Success Criterion 2.4.6: Headings and Labels (Level AA)**:
+    - Ensure that the heading text is descriptive.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure all `HeadingAppearance` and `color` combinations meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Flexible Heading Levels**: Allow the user to specify the heading level (e.g., `h1`, `h2`, etc.) independently of the visual size. This ensures a proper document outline.
+- [ ] **Contrast Audit**: Verify that the default colors and appearances meet WCAG AA contrast requirements.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/helpText/allyTask.md
+++ b/core/components/atoms/helpText/allyTask.md
@@ -1,0 +1,22 @@
+# Accessibility Audit: HelpText
+
+## Summary
+The `HelpText` component provides additional information or error messages for form fields. It uses `InlineMessage` for errors and `Text` for standard help messages.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The `HelpText` should be programmatically associated with the input it describes using `aria-describedby` on the input.
+- **Success Criterion 3.3.1: Error Identification (Level A)**:
+    - If `error` is true, the message should be clearly identified as an error. `InlineMessage` with `appearance="alert"` helps, but ensure the container has `role="alert"` if it's meant to be announced immediately.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` appearance for `Text` must meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Association**: Ensure the parent component (like `Input` or `Checkbox`) correctly links the `HelpText` using `aria-describedby`.
+- [ ] **Aria Role**: For error messages, consider adding `role="alert"` to ensure they are announced by screen readers when they appear.
+- [ ] **Contrast Verification**: Check the contrast of the `subtle` text color.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/icon/allyTask.md
+++ b/core/components/atoms/icon/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: Icon
+
+## Summary
+The `Icon` component renders a material icon using an `<i>` element. It uses a custom hook `useAccessibilityProps` to handle basic accessibility like `role`, `tabIndex`, and keyboard interactions if `onClick` is provided.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.1.1: Non-text Content (Level A)**:
+    - Icons are often decorative. If an icon doesn't have an `onClick` or a specific meaning, it should have `aria-hidden="true"`.
+    - If an icon is functional (e.g., used as a button), it MUST have an `aria-label`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `useAccessibilityProps` defaults `role` to `button` if `onClick` is present. This is good, but ensure the `aria-label` is also provided.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure all `IconAppearance` colors meet the 4.5:1 contrast ratio against their likely backgrounds.
+
+## Actionable Changes
+- [ ] **Aria Hidden by Default**: If no `onClick` or `aria-label` is provided, default to `aria-hidden="true"`.
+- [ ] **Mandatory Label for Functional Icons**: Encourage or enforce `aria-label` when `onClick` is provided.
+- [ ] **Contrast Audit**: Verify contrast for all icon appearances.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/input/allyTask.md
+++ b/core/components/atoms/input/allyTask.md
@@ -1,0 +1,28 @@
+# Accessibility Audit: Input
+
+## Summary
+The `Input` component is a standard text input field. It supports icons, inline labels, clear buttons, and info tooltips.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The `inlineLabel` is rendered as a `<div>` with `Text` but is not programmatically associated with the input. It should be part of the label or use `aria-labelledby`.
+    - The `info` tooltip should be associated with the input using `aria-describedby`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The clear button and info icon should have appropriate `aria-label`s.
+    - If `error` is true, the input should have `aria-invalid="true"`.
+- **Success Criterion 3.3.2: Labels or Instructions (Level A)**:
+    - Ensure every input has a visible label (handled by the `Label` component, but `Input` should support `aria-label` or `aria-labelledby` if no visible label is present).
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - The clear button is an `Icon` which uses `useAccessibilityProps`, but ensure it's easily reachable and usable via keyboard.
+
+## Actionable Changes
+- [ ] **Aria Invalid**: Add `aria-invalid={error}` to the input element.
+- [ ] **Aria Describedby**: Link `info` text and any external `HelpText` to the input.
+- [ ] **Inline Label Association**: Use `aria-labelledby` to include the `inlineLabel` in the input's accessible name.
+- [ ] **Clear Button Label**: Add `aria-label="Clear input"` to the clear button.
+- [ ] **Required Attribute**: The `required` prop is correctly passed to the native input.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)

--- a/core/components/atoms/label/allyTask.md
+++ b/core/components/atoms/label/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: Label
+
+## Summary
+The `Label` component provides a label for form elements. It supports required indicators, optional text, and info tooltips.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The required indicator is a `<span>` with a background color but no text content or `aria-label`. Screen readers won't announce that the field is required.
+    - The `info` tooltip icon should have an `aria-label` like "More information".
+- **Success Criterion 3.3.2: Labels or Instructions (Level A)**:
+    - Ensure the `Label` is correctly associated with an input using the `htmlFor` prop (passed via `...rest` to the native `label` element).
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` appearance for optional text and the info icon must meet contrast requirements.
+
+## Actionable Changes
+- [ ] **Required Indicator Label**: Add `aria-label="required"` or `aria-hidden="true"` (if `aria-required` is used on the input) to the required indicator. A better approach is to use a visible asterisk `*` with `aria-hidden="true"` and ensure the input has `aria-required="true"`.
+- [ ] **Info Icon Label**: Add `aria-label="More information"` to the info icon.
+- [ ] **Optional Text Contrast**: Verify the contrast ratio for the "(optional)" text.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/legend/allyTask.md
+++ b/core/components/atoms/legend/allyTask.md
@@ -1,0 +1,24 @@
+# Accessibility Audit: Legend
+
+## Summary
+The `Legend` component is used to describe items in a chart or list, typically with a colored icon and text.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If the `Legend` is clickable (`onClick`), it lacks a `role="button"` and `tabIndex`.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - If clickable, it's not accessible via keyboard.
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - The meaning of the legend icon is conveyed only by color. Ensure the text description is sufficient.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the legend icon color has sufficient contrast against the background.
+
+## Actionable Changes
+- [ ] **Keyboard Accessibility**: If `onClick` is provided, add `tabIndex={0}` and an `onKeyDown` handler for `Enter` and `Space`.
+- [ ] **Aria Role**: Add `role="button"` if clickable.
+- [ ] **Decorative Icon**: Add `aria-hidden="true"` to the icon span as it's purely decorative (the text provides the meaning).
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)

--- a/core/components/atoms/link/allyTask.md
+++ b/core/components/atoms/link/allyTask.md
@@ -1,0 +1,24 @@
+# Accessibility Audit: Link
+
+## Summary
+The `Link` component renders an `<a>` element. It supports different sizes, appearances, and a disabled state.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - When `disabled={true}`, the link has `tabIndex={-1}`, but it should also have `aria-disabled="true"`. Note that native `<a>` elements don't support the `disabled` attribute, so `aria-disabled` is essential.
+- **Success Criterion 2.4.4: Link Purpose (In Context) (Level A)**:
+    - If the link opens in a new window (`target="_blank"`), this should be communicated to screen readers, e.g., "opens in a new window".
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` appearance must meet the 4.5:1 contrast ratio.
+- **Success Criterion 2.4.7: Focus Visible (Level AA)**:
+    - Ensure the focus state is clearly visible.
+
+## Actionable Changes
+- [ ] **Aria Disabled**: Add `aria-disabled={disabled}` to the link element.
+- [ ] **New Window Warning**: If `target="_blank"`, add an `aria-label` or a hidden text that indicates the link opens in a new window. Also, ensure `rel="noopener noreferrer"` is added for security and performance.
+- [ ] **Contrast Verification**: Audit the `subtle` appearance contrast.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/linkButton/allyTask.md
+++ b/core/components/atoms/linkButton/allyTask.md
@@ -1,0 +1,22 @@
+# Accessibility Audit: LinkButton
+
+## Summary
+The `LinkButton` component is a button that visually resembles a link. It uses the native `<button>` element.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - While it uses a native button, its visual appearance as a link might be confusing. Ensure it behaves like a button (e.g., handles `Space` and `Enter`).
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` appearance must meet the 4.5:1 contrast ratio.
+- **Success Criterion 2.4.7: Focus Visible (Level AA)**:
+    - Ensure the focus state is clearly visible, even if it looks like a link.
+
+## Actionable Changes
+- [ ] **Contrast Verification**: Audit the `subtle` appearance contrast.
+- [ ] **Focus Ring**: Ensure a clear focus ring is visible when focused via keyboard.
+- [ ] **Aria Label**: If the button contains only an icon (though `children` is required in props), ensure an `aria-label` is used.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html)

--- a/core/components/atoms/mdsGrid/allyTask.md
+++ b/core/components/atoms/mdsGrid/allyTask.md
@@ -1,0 +1,21 @@
+# Accessibility Audit: MdsGrid
+
+## Summary
+The `MdsGrid` component is a layout utility that provides a CSS grid container. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `MdsGrid` itself doesn't have semantic meaning. However, if it's used to group related items, it might need a role like `group` or `list`.
+    - Ensure that the order of items in the grid matches the logical reading order.
+- **Success Criterion 1.4.10: Reflow (Level AA)**:
+    - Ensure that the grid system supports reflow and doesn't require two-dimensional scrolling at 400% zoom.
+
+## Actionable Changes
+- [ ] **Semantic Role**: Allow passing a `role` prop.
+- [ ] **Reading Order Warning**: Add documentation to warn developers about potential reading order issues when using complex grid placements.
+- [ ] **Polymorphic Component**: Consider allowing the `MdsGrid` component to be rendered as different HTML elements (e.g., `section`, `nav`, `ul`) using an `as` prop.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.10 Reflow](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)
+

--- a/core/components/atoms/message/allyTask.md
+++ b/core/components/atoms/message/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: Message
+
+## Summary
+The `Message` component displays informative or alert messages with an icon, title, description, and actions.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The icon is currently not hidden from screen readers, but it's redundant if the message appearance is already communicated by a role.
+    - The container lacks a role to communicate the type of message (e.g., `role="alert"` for alerts, `role="status"` for info).
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - Depending on the `appearance`, the component should have an appropriate role.
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - Ensure that the message's meaning is not conveyed by color alone. The icon and text content should also reflect the message type.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure all appearance-based colors meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="alert"` for `appearance="alert"` and `role="status"` for other appearances.
+- [ ] **Hide Redundant Icon**: Add `aria-hidden="true"` to the icon as it's decorative and the role already communicates the message type.
+- [ ] **Contrast Verification**: Audit all appearance colors for contrast compliance.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/metaList/allyTask.md
+++ b/core/components/atoms/metaList/allyTask.md
@@ -1,0 +1,21 @@
+# Accessibility Audit: MetaList
+
+## Summary
+The `MetaList` component displays a list of metadata items (icon + label) separated by dots. It's rendered as a `<div>` with `<span>` items.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The list of metadata items should be programmatically identified as a list, e.g., using `<ul>` and `<li>` or `role="list"` and `role="listitem"`.
+    - The separators (dots) are currently rendered as `Icon` components but should be hidden from screen readers using `aria-hidden="true"`.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The default `subtle` and `disabled` appearances for labels and separators must meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **List Structure**: Use `<ul>` and `<li>` elements or appropriate ARIA roles to define the list structure.
+- [ ] **Hide Separators**: Add `aria-hidden="true"` to the separator icons.
+- [ ] **Contrast Verification**: Audit the contrast of `subtle` and `disabled` appearances.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+

--- a/core/components/atoms/meter/allyTask.md
+++ b/core/components/atoms/meter/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: Meter
+
+## Summary
+The `Meter` component represents a scalar measurement within a known range. It uses `role="meter"` and appropriate `aria-value*` attributes.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The `Meter` should have an accessible name via `aria-label` or `aria-labelledby`. The `ariaLabel` prop is provided but should be encouraged.
+    - If the value is not a simple number (e.g., "3 out of 5 steps"), `aria-valuetext` should be used to provide a human-readable version of the value.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the `fillColor` and `emptyColor` have sufficient contrast against the background and each other to be distinguishable.
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - The status or value should not be conveyed by color alone. The `showLabel` prop helps by providing a text representation.
+
+## Actionable Changes
+- [ ] **Aria Value Text**: Add an `aria-valuetext` prop to allow providing a human-readable description of the current value.
+- [ ] **Accessible Name**: Ensure the `Meter` always has an accessible name, either through `aria-label` or by linking it to a label element.
+- [ ] **Contrast Verification**: Audit the default `fillColor` and `emptyColor` for contrast compliance.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)

--- a/core/components/atoms/metricInput/allyTask.md
+++ b/core/components/atoms/metricInput/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: MetricInput
+
+## Summary
+The `MetricInput` component is a specialized number input with increment/decrement buttons, prefix, and suffix. It uses the native `<input type="number">`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The prefix and suffix are not programmatically associated with the input. They should be part of the label or use `aria-labelledby`.
+    - If there's an error, it should be linked via `aria-describedby`.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The increment/decrement buttons have `aria-label`, which is good.
+    - If `error` is true, the input should have `aria-invalid="true"`.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` appearance for prefix/suffix and icons must meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Aria Invalid**: Add `aria-invalid={error}` to the input element.
+- [ ] **Aria Labeling**: Use `aria-labelledby` to include the prefix and suffix in the input's accessible name.
+- [ ] **Aria Describedby**: Link any external `HelpText` or error messages to the input.
+- [ ] **Contrast Verification**: Audit the `subtle` appearance contrast.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+

--- a/core/components/atoms/multiSlider/allyTask.md
+++ b/core/components/atoms/multiSlider/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: MultiSlider
+
+## Summary
+The `MultiSlider` component is a base component for `Slider` and `RangeSlider`. It manages multiple handles and a track.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The handles (rendered in `Handle.tsx`) should have `role="slider"`.
+    - Each handle needs `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext`.
+    - The slider needs an accessible name.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Keyboard navigation (Arrow keys) is partially implemented but needs to be robust and include `ArrowUp`/`ArrowDown`.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The slider track and labels should be correctly associated.
+
+## Actionable Changes
+- [ ] **Aria Roles & Attributes**: Add `role="slider"` and appropriate `aria-value*` attributes to each handle in `Handle.tsx`.
+- [ ] **Accessible Names**: Provide `aria-label` for each handle.
+- [ ] **Keyboard Support**: Update `handleKeyDown` in `Handle.tsx` to include `ArrowUp` and `ArrowDown` keys.
+- [ ] **Aria Valuetext**: Use `aria-valuetext` to provide a human-readable version of the value.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/outsideClick/allyTask.md
+++ b/core/components/atoms/outsideClick/allyTask.md
@@ -1,0 +1,18 @@
+# Accessibility Audit: OutsideClick
+
+## Summary
+The `OutsideClick` component detects clicks outside of its children and triggers a callback. It's often used for closing popovers, modals, or dropdowns.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Detecting only "clicks" outside might not be sufficient for keyboard users. If a user tabs out of a component, it should also potentially trigger the same "close" logic.
+- **Success Criterion 2.4.3: Focus Order (Level A)**:
+    - When an element is closed via an outside click, focus should be managed correctly (e.g., returning focus to the trigger).
+
+## Actionable Changes
+- [ ] **Escape Key Support**: Ensure that components using `OutsideClick` also handle the `Escape` key to close.
+- [ ] **Blur/Focusout Support**: Consider adding a listener for `focusout` to detect when focus moves outside the component, which is the keyboard equivalent of an outside click.
+
+## WCAG 2.2 AA Success Criteria References
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)

--- a/core/components/atoms/paragraph/allyTask.md
+++ b/core/components/atoms/paragraph/allyTask.md
@@ -1,0 +1,17 @@
+# Accessibility Audit: Paragraph
+
+## Summary
+The `Paragraph` component renders a `<p>` element for blocks of text. It supports various appearances and colors.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` and `disabled` appearances must meet the 4.5:1 contrast ratio for normal text.
+- **Success Criterion 1.4.8: Visual Presentation (Level AAA)**:
+    - While this is a Level AAA criterion, ensuring that line height and spacing are adequate is good practice for Level AA as well.
+
+## Actionable Changes
+- [ ] **Contrast Audit**: Verify that all `ParagraphAppearance` and `color` combinations meet WCAG AA contrast requirements.
+- [ ] **Typography Review**: Ensure default line-height and paragraph spacing are sufficient for readability.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/pills/allyTask.md
+++ b/core/components/atoms/pills/allyTask.md
@@ -1,0 +1,20 @@
+# Accessibility Audit: Pills
+
+## Summary
+The `Pills` component is used to display counts or labels with rounded corners. It's rendered as a `<span>` and shares styles with the `Badge` component.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Like `Badge`, the text color against the background must meet the 4.5:1 contrast ratio for all `appearance` and `subtle` combinations.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - If a pill is used to show a count (e.g., in a tab), it should be programmatically associated with the relevant element.
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - Color should not be the only means of conveying information.
+
+## Actionable Changes
+- [ ] **Contrast Verification**: Audit all `appearance` and `subtle` combinations for contrast compliance.
+- [ ] **Aria Label Support**: Allow passing an `aria-label` to provide context (e.g., "3 unread messages").
+
+## WCAG 2.2 AA Success Criteria References
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)

--- a/core/components/atoms/placeholderImage/allyTask.md
+++ b/core/components/atoms/placeholderImage/allyTask.md
@@ -1,0 +1,20 @@
+# Accessibility Audit: PlaceholderImage
+
+## Summary
+The `PlaceholderImage` component is a skeleton loader for images. It's rendered as a `<span>` with an animation.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.1.1: Non-text Content (Level A)**:
+    - Skeleton loaders should be hidden from screen readers to avoid noise, or they should communicate that content is loading.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - It should have `aria-hidden="true"` if it's purely decorative during loading.
+- **Success Criterion 2.2.2: Pause, Stop, Hide (Level A)**:
+    - The loading animation should not be distracting.
+
+## Actionable Changes
+- [ ] **Aria Hidden**: Add `aria-hidden="true"` to the placeholder as it's a temporary visual state and doesn't provide semantic content.
+- [ ] **Loading Announcement**: Ensure the parent container has `aria-busy="true"` while placeholders are visible.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)

--- a/core/components/atoms/placeholderParagraph/allyTask.md
+++ b/core/components/atoms/placeholderParagraph/allyTask.md
@@ -1,0 +1,18 @@
+# Accessibility Audit: PlaceholderParagraph
+
+## Summary
+The `PlaceholderParagraph` component is a skeleton loader for text blocks. It's rendered as a `<div>` with an animated `<span>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.1.1: Non-text Content (Level A)**:
+    - Like `PlaceholderImage`, skeleton loaders for text should be hidden from screen readers to avoid announcing empty or meaningless elements.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - It should have `aria-hidden="true"`.
+
+## Actionable Changes
+- [ ] **Aria Hidden**: Add `aria-hidden="true"` to the root element.
+- [ ] **Loading State**: Ensure the parent container communicates the loading state (e.g., `aria-busy="true"`).
+
+## WCAG 2.2 AA Success Criteria References
+- [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)

--- a/core/components/atoms/popperWrapper/allyTask.md
+++ b/core/components/atoms/popperWrapper/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: PopperWrapper
+
+## Summary
+The `PopperWrapper` component is a low-level utility that manages the positioning and visibility of popovers using `react-popper`. It handles triggers, portals, and outside clicks.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The trigger element needs appropriate ARIA attributes (`aria-haspopup`, `aria-expanded`, `aria-controls`) to communicate the state of the popover.
+    - The popover content itself needs a role (e.g., `dialog`, `menu`, `tooltip`) depending on its purpose.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Keyboard navigation between the trigger and the popover content must be managed.
+    - The `Escape` key should close the popover.
+- **Success Criterion 2.4.3: Focus Order (Level A)**:
+    - Focus should be managed when the popover opens (e.g., moving focus to the first interactive element in a dialog) and closes (returning focus to the trigger).
+
+## Actionable Changes
+- [ ] **Aria Attributes**: Ensure the trigger has `aria-haspopup`, `aria-expanded`, and `aria-controls`.
+- [ ] **Escape Key Support**: Implement `Escape` key handling to close the popover.
+- [ ] **Focus Management**: Implement focus trapping for dialog-like popovers and ensure focus is returned to the trigger upon closing.
+- [ ] **Aria Role**: Allow specifying the role of the popover content.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)
+

--- a/core/components/atoms/progressBar/allyTask.md
+++ b/core/components/atoms/progressBar/allyTask.md
@@ -1,0 +1,22 @@
+# Accessibility Audit: ProgressBar
+
+## Summary
+The `ProgressBar` component indicates the completion status of a task. It supports both determinate and indeterminate states.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The component lacks the `role="progressbar"`.
+    - It should have `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` (for determinate state).
+    - It should have an accessible name via `aria-label` or `aria-labelledby`.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The progress information is only visual. Screen readers won't know this is a progress bar or what its value is.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="progressbar"` to the root element.
+- [ ] **Aria Value Attributes**: Add `aria-valuemin="0"`, `aria-valuemax={max}`, and `aria-valuenow={value}` (if state is not indeterminate).
+- [ ] **Accessible Name**: Add an `aria-label` prop to describe what the progress bar is for.
+- [ ] **Indeterminate State**: For `state="indeterminate"`, ensure `aria-valuenow` is omitted or set appropriately (some recommend omitting it).
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)

--- a/core/components/atoms/progressRing/allyTask.md
+++ b/core/components/atoms/progressRing/allyTask.md
@@ -1,0 +1,21 @@
+# Accessibility Audit: ProgressRing
+
+## Summary
+The `ProgressRing` component is a circular progress indicator. It's rendered as an SVG.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The component lacks `role="progressbar"`.
+    - It should have `aria-valuemin`, `aria-valuemax`, and `aria-valuenow`.
+    - It lacks an accessible name.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The progress information is only visual.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="progressbar"` to the SVG element.
+- [ ] **Aria Value Attributes**: Add `aria-valuemin="0"`, `aria-valuemax={max}`, and `aria-valuenow={value}`.
+- [ ] **Accessible Name**: Add an `aria-label` to describe the progress (e.g., "Uploading file...").
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)

--- a/core/components/atoms/radio/allyTask.md
+++ b/core/components/atoms/radio/allyTask.md
@@ -1,0 +1,27 @@
+# Accessibility Audit: Radio
+
+## Summary
+The `Radio` component is a standard radio button. It uses a hidden native input and a custom styled span for the radio icon.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The `helpText` is not programmatically associated with the input. It should use `aria-describedby`.
+    - Radio buttons should be grouped using a `<fieldset>` and `<legend>` for proper context, especially when multiple radio buttons belong to the same group.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If `error` is true, the input should have `aria-invalid="true"`.
+- **Success Criterion 3.3.2: Labels or Instructions (Level A)**:
+    - The label is correctly associated using `htmlFor` and `id`.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the radio button border and selection indicator have sufficient contrast.
+
+## Actionable Changes
+- [ ] **Aria Describedby**: Link the `helpText` to the input using `aria-describedby`.
+- [ ] **Aria Invalid**: Add `aria-invalid={error}` to the input element.
+- [ ] **Focus Management**: Ensure the focus ring on the custom radio icon is clearly visible when the hidden native input is focused.
+- [ ] **Grouping**: Ensure that when used in a group, the radio buttons are wrapped in a `RadioGroup` component that uses `<fieldset>` and `<legend>`.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/rangeSlider/allyTask.md
+++ b/core/components/atoms/rangeSlider/allyTask.md
@@ -1,0 +1,25 @@
+# Accessibility Audit: RangeSlider
+
+## Summary
+The `RangeSlider` component allows selecting a range of values using two handles. It wraps the `MultiSlider` component.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The handles should have `role="slider"`.
+    - Each handle should have `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext`.
+    - Handles should have accessible names (e.g., "Start value", "End value").
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Keyboard navigation (Arrow keys) is partially implemented in `Handle.tsx` but needs to be robust and include `ArrowUp`/`ArrowDown`.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The slider track and labels should be correctly associated.
+
+## Actionable Changes
+- [ ] **Aria Roles & Attributes**: Add `role="slider"` and appropriate `aria-value*` attributes to each handle.
+- [ ] **Accessible Names**: Provide `aria-label` for each handle to distinguish between start and end.
+- [ ] **Keyboard Support**: Update `handleKeyDown` in `Handle.tsx` to include `ArrowUp` and `ArrowDown` keys.
+- [ ] **Aria Valuetext**: Use `aria-valuetext` to provide a human-readable version of the value if necessary.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)

--- a/core/components/atoms/row/allyTask.md
+++ b/core/components/atoms/row/allyTask.md
@@ -1,0 +1,18 @@
+# Accessibility Audit: Row
+
+## Summary
+The `Row` component is a layout utility used within a grid system to contain `Column` components. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - As a layout component, `Row` itself doesn't have semantic meaning. However, if it's used to group related items, it might need a role like `list` or `group`.
+- **Success Criterion 1.4.10: Reflow (Level AA)**:
+    - Ensure that the grid system (including `Row`) supports reflow.
+
+## Actionable Changes
+- [ ] **Semantic Role**: Allow passing a `role` prop.
+- [ ] **Polymorphic Component**: Consider allowing the `Row` component to be rendered as different HTML elements (e.g., `ul`, `section`) using an `as` prop.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.10 Reflow](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html)

--- a/core/components/atoms/segmentedControl/allyTask.md
+++ b/core/components/atoms/segmentedControl/allyTask.md
@@ -1,0 +1,25 @@
+# Accessibility Audit: SegmentedControl
+
+## Summary
+The `SegmentedControl` component is a linear set of two or more segments, each of which functions as a mutually exclusive button.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The component should follow the `tablist` pattern. The container should have `role="tablist"`, and each segment should have `role="tab"`.
+    - Selected segment should have `aria-selected="true"`.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Keyboard navigation should follow the `tablist` pattern (Left/Right arrows to move focus, Space/Enter to select). Currently, it uses standard button tab order.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The relationship between segments in the control should be programmatically defined.
+
+## Actionable Changes
+- [ ] **Aria Roles**: Add `role="tablist"` to the container and `role="tab"` to each `SegmentedControlItem`.
+- [ ] **Selection State**: Ensure `aria-selected` is correctly applied to the active segment.
+- [ ] **Keyboard Navigation**: Implement Arrow key navigation within the `tablist` to move focus between segments.
+- [ ] **Accessible Name**: Ensure the `tablist` has an `aria-label` or `aria-labelledby`.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/selectionCard/allyTask.md
+++ b/core/components/atoms/selectionCard/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: SelectionCard
+
+## Summary
+The `SelectionCard` component is a clickable card that can be selected. It uses `role="checkbox"` and `aria-checked`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - While it handles `Enter`, it should also handle the `Space` key for toggling selection, as expected for a checkbox role.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The card needs an accessible name. If the children don't provide a clear name, `aria-label` or `aria-labelledby` should be used.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - If used in a group where only one can be selected, `role="radio"` and `aria-checked` should be used instead of `checkbox`.
+
+## Actionable Changes
+- [ ] **Keyboard Support**: Add `Space` key support in `onKeyDownHandler`.
+- [ ] **Role Flexibility**: Allow the user to specify `role` (defaulting to `checkbox`, but supporting `radio`).
+- [ ] **Accessible Name**: Ensure the card has an accessible name.
+
+## WCAG 2.2 AA Success Criteria References
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/slider/allyTask.md
+++ b/core/components/atoms/slider/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: Slider
+
+## Summary
+The `Slider` component allows selecting a single value from a range. It wraps the `MultiSlider` component.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The handle should have `role="slider"`.
+    - The handle should have `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, and `aria-valuetext`.
+    - The slider needs an accessible name.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - Keyboard navigation (Arrow keys) must be robust and include `ArrowUp`/`ArrowDown`.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The slider track and labels should be correctly associated.
+
+## Actionable Changes
+- [ ] **Aria Roles & Attributes**: Add `role="slider"` and appropriate `aria-value*` attributes to the handle.
+- [ ] **Accessible Name**: Provide an `aria-label` for the slider.
+- [ ] **Keyboard Support**: Update `handleKeyDown` in `Handle.tsx` to include `ArrowUp` and `ArrowDown` keys.
+- [ ] **Aria Valuetext**: Use `aria-valuetext` to provide a human-readable version of the value.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/spinner/allyTask.md
+++ b/core/components/atoms/spinner/allyTask.md
@@ -1,0 +1,22 @@
+# Accessibility Audit: Spinner
+
+## Summary
+The `Spinner` component is a visual indicator of a loading state. It's rendered as an SVG.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.1.1: Non-text Content (Level A)**:
+    - The `Spinner` is a non-text content that conveys information (loading). It should have an accessible name like "Loading".
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - It should have `role="status"` or `role="progressbar"` to communicate its purpose to screen readers.
+- **Success Criterion 2.2.2: Pause, Stop, Hide (Level A)**:
+    - For any moving, blinking or scrolling information that (1) starts automatically, (2) lasts more than five seconds, and (3) is presented in parallel with other content, there is a mechanism for the user to pause, stop, or hide it. While a spinner is usually temporary, it's important to ensure it doesn't distract users.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="status"` and `aria-live="polite"` to the SVG or its container.
+- [ ] **Accessible Name**: Add a `<title>` element inside the SVG or an `aria-label="Loading"` to the SVG.
+- [ ] **Aria Hidden**: If the spinner is used inside a button that already has a "Loading" label, the spinner itself should be `aria-hidden="true"`.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.2.2 Pause, Stop, Hide](https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html)

--- a/core/components/atoms/statusHint/allyTask.md
+++ b/core/components/atoms/statusHint/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: StatusHint
+
+## Summary
+The `StatusHint` component displays a status indicator (colored dot) and a label. It's rendered as a `<div>`.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.4.1: Use of Color (Level A)**:
+    - The status is conveyed only by the color of the dot. Ensure the text label explicitly states the status (e.g., "Active", "Inactive").
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If clickable, it lacks a `role="button"` and `tabIndex`.
+- **Success Criterion 2.1.1: Keyboard (Level A)**:
+    - If clickable, it's not accessible via keyboard.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the status dot color has sufficient contrast against the background.
+
+## Actionable Changes
+- [ ] **Keyboard Accessibility**: If `onClick` is provided, add `tabIndex={0}` and an `onKeyDown` handler for `Enter` and `Space`.
+- [ ] **Aria Role**: Add `role="button"` if clickable.
+- [ ] **Decorative Icon**: Add `aria-hidden="true"` to the status dot span.
+- [ ] **Aria Label**: If the text label is not descriptive enough, allow an `aria-label` to provide more context.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)
+

--- a/core/components/atoms/subheading/allyTask.md
+++ b/core/components/atoms/subheading/allyTask.md
@@ -1,0 +1,19 @@
+# Accessibility Audit: Subheading
+
+## Summary
+The `Subheading` component renders an `h4` element. It supports various appearances and colors.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The component is hardcoded to use `h4`. This can lead to skipped heading levels if not used correctly in the document hierarchy.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure all appearance and color combinations meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Flexible Heading Level**: Allow users to specify the heading level (e.g., `h2`, `h3`, `h4`) to maintain a proper document outline.
+- [ ] **Contrast Verification**: Audit default colors for contrast compliance.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+

--- a/core/components/atoms/switchInput/allyTask.md
+++ b/core/components/atoms/switchInput/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: Switch
+
+## Summary
+The `Switch` component is a toggle switch. It uses a hidden native checkbox input and a custom styled span.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - While it uses a native checkbox, a switch should ideally have `role="switch"` to communicate its behavior better to screen readers.
+    - It lacks an accessible name if not wrapped in a label.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - Ensure the switch is programmatically associated with a label.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the switch background (both on and off states) and the handle have sufficient contrast.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="switch"` to the input element.
+- [ ] **Accessible Name**: Ensure the switch has an `aria-label` or is linked to a `Label` component.
+- [ ] **Focus Management**: Ensure the focus ring on the custom switch wrapper is clearly visible when the hidden native input is focused.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)

--- a/core/components/atoms/text/allyTask.md
+++ b/core/components/atoms/text/allyTask.md
@@ -1,0 +1,19 @@
+# Accessibility Audit: Text
+
+## Summary
+The `Text` component is a basic typography utility that renders a `<span>`. It supports various sizes, weights, and appearances.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - The `subtle` and `disabled` appearances must meet the 4.5:1 contrast ratio.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - If `Text` is used to represent a heading or other semantic element, it should use the appropriate HTML tag or ARIA role.
+
+## Actionable Changes
+- [ ] **Contrast Audit**: Verify all `TextAppearance` and `color` combinations for contrast compliance.
+- [ ] **Polymorphic Component**: Consider allowing the `Text` component to be rendered as different HTML elements (e.g., `strong`, `em`, `div`) using an `as` prop to improve semantics.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+

--- a/core/components/atoms/textarea/allyTask.md
+++ b/core/components/atoms/textarea/allyTask.md
@@ -1,0 +1,23 @@
+# Accessibility Audit: Textarea
+
+## Summary
+The `Textarea` component is a standard multi-line text input field. It uses the native `<textarea>` element.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - If `error` is true, the textarea should have `aria-invalid="true"`.
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - Ensure the textarea is programmatically associated with a label using `htmlFor` on the `Label` component and `id` on the `Textarea`.
+    - If there's help text or an error message, it should be linked via `aria-describedby`.
+- **Success Criterion 3.3.2: Labels or Instructions (Level A)**:
+    - Ensure every textarea has a visible label.
+
+## Actionable Changes
+- [ ] **Aria Invalid**: Add `aria-invalid={error}` to the textarea element.
+- [ ] **Aria Describedby**: Link any external `HelpText` or error messages to the textarea.
+- [ ] **Accessible Name**: Support `aria-label` or `aria-labelledby` for cases where a visible label is not used.
+
+## WCAG 2.2 AA Success Criteria References
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html)

--- a/core/components/atoms/toast/allyTask.md
+++ b/core/components/atoms/toast/allyTask.md
@@ -1,0 +1,26 @@
+# Accessibility Audit: Toast
+
+## Summary
+The `Toast` component provides brief feedback about an operation. It's usually displayed temporarily and should be accessible to screen readers.
+
+## WCAG 2.2 AA Violations/Gaps
+- **Success Criterion 1.3.1: Info and Relationships (Level A)**:
+    - The `Toast` container lacks a role. It should have `role="status"` or `role="alert"` depending on the severity.
+    - The icons should be hidden from screen readers if they are redundant.
+- **Success Criterion 4.1.2: Name, Role, Value (Level A)**:
+    - The close icon should have an `aria-label="Close"`.
+- **Success Criterion 2.2.3: No Timing (Level AAA)**:
+    - While Level AAA, Level AA requires that users have enough time to read the content. Toasts that disappear automatically can be problematic. Ensure there's a way to pause or extend the time, or that the information is available elsewhere.
+- **Success Criterion 1.4.3: Contrast (Minimum) (Level AA)**:
+    - Ensure the text and background colors for all appearances meet the 4.5:1 contrast ratio.
+
+## Actionable Changes
+- [ ] **Aria Role**: Add `role="status"` and `aria-live="polite"` for most toasts, or `role="alert"` and `aria-live="assertive"` for critical alerts.
+- [ ] **Close Button Label**: Add `aria-label="Close"` to the close icon.
+- [ ] **Hide Redundant Icons**: Add `aria-hidden="true"` to the status icon.
+- [ ] **Persistence**: Ensure toasts containing important information or actions do not disappear too quickly, or provide a way to access them later.
+
+## WCAG 2.2 AA Success Criteria References
+- [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html)
+- [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html)
+- [1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html)


### PR DESCRIPTION
### Motivation
- Improve Button accessibility by ensuring icon-only buttons expose a visible accessible name and loading state is announced to assistive technologies.
- Address WCAG Name, Role, Value and loading-state communication by providing `aria-label` fallbacks and `aria-busy` on the control.

### Description
- Compute a `computedAriaLabel` from an explicit `aria-label`, the `tooltip` for icon-only buttons, or a loading label and apply it to the `<button>` as `aria-label`.
- Add `aria-busy={loading}` to the `<button>` so screen readers are informed when the button is in a loading state.
- Accept the native `aria-label` prop (`['aria-label']: ariaLabel`) and keep existing behavior for icons, spinner, and children.
- Add accessibility-focused unit tests in `core/components/atoms/button/__tests__/Button.test.tsx` and update snapshots to reflect the new attributes.

### Testing
- Ran `npm test -- Button --updateSnapshot` which passed and updated 8 snapshots for the Button tests.
- Ran `npm run lint:check` which passed.
- Ran `npm test` (full suite) which completed successfully (142 test suites, all passing).
- Ran `npm run prettier:check` which failed with `No parser and no file path given`.
- Ran `npm run lint:types` which failed due to existing TypeScript errors in `node_modules` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e510a7590832da16dd49716495b71)