### PR TITLE
test(badge): add accessibility tests for aria-label and role

### DIFF
--- a/core/components/atoms/badge/__tests__/Badge.test.tsx
+++ b/core/components/atoms/badge/__tests__/Badge.test.tsx
@@ -117,3 +117,23 @@ describe('Badge component hover event', () => {
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Badge component accessibility', () => {
+  it('supports aria-label for additional context', () => {
+    const { getByTestId } = render(
+      <Badge appearance="success" aria-label="Status: success">
+        Success
+      </Badge>
+    );
+    expect(getByTestId('DesignSystem-Badge')).toHaveAttribute('aria-label', 'Status: success');
+  });
+
+  it('allows passing a role attribute', () => {
+    const { getByTestId } = render(
+      <Badge appearance="warning" role="status">
+        Warning
+      </Badge>
+    );
+    expect(getByTestId('DesignSystem-Badge')).toHaveAttribute('role', 'status');
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure the `Badge` component forwards accessibility attributes so assistive technologies can read status/context from the rendered element.

### Description
- Added unit tests in `core/components/atoms/badge/__tests__/Badge.test.tsx` to assert that `aria-label` and `role` attributes are forwarded to the rendered badge element.

### Testing
- Ran `npm test -- Badge --updateSnapshot` which passed and exercised the new tests.
- Ran `npm run lint:check` which passed, while `npm run prettier:check` failed with "No parser and no file path given" and `npm run lint:types` failed due to TypeScript errors originating in `node_modules`.
- Ran full `npm test` which passed (all test suites succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697e510a7590832da16dd49716495b71)