### PR TITLE
feat(a11y): add accessibility improvements in components

### DIFF
--- a/.cursor/rules/vercel-a11y-guidelines.mdc
+++ b/.cursor/rules/vercel-a11y-guidelines.mdc
@@ -1,0 +1,153 @@
+---
+alwaysApply: true
+---
+
+Concise rules for building accessible, fast, delightful UIs. Use MUST/SHOULD/NEVER to guide decisions.
+
+## Interactions
+
+### Keyboard
+
+- MUST: Full keyboard support per [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/patterns/)
+- MUST: Visible focus rings (`:focus-visible`; group with `:focus-within`)
+- MUST: Manage focus (trap, move, return) per APG patterns
+- NEVER: `outline: none` without visible focus replacement
+
+### Targets & Input
+
+- MUST: Hit target ≥24px (mobile ≥44px); if visual <24px, expand hit area
+- MUST: Mobile `<input>` font-size ≥16px to prevent iOS zoom
+- NEVER: Disable browser zoom (`user-scalable=no`, `maximum-scale=1`)
+- MUST: `touch-action: manipulation` to prevent double-tap zoom
+- SHOULD: Set `-webkit-tap-highlight-color` to match design
+
+### Forms
+
+- MUST: Hydration-safe inputs (no lost focus/value)
+- NEVER: Block paste in `<input>`/`<textarea>`
+- MUST: Loading buttons show spinner and keep original label
+- MUST: Enter submits focused input; in `<textarea>`, ⌘/Ctrl+Enter submits
+- MUST: Keep submit enabled until request starts; then disable with spinner
+- MUST: Accept free text, validate after—don't block typing
+- MUST: Allow incomplete form submission to surface validation
+- MUST: Errors inline next to fields; on submit, focus first error
+- MUST: `autocomplete` + meaningful `name`; correct `type` and `inputmode`
+- SHOULD: Disable spellcheck for emails/codes/usernames
+- SHOULD: Placeholders end with `…` and show example pattern
+- MUST: Warn on unsaved changes before navigation
+- MUST: Compatible with password managers & 2FA; allow pasting codes
+- MUST: Trim values to handle text expansion trailing spaces
+- MUST: No dead zones on checkboxes/radios; label+control share one hit target
+
+### State & Navigation
+
+- MUST: URL reflects state (deep-link filters/tabs/pagination/expanded panels)
+- MUST: Back/Forward restores scroll position
+- MUST: Links use `<a>`/`<Link>` for navigation (support Cmd/Ctrl/middle-click)
+- NEVER: Use `<div onClick>` for navigation
+
+### Feedback
+
+- SHOULD: Optimistic UI; reconcile on response; on failure rollback or offer Undo
+- MUST: Confirm destructive actions or provide Undo window
+- MUST: Use polite `aria-live` for toasts/inline validation
+- SHOULD: Ellipsis (`…`) for options opening follow-ups ("Rename…") and loading states ("Loading…")
+
+### Touch & Drag
+
+- MUST: Generous targets, clear affordances; avoid finicky interactions
+- MUST: Delay first tooltip; subsequent peers instant
+- MUST: `overscroll-behavior: contain` in modals/drawers
+- MUST: During drag, disable text selection and set `inert` on dragged elements
+- MUST: If it looks clickable, it must be clickable
+
+### Autofocus
+
+- SHOULD: Autofocus on desktop with single primary input; rarely on mobile
+
+## Animation
+
+- MUST: Honor `prefers-reduced-motion` (provide reduced variant or disable)
+- SHOULD: Prefer CSS > Web Animations API > JS libraries
+- MUST: Animate compositor-friendly props (`transform`, `opacity`) only
+- NEVER: Animate layout props (`top`, `left`, `width`, `height`)
+- NEVER: `transition: all`—list properties explicitly
+- SHOULD: Animate only to clarify cause/effect or add deliberate delight
+- SHOULD: Choose easing to match the change (size/distance/trigger)
+- MUST: Animations interruptible and input-driven (no autoplay)
+- MUST: Correct `transform-origin` (motion starts where it "physically" should)
+- MUST: SVG transforms on `<g>` wrapper with `transform-box: fill-box`
+
+## Layout
+
+- SHOULD: Optical alignment; adjust ±1px when perception beats geometry
+- MUST: Deliberate alignment to grid/baseline/edges—no accidental placement
+- SHOULD: Balance icon/text lockups (weight/size/spacing/color)
+- MUST: Verify mobile, laptop, ultra-wide (simulate ultra-wide at 50% zoom)
+- MUST: Respect safe areas (`env(safe-area-inset-*)`)
+- MUST: Avoid unwanted scrollbars; fix overflows
+- SHOULD: Flex/grid over JS measurement for layout
+
+## Content & Accessibility
+
+- SHOULD: Inline help first; tooltips last resort
+- MUST: Skeletons mirror final content to avoid layout shift
+- MUST: `<title>` matches current context
+- MUST: No dead ends; always offer next step/recovery
+- MUST: Design empty/sparse/dense/error states
+- SHOULD: Curly quotes (" "); avoid widows/orphans (`text-wrap: balance`)
+- MUST: `font-variant-numeric: tabular-nums` for number comparisons
+- MUST: Redundant status cues (not color-only); icons have text labels
+- MUST: Accessible names exist even when visuals omit labels
+- MUST: Use `…` character (not `...`)
+- MUST: `scroll-margin-top` on headings; "Skip to content" link; hierarchical `<h1>`–`<h6>`
+- MUST: Resilient to user-generated content (short/avg/very long)
+- MUST: Locale-aware dates/times/numbers (`Intl.DateTimeFormat`, `Intl.NumberFormat`)
+- MUST: Accurate `aria-label`; decorative elements `aria-hidden`
+- MUST: Icon-only buttons have descriptive `aria-label`
+- MUST: Prefer native semantics (`button`, `a`, `label`, `table`) before ARIA
+- MUST: Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
+
+## Content Handling
+
+- MUST: Text containers handle long content (`truncate`, `line-clamp-*`, `break-words`)
+- MUST: Flex children need `min-w-0` to allow truncation
+- MUST: Handle empty states—no broken UI for empty strings/arrays
+
+## Performance
+
+- SHOULD: Test iOS Low Power Mode and macOS Safari
+- MUST: Measure reliably (disable extensions that skew runtime)
+- MUST: Track and minimize re-renders (React DevTools/React Scan)
+- MUST: Profile with CPU/network throttling
+- MUST: Batch layout reads/writes; avoid reflows/repaints
+- MUST: Mutations (`POST`/`PATCH`/`DELETE`) target <500ms
+- SHOULD: Prefer uncontrolled inputs; controlled inputs cheap per keystroke
+- MUST: Virtualize large lists (>50 items)
+- MUST: Preload above-fold images; lazy-load the rest
+- MUST: Prevent CLS (explicit image dimensions)
+- SHOULD: `<link rel="preconnect">` for CDN domains
+- SHOULD: Critical fonts: `<link rel="preload" as="font">` with `font-display: swap`
+
+## Dark Mode & Theming
+
+- MUST: `color-scheme: dark` on `<html>` for dark themes
+- SHOULD: `<meta name="theme-color">` matches page background
+- MUST: Native `<select>`: explicit `background-color` and `color` (Windows fix)
+
+## Hydration
+
+- MUST: Inputs with `value` need `onChange` (or use `defaultValue`)
+- SHOULD: Guard date/time rendering against hydration mismatch
+
+## Design
+
+- SHOULD: Layered shadows (ambient + direct)
+- SHOULD: Crisp edges via semi-transparent borders + shadows
+- SHOULD: Nested radii: child ≤ parent; concentric
+- SHOULD: Hue consistency: tint borders/shadows/text toward bg hue
+- MUST: Accessible charts (color-blind-friendly palettes)
+- MUST: Meet contrast—prefer [APCA](https://apcacontrast.com/) over WCAG 2
+- MUST: Increase contrast on `:hover`/`:active`/`:focus`
+- SHOULD: Match browser UI to bg
+- SHOULD: Avoid dark color gradient banding (use background images when needed)

--- a/.cursor/rules/wcag-a11y-audit-report.mdc
+++ b/.cursor/rules/wcag-a11y-audit-report.mdc
@@ -1,0 +1,104 @@
+---
+alwaysApply: true
+---
+
+Use these sources as the primary references:
+- [a11y-context/wcag-as-json.json](mdc:a11y-context/wcag-as-json.json) for the full WCAG 2.2 success criteria set.
+- [wcag-audit-patterns.md](mdc:.cursor/rules/wcag-audit-patterns.md) for audit methodology.
+- [vercel-a11y-guidelines.mdc](mdc:.cursor/rules/vercel-a11y-guidelines.mdc) and
+  [web-interface-a11y-guidelines.mdc](mdc:.cursor/rules/web-interface-a11y-guidelines.mdc)
+  for supporting accessibility guidance.
+
+## Objective
+Perform a comprehensive WCAG 2.2 AA audit across all UI components, starting from
+atomic components, and consolidate all findings and remediations into a single
+markdown report.
+
+## Strict Requirements
+- Do not skip any WCAG 2.2 AA success criterion.
+- Cross-reference related criteria and evaluate exceptions.
+- Never assume compliance or developer intent.
+- If a component composes other components, re-validate inherited risks.
+- Never stop early; complete the audit for all components.
+- When measurable validation is required (contrast, focus order, etc), generate
+  scripts in `/scripts/`, execute them, and use their outputs.
+
+## Per-Issue Minimum Fields
+Each issue must include:
+- WCAG SC ID
+- Problem statement
+- Why it violates the criterion
+- Code-level fix
+- Testing strategy
+
+## Per-Component Audit Prompt
+You are auditing a single UI component for WCAG 2.2 AA compliance.
+Component: `{{component_name}}`
+
+You must:
+1. Analyze source code.
+2. Identify:
+   - HTML structure
+   - ARIA usage
+   - Events
+   - States
+   - Keyboard interactions
+   - Visual styling
+   - Color tokens
+   - Touch targets
+   - Focus handling
+3. For each WCAG 2.2 AA success criterion:
+   - Evaluate applicability
+   - Check the full requirement
+   - Check exceptions
+   - Cross-reference related criteria
+   - Identify violations
+   - Provide remediation steps
+   - Provide example code fixes
+4. Generate programmatic validation when needed:
+   - Contrast calculation
+   - Focus order simulation
+   - Keyboard trap detection
+   - ARIA role validation
+5. Output structured markdown:
+
+# Component: {{component_name}}
+
+## Summary
+Compliance score:
+Risk level:
+
+## Success Criteria Audit
+
+### SC 1.4.3 Contrast (Minimum)
+
+Status:
+Issues:
+Fix:
+Code Example:
+(repeat for all criteria)
+
+## Cross-Criteria Risks
+## Required Refactors
+## Automated Tests To Add
+
+Be legally strict. Assume nothing. Cross-reference aggressively.
+
+## Mandatory Validation Checks
+- Treat WCAG as legal requirements.
+- Validate interactive states (hover, focus, active, disabled).
+- Validate keyboard-only navigation.
+- Validate screen reader semantics.
+- Validate touch target size (2.5.5 AA).
+- Validate focus visibility (2.4.7).
+- Validate drag alternatives (2.5.7).
+- Validate target size (2.5.8 if applicable).
+- Validate error handling (3.3.x).
+- Validate name/role/value (4.1.2).
+- Validate status messages (4.1.3).
+
+For any criterion that requires computation (e.g., color contrast), create a
+program, run it, and act on its output. Ensure the program is accurate or the
+audit results will be invalid.
+
+Continue until every component is audited and the report is complete.

--- a/.cursor/rules/wcag-audit-patterns.md
+++ b/.cursor/rules/wcag-audit-patterns.md
@@ -1,0 +1,555 @@
+---
+name: wcag-audit-patterns
+description: Conduct WCAG 2.2 accessibility audits with automated testing, manual verification, and remediation guidance. Use when auditing websites for accessibility, fixing WCAG violations, or implementing accessible design patterns.
+---
+
+# WCAG Audit Patterns
+
+Comprehensive guide to auditing web content against WCAG 2.2 guidelines with actionable remediation strategies.
+
+## When to Use This Skill
+
+- Conducting accessibility audits
+- Fixing WCAG violations
+- Implementing accessible components
+- Preparing for accessibility lawsuits
+- Meeting ADA/Section 508 requirements
+- Achieving VPAT compliance
+
+## Core Concepts
+
+### 1. WCAG Conformance Levels
+
+| Level   | Description            | Required For      |
+| ------- | ---------------------- | ----------------- |
+| **A**   | Minimum accessibility  | Legal baseline    |
+| **AA**  | Standard conformance   | Most regulations  |
+| **AAA** | Enhanced accessibility | Specialized needs |
+
+### 2. POUR Principles
+
+```
+Perceivable:  Can users perceive the content?
+Operable:     Can users operate the interface?
+Understandable: Can users understand the content?
+Robust:       Does it work with assistive tech?
+```
+
+### 3. Common Violations by Impact
+
+```
+Critical (Blockers):
+├── Missing alt text for functional images
+├── No keyboard access to interactive elements
+├── Missing form labels
+└── Auto-playing media without controls
+
+Serious:
+├── Insufficient color contrast
+├── Missing skip links
+├── Inaccessible custom widgets
+└── Missing page titles
+
+Moderate:
+├── Missing language attribute
+├── Unclear link text
+├── Missing landmarks
+└── Improper heading hierarchy
+```
+
+## Audit Checklist
+
+### Perceivable (Principle 1)
+
+````markdown
+## 1.1 Text Alternatives
+
+### 1.1.1 Non-text Content (Level A)
+
+- [ ] All images have alt text
+- [ ] Decorative images have alt=""
+- [ ] Complex images have long descriptions
+- [ ] Icons with meaning have accessible names
+- [ ] CAPTCHAs have alternatives
+
+Check:
+
+```html
+<!-- Good -->
+<img src="chart.png" alt="Sales increased 25% from Q1 to Q2" />
+<img src="decorative-line.png" alt="" />
+
+<!-- Bad -->
+<img src="chart.png" />
+<img src="decorative-line.png" alt="decorative line" />
+```
+````
+
+## 1.2 Time-based Media
+
+### 1.2.1 Audio-only and Video-only (Level A)
+
+- [ ] Audio has text transcript
+- [ ] Video has audio description or transcript
+
+### 1.2.2 Captions (Level A)
+
+- [ ] All video has synchronized captions
+- [ ] Captions are accurate and complete
+- [ ] Speaker identification included
+
+### 1.2.3 Audio Description (Level A)
+
+- [ ] Video has audio description for visual content
+
+## 1.3 Adaptable
+
+### 1.3.1 Info and Relationships (Level A)
+
+- [ ] Headings use proper tags (h1-h6)
+- [ ] Lists use ul/ol/dl
+- [ ] Tables have headers
+- [ ] Form inputs have labels
+- [ ] ARIA landmarks present
+
+Check:
+
+```html
+<!-- Heading hierarchy -->
+<h1>Page Title</h1>
+<h2>Section</h2>
+<h3>Subsection</h3>
+<h2>Another Section</h2>
+
+<!-- Table headers -->
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Price</th>
+    </tr>
+  </thead>
+</table>
+```
+
+### 1.3.2 Meaningful Sequence (Level A)
+
+- [ ] Reading order is logical
+- [ ] CSS positioning doesn't break order
+- [ ] Focus order matches visual order
+
+### 1.3.3 Sensory Characteristics (Level A)
+
+- [ ] Instructions don't rely on shape/color alone
+- [ ] "Click the red button" → "Click Submit (red button)"
+
+## 1.4 Distinguishable
+
+### 1.4.1 Use of Color (Level A)
+
+- [ ] Color is not only means of conveying info
+- [ ] Links distinguishable without color
+- [ ] Error states not color-only
+
+### 1.4.3 Contrast (Minimum) (Level AA)
+
+- [ ] Text: 4.5:1 contrast ratio
+- [ ] Large text (18pt+): 3:1 ratio
+- [ ] UI components: 3:1 ratio
+
+Tools: WebAIM Contrast Checker, axe DevTools
+
+### 1.4.4 Resize Text (Level AA)
+
+- [ ] Text resizes to 200% without loss
+- [ ] No horizontal scrolling at 320px
+- [ ] Content reflows properly
+
+### 1.4.10 Reflow (Level AA)
+
+- [ ] Content reflows at 400% zoom
+- [ ] No two-dimensional scrolling
+- [ ] All content accessible at 320px width
+
+### 1.4.11 Non-text Contrast (Level AA)
+
+- [ ] UI components have 3:1 contrast
+- [ ] Focus indicators visible
+- [ ] Graphical objects distinguishable
+
+### 1.4.12 Text Spacing (Level AA)
+
+- [ ] No content loss with increased spacing
+- [ ] Line height 1.5x font size
+- [ ] Paragraph spacing 2x font size
+- [ ] Letter spacing 0.12x font size
+- [ ] Word spacing 0.16x font size
+
+````
+
+### Operable (Principle 2)
+
+```markdown
+## 2.1 Keyboard Accessible
+
+### 2.1.1 Keyboard (Level A)
+- [ ] All functionality keyboard accessible
+- [ ] No keyboard traps
+- [ ] Tab order is logical
+- [ ] Custom widgets are keyboard operable
+
+Check:
+```javascript
+// Custom button must be keyboard accessible
+<div role="button" tabindex="0"
+     onkeydown="if(event.key === 'Enter' || event.key === ' ') activate()">
+````
+
+### 2.1.2 No Keyboard Trap (Level A)
+
+- [ ] Focus can move away from all components
+- [ ] Modal dialogs trap focus correctly
+- [ ] Focus returns after modal closes
+
+## 2.2 Enough Time
+
+### 2.2.1 Timing Adjustable (Level A)
+
+- [ ] Session timeouts can be extended
+- [ ] User warned before timeout
+- [ ] Option to disable auto-refresh
+
+### 2.2.2 Pause, Stop, Hide (Level A)
+
+- [ ] Moving content can be paused
+- [ ] Auto-updating content can be paused
+- [ ] Animations respect prefers-reduced-motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+```
+
+## 2.3 Seizures and Physical Reactions
+
+### 2.3.1 Three Flashes (Level A)
+
+- [ ] No content flashes more than 3 times/second
+- [ ] Flashing area is small (<25% viewport)
+
+## 2.4 Navigable
+
+### 2.4.1 Bypass Blocks (Level A)
+
+- [ ] Skip to main content link present
+- [ ] Landmark regions defined
+- [ ] Proper heading structure
+
+```html
+<a href="#main" class="skip-link">Skip to main content</a>
+<main id="main">...</main>
+```
+
+### 2.4.2 Page Titled (Level A)
+
+- [ ] Unique, descriptive page titles
+- [ ] Title reflects page content
+
+### 2.4.3 Focus Order (Level A)
+
+- [ ] Focus order matches visual order
+- [ ] tabindex used correctly
+
+### 2.4.4 Link Purpose (In Context) (Level A)
+
+- [ ] Links make sense out of context
+- [ ] No "click here" or "read more" alone
+
+```html
+<!-- Bad -->
+<a href="report.pdf">Click here</a>
+
+<!-- Good -->
+<a href="report.pdf">Download Q4 Sales Report (PDF)</a>
+```
+
+### 2.4.6 Headings and Labels (Level AA)
+
+- [ ] Headings describe content
+- [ ] Labels describe purpose
+
+### 2.4.7 Focus Visible (Level AA)
+
+- [ ] Focus indicator visible on all elements
+- [ ] Custom focus styles meet contrast
+
+```css
+:focus {
+  outline: 3px solid #005fcc;
+  outline-offset: 2px;
+}
+```
+
+### 2.4.11 Focus Not Obscured (Level AA) - WCAG 2.2
+
+- [ ] Focused element not fully hidden
+- [ ] Sticky headers don't obscure focus
+
+````
+
+### Understandable (Principle 3)
+
+```markdown
+## 3.1 Readable
+
+### 3.1.1 Language of Page (Level A)
+- [ ] HTML lang attribute set
+- [ ] Language correct for content
+
+```html
+<html lang="en">
+````
+
+### 3.1.2 Language of Parts (Level AA)
+
+- [ ] Language changes marked
+
+```html
+<p>The French word <span lang="fr">bonjour</span> means hello.</p>
+```
+
+## 3.2 Predictable
+
+### 3.2.1 On Focus (Level A)
+
+- [ ] No context change on focus alone
+- [ ] No unexpected popups on focus
+
+### 3.2.2 On Input (Level A)
+
+- [ ] No automatic form submission
+- [ ] User warned before context change
+
+### 3.2.3 Consistent Navigation (Level AA)
+
+- [ ] Navigation consistent across pages
+- [ ] Repeated components same order
+
+### 3.2.4 Consistent Identification (Level AA)
+
+- [ ] Same functionality = same label
+- [ ] Icons used consistently
+
+## 3.3 Input Assistance
+
+### 3.3.1 Error Identification (Level A)
+
+- [ ] Errors clearly identified
+- [ ] Error message describes problem
+- [ ] Error linked to field
+
+```html
+<input aria-describedby="email-error" aria-invalid="true" />
+<span id="email-error" role="alert">Please enter valid email</span>
+```
+
+### 3.3.2 Labels or Instructions (Level A)
+
+- [ ] All inputs have visible labels
+- [ ] Required fields indicated
+- [ ] Format hints provided
+
+### 3.3.3 Error Suggestion (Level AA)
+
+- [ ] Errors include correction suggestion
+- [ ] Suggestions are specific
+
+### 3.3.4 Error Prevention (Level AA)
+
+- [ ] Legal/financial forms reversible
+- [ ] Data checked before submission
+- [ ] User can review before submit
+
+````
+
+### Robust (Principle 4)
+
+```markdown
+## 4.1 Compatible
+
+### 4.1.1 Parsing (Level A) - Obsolete in WCAG 2.2
+- [ ] Valid HTML (good practice)
+- [ ] No duplicate IDs
+- [ ] Complete start/end tags
+
+### 4.1.2 Name, Role, Value (Level A)
+- [ ] Custom widgets have accessible names
+- [ ] ARIA roles correct
+- [ ] State changes announced
+
+```html
+<!-- Accessible custom checkbox -->
+<div role="checkbox"
+     aria-checked="false"
+     tabindex="0"
+     aria-labelledby="label">
+</div>
+<span id="label">Accept terms</span>
+````
+
+### 4.1.3 Status Messages (Level AA)
+
+- [ ] Status updates announced
+- [ ] Live regions used correctly
+
+```html
+<div role="status" aria-live="polite">3 items added to cart</div>
+
+<div role="alert" aria-live="assertive">Error: Form submission failed</div>
+```
+
+````
+
+## Automated Testing
+
+```javascript
+// axe-core integration
+const axe = require('axe-core');
+
+async function runAccessibilityAudit(page) {
+  await page.addScriptTag({ path: require.resolve('axe-core') });
+
+  const results = await page.evaluate(async () => {
+    return await axe.run(document, {
+      runOnly: {
+        type: 'tag',
+        values: ['wcag2a', 'wcag2aa', 'wcag21aa', 'wcag22aa']
+      }
+    });
+  });
+
+  return {
+    violations: results.violations,
+    passes: results.passes,
+    incomplete: results.incomplete
+  };
+}
+
+// Playwright test example
+test('should have no accessibility violations', async ({ page }) => {
+  await page.goto('/');
+  const results = await runAccessibilityAudit(page);
+
+  expect(results.violations).toHaveLength(0);
+});
+````
+
+```bash
+# CLI tools
+npx @axe-core/cli https://example.com
+npx pa11y https://example.com
+lighthouse https://example.com --only-categories=accessibility
+```
+
+## Remediation Patterns
+
+### Fix: Missing Form Labels
+
+```html
+<!-- Before -->
+<input type="email" placeholder="Email" />
+
+<!-- After: Option 1 - Visible label -->
+<label for="email">Email address</label>
+<input id="email" type="email" />
+
+<!-- After: Option 2 - aria-label -->
+<input type="email" aria-label="Email address" />
+
+<!-- After: Option 3 - aria-labelledby -->
+<span id="email-label">Email</span>
+<input type="email" aria-labelledby="email-label" />
+```
+
+### Fix: Insufficient Color Contrast
+
+```css
+/* Before: 2.5:1 contrast */
+.text {
+  color: #767676;
+}
+
+/* After: 4.5:1 contrast */
+.text {
+  color: #595959;
+}
+
+/* Or add background */
+.text {
+  color: #767676;
+  background: #000;
+}
+```
+
+### Fix: Keyboard Navigation
+
+```javascript
+// Make custom element keyboard accessible
+class AccessibleDropdown extends HTMLElement {
+  connectedCallback() {
+    this.setAttribute("tabindex", "0");
+    this.setAttribute("role", "combobox");
+    this.setAttribute("aria-expanded", "false");
+
+    this.addEventListener("keydown", (e) => {
+      switch (e.key) {
+        case "Enter":
+        case " ":
+          this.toggle();
+          e.preventDefault();
+          break;
+        case "Escape":
+          this.close();
+          break;
+        case "ArrowDown":
+          this.focusNext();
+          e.preventDefault();
+          break;
+        case "ArrowUp":
+          this.focusPrevious();
+          e.preventDefault();
+          break;
+      }
+    });
+  }
+}
+```
+
+## Best Practices
+
+### Do's
+
+- **Start early** - Accessibility from design phase
+- **Test with real users** - Disabled users provide best feedback
+- **Automate what you can** - 30-50% issues detectable
+- **Use semantic HTML** - Reduces ARIA needs
+- **Document patterns** - Build accessible component library
+
+### Don'ts
+
+- **Don't rely only on automated testing** - Manual testing required
+- **Don't use ARIA as first solution** - Native HTML first
+- **Don't hide focus outlines** - Keyboard users need them
+- **Don't disable zoom** - Users need to resize
+- **Don't use color alone** - Multiple indicators needed
+
+## Resources
+
+- [WCAG 2.2 Guidelines](https://www.w3.org/TR/WCAG22/)
+- [WebAIM](https://webaim.org/)
+- [A11y Project Checklist](https://www.a11yproject.com/checklist/)
+- [axe DevTools](https://www.deque.com/axe/)

--- a/.cursor/rules/web-interface-a11y-guidelines.mdc
+++ b/.cursor/rules/web-interface-a11y-guidelines.mdc
@@ -1,0 +1,177 @@
+---
+alwaysApply: true
+description: Review UI code for Vercel Web Interface Guidelines compliance
+---
+
+# Web Interface Guidelines
+
+Read files, check against rules below. Output concise but comprehensive—sacrifice grammar for brevity. High signal-to-noise.
+
+## Rules
+
+### Accessibility
+
+- Icon-only buttons need `aria-label`
+- Form controls need `<label>` or `aria-label`
+- Interactive elements need keyboard handlers (`onKeyDown`/`onKeyUp`)
+- `<button>` for actions, `<a>`/`<Link>` for navigation (not `<div onClick>`)
+- Images need `alt` (or `alt=""` if decorative)
+- Decorative icons need `aria-hidden="true"`
+- Async updates (toasts, validation) need `aria-live="polite"`
+- Use semantic HTML (`<button>`, `<a>`, `<label>`, `<table>`) before ARIA
+- Headings hierarchical `<h1>`–`<h6>`; include skip link for main content
+- `scroll-margin-top` on heading anchors
+
+### Focus States
+
+- Interactive elements need visible focus: `focus-visible:ring-*` or equivalent
+- Never `outline-none` / `outline: none` without focus replacement
+- Use `:focus-visible` over `:focus` (avoid focus ring on click)
+- Group focus with `:focus-within` for compound controls
+
+### Forms
+
+- Inputs need `autocomplete` and meaningful `name`
+- Use correct `type` (`email`, `tel`, `url`, `number`) and `inputmode`
+- Never block paste (`onPaste` + `preventDefault`)
+- Labels clickable (`htmlFor` or wrapping control)
+- Disable spellcheck on emails, codes, usernames (`spellCheck={false}`)
+- Checkboxes/radios: label + control share single hit target (no dead zones)
+- Submit button stays enabled until request starts; spinner during request
+- Errors inline next to fields; focus first error on submit
+- Placeholders end with `…` and show example pattern
+- `autocomplete="off"` on non-auth fields to avoid password manager triggers
+- Warn before navigation with unsaved changes (`beforeunload` or router guard)
+
+### Animation
+
+- Honor `prefers-reduced-motion` (provide reduced variant or disable)
+- Animate `transform`/`opacity` only (compositor-friendly)
+- Never `transition: all`—list properties explicitly
+- Set correct `transform-origin`
+- SVG: transforms on `<g>` wrapper with `transform-box: fill-box; transform-origin: center`
+- Animations interruptible—respond to user input mid-animation
+
+### Typography
+
+- `…` not `...`
+- Curly quotes `"` `"` not straight `"`
+- Non-breaking spaces: `10&nbsp;MB`, `⌘&nbsp;K`, brand names
+- Loading states end with `…`: `"Loading…"`, `"Saving…"`
+- `font-variant-numeric: tabular-nums` for number columns/comparisons
+- Use `text-wrap: balance` or `text-pretty` on headings (prevents widows)
+
+### Content Handling
+
+- Text containers handle long content: `truncate`, `line-clamp-*`, or `break-words`
+- Flex children need `min-w-0` to allow text truncation
+- Handle empty states—don't render broken UI for empty strings/arrays
+- User-generated content: anticipate short, average, and very long inputs
+
+### Images
+
+- `<img>` needs explicit `width` and `height` (prevents CLS)
+- Below-fold images: `loading="lazy"`
+- Above-fold critical images: `priority` or `fetchpriority="high"`
+
+### Performance
+
+- Large lists (>50 items): virtualize (`virtua`, `content-visibility: auto`)
+- No layout reads in render (`getBoundingClientRect`, `offsetHeight`, `offsetWidth`, `scrollTop`)
+- Batch DOM reads/writes; avoid interleaving
+- Prefer uncontrolled inputs; controlled inputs must be cheap per keystroke
+- Add `<link rel="preconnect">` for CDN/asset domains
+- Critical fonts: `<link rel="preload" as="font">` with `font-display: swap`
+
+### Navigation & State
+
+- URL reflects state—filters, tabs, pagination, expanded panels in query params
+- Links use `<a>`/`<Link>` (Cmd/Ctrl+click, middle-click support)
+- Deep-link all stateful UI (if uses `useState`, consider URL sync via nuqs or similar)
+- Destructive actions need confirmation modal or undo window—never immediate
+
+### Touch & Interaction
+
+- `touch-action: manipulation` (prevents double-tap zoom delay)
+- `-webkit-tap-highlight-color` set intentionally
+- `overscroll-behavior: contain` in modals/drawers/sheets
+- During drag: disable text selection, `inert` on dragged elements
+- `autoFocus` sparingly—desktop only, single primary input; avoid on mobile
+
+### Safe Areas & Layout
+
+- Full-bleed layouts need `env(safe-area-inset-*)` for notches
+- Avoid unwanted scrollbars: `overflow-x-hidden` on containers, fix content overflow
+- Flex/grid over JS measurement for layout
+
+### Dark Mode & Theming
+
+- `color-scheme: dark` on `<html>` for dark themes (fixes scrollbar, inputs)
+- `<meta name="theme-color">` matches page background
+- Native `<select>`: explicit `background-color` and `color` (Windows dark mode)
+
+### Locale & i18n
+
+- Dates/times: use `Intl.DateTimeFormat` not hardcoded formats
+- Numbers/currency: use `Intl.NumberFormat` not hardcoded formats
+- Detect language via `Accept-Language` / `navigator.languages`, not IP
+
+### Hydration Safety
+
+- Inputs with `value` need `onChange` (or use `defaultValue` for uncontrolled)
+- Date/time rendering: guard against hydration mismatch (server vs client)
+- `suppressHydrationWarning` only where truly needed
+
+### Hover & Interactive States
+
+- Buttons/links need `hover:` state (visual feedback)
+- Interactive states increase contrast: hover/active/focus more prominent than rest
+
+### Content & Copy
+
+- Active voice: "Install the CLI" not "The CLI will be installed"
+- Title Case for headings/buttons (Chicago style)
+- Numerals for counts: "8 deployments" not "eight"
+- Specific button labels: "Save API Key" not "Continue"
+- Error messages include fix/next step, not just problem
+- Second person; avoid first person
+- `&` over "and" where space-constrained
+
+### Anti-patterns (flag these)
+
+- `user-scalable=no` or `maximum-scale=1` disabling zoom
+- `onPaste` with `preventDefault`
+- `transition: all`
+- `outline-none` without focus-visible replacement
+- Inline `onClick` navigation without `<a>`
+- `<div>` or `<span>` with click handlers (should be `<button>`)
+- Images without dimensions
+- Large arrays `.map()` without virtualization
+- Form inputs without labels
+- Icon buttons without `aria-label`
+- Hardcoded date/number formats (use `Intl.*`)
+- `autoFocus` without clear justification
+
+## Output Format
+
+Group by file. Use `file:line` format (VS Code clickable). Terse findings.
+
+```text
+## src/Button.tsx
+
+src/Button.tsx:42 - icon button missing aria-label
+src/Button.tsx:18 - input lacks label
+src/Button.tsx:55 - animation missing prefers-reduced-motion
+src/Button.tsx:67 - transition: all → list properties
+
+## src/Modal.tsx
+
+src/Modal.tsx:12 - missing overscroll-behavior: contain
+src/Modal.tsx:34 - "..." → "…"
+
+## src/Card.tsx
+
+✓ pass
+```
+
+State issue + location. Skip explanation unless fix non-obvious. No preamble.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
     "jsx-no-lambda": "off",
     "jsx-no-bind": "off",
     "no-empty": "off",
+    "jsx-a11y/no-autofocus": "off",
     "no-duplicate-imports": "error",
     "no-restricted-imports": "off",
     "no-bitwise": "off",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ ___
 - Ensure components meet WCAG 2.0 AA.
 - Verify keyboard navigation, color contrast, and ARIA attributes.
 - Resolve any `jsx-a11y` lint warnings.
+- **A11y references:** See `a11y-context/README.md`.
 
 ---
 

--- a/a11y-context/README.md
+++ b/a11y-context/README.md
@@ -1,0 +1,9 @@
+# Accessibility References
+
+This index lists the accessibility rules and source data used in this repo.
+
+## Primary references
+- Audit process: `.cursor/rules/wcag-a11y-audit-report.mdc`
+- Audit patterns: `.cursor/rules/wcag-audit-patterns.md`
+- Guidelines: `.cursor/rules/vercel-a11y-guidelines.mdc`, `.cursor/rules/web-interface-a11y-guidelines.mdc`
+- WCAG source data: `a11y-context/wcag-as-json.json`

--- a/a11y-context/wcag-as-json.json
+++ b/a11y-context/wcag-as-json.json
@@ -1,0 +1,2472 @@
+[
+    {
+        "ref_id": "1",
+        "title": "Perceivable",
+        "description": "Information and user interface components must be presentable to users in ways they can perceive.",
+        "url": "https://www.w3.org/TR/WCAG22/#perceivable",
+        "guidelines": [
+            {
+                "ref_id": "1.1",
+                "title": "Text Alternatives",
+                "description": "Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.",
+                "url": "https://www.w3.org/TR/WCAG22/#text-alternatives",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 1.1",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/text-alternatives.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "1.1.1",
+                        "title": "Non-text Content",
+                        "description": "All non-text content that is presented to the user has a text alternative that serves the equivalent purpose, except for the situations listed below.",
+                        "url": "https://www.w3.org/TR/WCAG22/#non-text-content",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Controls, Input",
+                                "description": "If non-text content is a control or accepts user input, then it has a name that describes its purpose. (Refer to Guideline 4.1 for additional requirements for controls and content that accepts user input.)"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Time-based Media",
+                                "description": "If non-text content is time-based media, then text alternatives at least provide descriptive identification of the non-text content. (Refer to Guideline 1.2 for additional requirements for media.)"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Test",
+                                "description": "If non-text content is a test or exercise that would be invalid if presented in text, then text alternatives at least provide descriptive identification of the non-text content."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Sensory",
+                                "description": "If non-text content is primarily intended to create a specific sensory experience, then text alternatives at least provide descriptive identification of the non-text content."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "CAPTCHA",
+                                "description": "If the purpose of non-text content is to confirm that content is being accessed by a person rather than a computer, then text alternatives that identify and describe the purpose of the non-text content are provided, and alternative forms of CAPTCHA using output modes for different types of sensory perception are provided to accommodate different disabilities."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Decoration, Formatting, Invisible",
+                                "description": "If non-text content is pure decoration, is used only for visual formatting, or is not presented to users, then it is implemented in a way that it can be ignored by assistive technology."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#non-text-content"
+                            },
+                            {
+                                "title": "Understanding 1.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "1.2",
+                "title": "Time-based Media",
+                "description": "Provide alternatives for time-based media.",
+                "url": "https://www.w3.org/TR/WCAG22/#time-based-media",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 1.2",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/time-based-media.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "1.2.1",
+                        "title": "Audio-only and Video-only (Prerecorded)",
+                        "description": "For prerecorded audio-only and prerecorded video-only media, the following are true, except when the audio or video is a media alternative for text and is clearly labeled as such.",
+                        "url": "https://www.w3.org/TR/WCAG22/#audio-only-and-video-only-prerecorded",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "Prerecorded Audio-only",
+                                "description": "An alternative for time-based media is provided that presents equivalent information for prerecorded audio-only content."
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Prerecorded Video-only",
+                                "description": "Either an alternative for time-based media or an audio track is provided that presents equivalent information for prerecorded video-only content."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#audio-only-and-video-only-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/audio-only-and-video-only-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.2",
+                        "title": "Captions (Prerecorded)",
+                        "description": "Captions are provided for all prerecorded audio content in synchronized media, except when the media is a media alternative for text and is clearly labeled as such.",
+                        "url": "https://www.w3.org/TR/WCAG22/#captions-prerecorded",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#captions-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/captions-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.3",
+                        "title": "Audio Description or Media Alternative (Prerecorded)",
+                        "description": "An alternative for time-based media or audio description of the prerecorded video content is provided for synchronized media, except when the media is a media alternative for text and is clearly labeled as such.",
+                        "url": "https://www.w3.org/TR/WCAG22/#audio-description-or-media-alternative-prerecorded",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#audio-description-or-media-alternative-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/audio-description-or-media-alternative-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.4",
+                        "title": "Captions (Live)",
+                        "description": "Captions are provided for all live audio content in synchronized media.",
+                        "url": "https://www.w3.org/TR/WCAG22/#captions-live",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/captions-live.html"
+                            },
+                            {
+                                "title": "Understanding 1.2.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/captions-live.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.5",
+                        "title": "Audio Description (Prerecorded)",
+                        "description": "Audio description is provided for all prerecorded video content in synchronized media.",
+                        "url": "https://www.w3.org/TR/WCAG22/#audio-description-prerecorded",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#audio-description-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/audio-description-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.6",
+                        "title": "Sign Language (Prerecorded)",
+                        "description": "Sign language interpretation is provided for all prerecorded audio content in synchronized media.",
+                        "url": "https://www.w3.org/TR/WCAG22/#sign-language-prerecorded",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#sign-language-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/sign-language-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.7",
+                        "title": "Extended Audio Description (Prerecorded)",
+                        "description": "Where pauses in foreground audio are insufficient to allow audio descriptions to convey the sense of the video, extended audio description is provided for all prerecorded video content in synchronized media.",
+                        "url": "https://www.w3.org/TR/WCAG22/#extended-audio-description-prerecorded",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#extended-audio-description-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/extended-audio-description-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.8",
+                        "title": "Media Alternative (Prerecorded)",
+                        "description": "An alternative for time-based media is provided for all prerecorded synchronized media and for all prerecorded video-only media.",
+                        "url": "https://www.w3.org/TR/WCAG22/#media-alternative-prerecorded",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#media-alternative-prerecorded"
+                            },
+                            {
+                                "title": "Understanding 1.2.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/media-alternative-prerecorded.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.2.9",
+                        "title": "Audio-only (Live)",
+                        "description": " An alternative for time-based media that presents equivalent information for live audio-only content is provided.",
+                        "url": "https://www.w3.org/TR/WCAG22/#audio-only-live",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.2.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#audio-only-live"
+                            },
+                            {
+                                "title": "Understanding 1.2.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/audio-only-live.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "1.3",
+                "title": "Adaptable",
+                "description": "Create content that can be presented in different ways (for example simpler layout) without losing information or structure.",
+                "url": "https://www.w3.org/TR/WCAG22/#adaptable",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 1.3",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/adaptable.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "1.3.1",
+                        "title": "Info and Relationships",
+                        "description": "Information, structure, and relationships conveyed through presentation can be programmatically determined or are available in text.",
+                        "url": "https://www.w3.org/TR/WCAG22/#info-and-relationships",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.3.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#info-and-relationships"
+                            },
+                            {
+                                "title": "Understanding 1.3.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.3.2",
+                        "title": "Meaningful Sequence",
+                        "description": "When the sequence in which content is presented affects its meaning, a correct reading sequence can be programmatically determined.",
+                        "url": "https://www.w3.org/TR/WCAG22/#meaningful-sequence",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.3.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#meaningful-sequence"
+                            },
+                            {
+                                "title": "Understanding 1.3.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/meaningful-sequence.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.3.3",
+                        "title": "Sensory Characteristics",
+                        "description": "Instructions provided for understanding and operating content do not rely solely on sensory characteristics of components such as shape, size, visual location, orientation, or sound.",
+                        "url": "https://www.w3.org/TR/WCAG22/#sensory-characteristics",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "For requirements related to color, refer to Guideline 1.4."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.3.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#sensory-characteristics"
+                            },
+                            {
+                                "title": "Understanding 1.3.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/sensory-characteristics.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.3.4",
+                        "title": "Orientation",
+                        "description": "Content does not restrict its view and operation to a single display orientation, such as portrait or landscape, unless a specific display orientation is essential.",
+                        "url": "https://www.w3.org/TR/WCAG22/#orientation",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Examples where a particular display orientation may be essential are a bank check, a piano application, slides for a projector or television, or virtual reality content where binary display orientation is not applicable."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.3.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#orientation"
+                            },
+                            {
+                                "title": "Understanding 1.3.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/orientation.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.3.5",
+                        "title": "Identify Input Purpose",
+                        "description": "The purpose of each input field collecting information about the user can be programmatically determined when:",
+                        "url": "https://www.w3.org/TR/WCAG22/#identify-input-purpose",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "The input field serves a purpose identified in the Input Purposes for User Interface Components section; and"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "The content is implemented using technologies with support for identifying the expected meaning for form input data."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.3.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#identify-input-purpose"
+                            },
+                            {
+                                "title": "Understanding 1.3.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.3.6",
+                        "title": "Identify Purpose",
+                        "description": "In content implemented using markup languages, the purpose of User Interface Components, icons, and regions can be programmatically determined.",
+                        "url": "https://www.w3.org/TR/WCAG22/#identify-purpose",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.3.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#identify-purpose"
+                            },
+                            {
+                                "title": "Understanding 1.3.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/identify-purpose.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "1.4",
+                "title": "Distinguishable",
+                "description": "Make it easier for users to see and hear content including separating foreground from background.",
+                "url": "https://www.w3.org/TR/WCAG22/#distinguishable",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 1.4",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/distinguishable.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "1.4.1",
+                        "title": "Use of Color",
+                        "description": "Color is not used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.",
+                        "url": "https://www.w3.org/TR/WCAG22/#use-of-color",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "This success criterion addresses color perception specifically. Other forms of perception are covered in Guideline 1.3 including programmatic access to color and other visual presentation coding."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#use-of-color"
+                            },
+                            {
+                                "title": "Understanding 1.4.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.2",
+                        "title": "Audio Control",
+                        "description": "If any audio on a Web page plays automatically for more than 3 seconds, either a mechanism is available to pause or stop the audio, or a mechanism is available to control audio volume independently from the overall system volume level.",
+                        "url": "https://www.w3.org/TR/WCAG22/#audio-control",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the Web page (whether or not it is used to meet other success criteria) must meet this success criterion. See Conformance Requirement 5: Non-Interference. (https://www.w3.org/TR/WCAG22/#cc5)"
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#audio-control"
+                            },
+                            {
+                                "title": "Understanding 1.4.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/audio-control.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.3",
+                        "title": "Contrast (Minimum)",
+                        "description": " The visual presentation of text and images of text has a contrast ratio of at least 4.5:1, except for the following:",
+                        "url": "https://www.w3.org/TR/WCAG22/#contrast-minimum",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Large Text",
+                                "description": "Large-scale text and images of large-scale text have a contrast ratio of at least 3:1;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Incidental",
+                                "description": "Text or images of text that are part of an inactive user interface component, that are pure decoration, that are not visible to anyone, or that are part of a picture that contains significant other visual content, have no contrast requirement."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Logotypes",
+                                "description": "Text that is part of a logo or brand name has no minimum contrast requirement."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#contrast-minimum"
+                            },
+                            {
+                                "title": "Understanding 1.4.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.4",
+                        "title": "Resize text",
+                        "description": "Except for captions and images of text, text can be resized without assistive technology up to 200 percent without loss of content or functionality.",
+                        "url": "https://www.w3.org/TR/WCAG22/#resize-text",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#resize-text"
+                            },
+                            {
+                                "title": "Understanding 1.4.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.5",
+                        "title": "Images of Text",
+                        "description": "If the technologies being used can achieve the visual presentation, text is used to convey information rather than images of text except for the following:",
+                        "url": "https://www.w3.org/TR/WCAG22/#images-of-text",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Customizable",
+                                "description": "The image of text can be visually customized to the user's requirements;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Essential",
+                                "description": "A particular presentation of text is essential to the information being conveyed."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "Logotypes (text that is part of a logo or brand name) are considered essential."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#images-of-text"
+                            },
+                            {
+                                "title": "Understanding 1.4.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/images-of-text.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.6",
+                        "title": "Contrast (Enhanced)",
+                        "description": "The visual presentation of text and images of text has a contrast ratio of at least 7:1, except for the following: ",
+                        "url": "https://www.w3.org/TR/WCAG22/#contrast-enhanced",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Large Text",
+                                "description": "Large-scale text and images of large-scale text have a contrast ratio of at least 4.5:1;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Incidental",
+                                "description": "Text or images of text that are part of an inactive user interface component, that are pure decoration, that are not visible to anyone, or that are part of a picture that contains significant other visual content, have no contrast requirement."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Logotypes",
+                                "description": "Text that is part of a logo or brand name has no minimum contrast requirement."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#contrast-enhanced"
+                            },
+                            {
+                                "title": "Understanding 1.4.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/contrast-enhanced.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.7",
+                        "title": "Low or No Background Audio",
+                        "description": "For prerecorded audio-only content that (1) contains primarily speech in the foreground, (2) is not an audio CAPTCHA or audio logo, and (3) is not vocalization intended to be primarily musical expression such as singing or rapping, at least one of the following is true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#low-or-no-background-audio",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "No Background",
+                                "description": "The audio does not contain background sounds."
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Turn Off",
+                                "description": "The background sounds can be turned off."
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "20 dB",
+                                "description": "The background sounds are at least 20 decibels lower than the foreground speech content, with the exception of occasional sounds that last for only one or two seconds."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "Per the definition of 'decibel,' background sound that meets this requirement will be approximately four times quieter than the foreground speech content."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#low-or-no-background-audio"
+                            },
+                            {
+                                "title": "Understanding 1.4.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/low-or-no-background-audio.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.8",
+                        "title": "Visual Presentation",
+                        "description": "For the visual presentation of blocks of text, a mechanism is available to achieve the following:",
+                        "url": "https://www.w3.org/TR/WCAG22/#visual-presentation",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "Foreground and background colors can be selected by the user."
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Width is no more than 80 characters or glyphs (40 if CJK)."
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Text is not justified (aligned to both the left and the right margins)."
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Line spacing (leading) is at least space-and-a-half within paragraphs, and paragraph spacing is at least 1.5 times larger than the line spacing."
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Text can be resized without assistive technology up to 200 percent in a way that does not require the user to scroll horizontally to read a line of text on a full-screen window."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#visual-presentation"
+                            },
+                            {
+                                "title": "Understanding 1.4.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/visual-presentation.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.9",
+                        "title": "Images of Text (No Exception)",
+                        "description": "Images of text are only used for pure decoration or where a particular presentation of text is essential to the information being conveyed.",
+                        "url": "https://www.w3.org/TR/WCAG22/#images-of-text-no-exception",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Logotypes (text that is part of a logo or brand name) are considered essential."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#images-of-text-no-exception"
+                            },
+                            {
+                                "title": "Understanding 1.4.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/images-of-text-no-exception.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.10",
+                        "title": "Reflow",
+                        "description": "Content can be presented without loss of information or functionality, and without requiring scrolling in two dimensions for:",
+                        "url": "https://www.w3.org/TR/WCAG22/#reflow",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "Vertical scrolling content at a width equivalent to 320 CSS pixels;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Horizontal scrolling content at a height equivalent to 256 CSS pixels."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Except for parts of the content which require two-dimensional layout for usage or meaning."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "Note: 320 CSS pixels is equivalent to a starting viewport width of 1280 CSS pixels wide at 400% zoom. For web content which are designed to scroll horizontally (e.g. with vertical text), the 256 CSS pixels is equivalent to a starting viewport height of 1024px at 400% zoom."
+                            },
+                            {
+                                "content": "Examples of content which require two-dimensional layout are images, maps, diagrams, video, games, presentations, data tables, and interfaces where it is necessary to keep toolbars in view while manipulating content."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.10",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#reflow"
+                            },
+                            {
+                                "title": "Understanding 1.4.10",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/reflow.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.11",
+                        "title": "Non-text Contrast",
+                        "description": "The visual presentation of the following have a contrast ratio of at least 3:1 against adjacent color(s):",
+                        "url": "https://www.w3.org/TR/WCAG22/#non-text-contrast",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "User Interface Components",
+                                "description": "Visual information required to identify user interface components and states, except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Graphical Objects",
+                                "description": "Parts of graphics required to understand the content, except when a particular presentation of graphics is essential to the information being conveyed."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.11",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#non-text-contrast"
+                            },
+                            {
+                                "title": "Understanding 1.4.11",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.12",
+                        "title": "Text Spacing",
+                        "description": "In content implemented using markup languages that support the following text style properties, no loss of content or functionality occurs by setting all of the following and by changing no other style property:",
+                        "url": "https://www.w3.org/TR/WCAG22/#text-spacing",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "Line height (line spacing) to at least 1.5 times the font size;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Spacing following paragraphs to at least 2 times the font size;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Letter spacing (tracking) to at least 0.12 times the font size;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Word spacing to at least 0.16 times the font size."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Exception: Human languages and scripts that do not make use of one or more of these text style properties in written text can conform using only the properties that exist for that combination of language and script."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.12",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#text-spacing"
+                            },
+                            {
+                                "title": "Understanding 1.4.12",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/text-spacing.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "1.4.13",
+                        "title": "Content on Hover or Focus",
+                        "description": "Where receiving and then removing pointer hover or keyboard focus triggers additional content to become visible and then hidden, the following are true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#content-on-hover-or-focus",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "Dismissable",
+                                "description": "A mechanism is available to dismiss the additional content without moving pointer hover or keyboard focus, unless the additional content communicates an input error or does not obscure or replace other content;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Hoverable",
+                                "description": "If pointer hover can trigger the additional content, then the pointer can be moved over the additional content without the additional content disappearing;"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Persistent",
+                                "description": "The additional content remains visible until the hover or focus trigger is removed, the user dismisses it, or its information is no longer valid."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Exception: The visual presentation of the additional content is controlled by the user agent and is not modified by the author."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "Examples of additional content controlled by the user agent include browser tooltips created through use of the HTML title attribute."
+                            },
+                            {
+                                "content": "Custom tooltips, sub-menus, and other nonmodal popups that display on hover and focus are examples of additional content covered by this criterion."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 1.4.13",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#content-on-hover-or-focus"
+                            },
+                            {
+                                "title": "Understanding 1.4.13",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "ref_id": "2",
+        "title": "Operable",
+        "description": "User interface components and navigation must be operable.",
+        "url": "https://www.w3.org/TR/WCAG22/#operable",
+        "guidelines": [
+            {
+                "ref_id": "2.1",
+                "title": "Keyboard Accessible",
+                "description": "Make all functionality available from a keyboard.",
+                "url": "https://www.w3.org/TR/WCAG22/#keyboard-accessible",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 2.1",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/keyboard-accessible.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "2.1.1",
+                        "title": "Keyboard",
+                        "description": "All functionality of the content is operable through a keyboard interface without requiring specific timings for individual keystrokes, except where the underlying function requires input that depends on the path of the user's movement and not just the endpoints.",
+                        "url": "https://www.w3.org/TR/WCAG22/#keyboard",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "This exception relates to the underlying function, not the input technique. For example, if using handwriting to enter text, the input technique (handwriting) requires path-dependent input but the underlying function (text input) does not."
+                            },
+                            {
+                                "content": "This does not forbid and should not discourage providing mouse input or other input methods in addition to keyboard operation."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#keyboard"
+                            },
+                            {
+                                "title": "Understanding 2.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.1.2",
+                        "title": "No Keyboard Trap",
+                        "description": "If keyboard focus can be moved to a component of the page using a keyboard interface, then focus can be moved away from that component using only a keyboard interface, and, if it requires more than unmodified arrow or tab keys or other standard exit methods, the user is advised of the method for moving focus away.",
+                        "url": "https://www.w3.org/TR/WCAG22/#no-keyboard-trap",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the Web page (whether it is used to meet other success criteria or not) must meet this success criterion. See Conformance Requirement 5: Non-Interference. (https://www.w3.org/TR/WCAG22/#cc5)"
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.1.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#no-keyboard-trap"
+                            },
+                            {
+                                "title": "Understanding 2.1.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/no-keyboard-trap.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.1.3",
+                        "title": "Keyboard (No Exception)",
+                        "description": "All functionality of the content is operable through a keyboard interface without requiring specific timings for individual keystrokes.",
+                        "url": "https://www.w3.org/TR/WCAG22/#keyboard-no-exception",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.1.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#keyboard-no-exception"
+                            },
+                            {
+                                "title": "Understanding 2.1.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/keyboard-no-exception.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.1.4",
+                        "title": "Character Key Shortcuts",
+                        "description": "If a keyboard shortcut is implemented in content using only letter (including upper- and lower-case letters), punctuation, number, or symbol characters, then at least one of the following is true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#character-key-shortcuts",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "Turn off",
+                                "description": "A mechanism is available to turn the shortcut off;"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Remap",
+                                "description": "A mechanism is available to remap the shortcut to use one or more non-printable keyboard characters (e.g. Ctrl, Alt, etc);"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Active only on focus",
+                                "description": "The keyboard shortcut for a user interface component is only active when that component has focus."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.1.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#character-key-shortcuts"
+                            },
+                            {
+                                "title": "Understanding 2.1.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/character-key-shortcuts.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "2.2",
+                "title": "Enough Time",
+                "description": "Provide users enough time to read and use content.",
+                "url": "https://www.w3.org/TR/WCAG22/#enough-time",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 2.2",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/enough-time.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "2.2.1",
+                        "title": "Timing Adjustable",
+                        "description": "For each time limit that is set by the content, at least one of the following is true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#timing-adjustable",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "Turn off",
+                                "description": "The user is allowed to turn off the time limit before encountering it; or"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Adjust",
+                                "description": "The user is allowed to adjust the time limit before encountering it over a wide range that is at least ten times the length of the default setting; or"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Extend",
+                                "description": "The user is warned before time expires and given at least 20 seconds to extend the time limit with a simple action (for example, 'press the space bar'), and the user is allowed to extend the time limit at least ten times; or"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Real-time Exception",
+                                "description": "The time limit is a required part of a real-time event (for example, an auction), and no alternative to the time limit is possible; or"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Essential Exception",
+                                "description": "The time limit is essential and extending it would invalidate the activity; or"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "20 Hour Exception",
+                                "description": "The time limit is longer than 20 hours."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "This success criterion helps ensure that users can complete tasks without unexpected changes in content or context that are a result of a time limit. This success criterion should be considered in conjunction with Success Criterion 3.2.1 (https://www.w3.org/TR/WCAG22/#on-focus), which puts limits on changes of content or context as a result of user action."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.2.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#timing-adjustable"
+                            },
+                            {
+                                "title": "Understanding 2.2.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/timing-adjustable.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.2.2",
+                        "title": "Pause, Stop, Hide",
+                        "description": "For moving, blinking, scrolling, or auto-updating information, all of the following are true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#pause-stop-hide",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "Moving, blinking, scrolling",
+                                "description": "For any moving, blinking or scrolling information that (1) starts automatically, (2) lasts more than five seconds, and (3) is presented in parallel with other content, there is a mechanism for the user to pause, stop, or hide it unless the movement, blinking, or scrolling is part of an activity where it is essential; and"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "Auto-updating",
+                                "description": "For any auto-updating information that (1) starts automatically and (2) is presented in parallel with other content, there is a mechanism for the user to pause, stop, or hide it or to control the frequency of the update unless the auto-updating is part of an activity where it is essential."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "For requirements related to flickering or flashing content, refer to Guideline 2.3. (https://www.w3.org/TR/WCAG22/#seizures-and-physical-reactions)"
+                            },
+                            {
+                                "content": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the Web page (whether it is used to meet other success criteria or not) must meet this success criterion. See Conformance Requirement 5: Non-Interference (https://www.w3.org/TR/WCAG22/#cc5)"
+                            },
+                            {
+                                "content": "Content that is updated periodically by software or that is streamed to the user agent is not required to preserve or present information that is generated or received between the initiation of the pause and resuming presentation, as this may not be technically possible, and in many situations could be misleading to do so."
+                            },
+                            {
+                                "content": "An animation that occurs as part of a preload phase or similar situation can be considered essential if interaction cannot occur during that phase for all users and if not indicating progress could confuse users or cause them to think that content was frozen or broken."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.2.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#pause-stop-hide"
+                            },
+                            {
+                                "title": "Understanding 2.2.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.2.3",
+                        "title": "No Timing",
+                        "description": "Timing is not an essential part of the event or activity presented by the content, except for non-interactive synchronized media and real-time events.",
+                        "url": "https://www.w3.org/TR/WCAG22/#no-timing",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.2.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#no-timing"
+                            },
+                            {
+                                "title": "Understanding 2.2.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/no-timing.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.2.4",
+                        "title": "Interruptions",
+                        "description": "Interruptions can be postponed or suppressed by the user, except interruptions involving an emergency.",
+                        "url": "https://www.w3.org/TR/WCAG22/#interruptions",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.2.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#interruptions"
+                            },
+                            {
+                                "title": "Understanding 2.2.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/interruptions.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.2.5",
+                        "title": "Re-authenticating",
+                        "description": "When an authenticated session expires, the user can continue the activity without loss of data after re-authenticating.",
+                        "url": "https://www.w3.org/TR/WCAG22/#re-authenticating",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.2.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#re-authenticating"
+                            },
+                            {
+                                "title": "Understanding 2.2.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/re-authenticating.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.2.6",
+                        "title": "Timeouts",
+                        "description": "Users are warned of the duration of any user inactivity that could cause data loss, unless the data is preserved for more than 20 hours when the user does not take any actions.",
+                        "url": "https://www.w3.org/TR/WCAG22/#timeouts",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Privacy regulations may require explicit user consent before user identification has been authenticated and before user data is preserved. In cases where the user is a minor, explicit consent may not be solicited in most jurisdictions, countries or regions. Consultation with privacy professionals and legal counsel is advised when considering data preservation as an approach to satisfy this success criterion."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.2.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#timeouts"
+                            },
+                            {
+                                "title": "Understanding 2.2.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/timeouts.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "2.3",
+                "title": "Seizures",
+                "description": "Do not design content in a way that is known to cause seizures.",
+                "url": "https://www.w3.org/TR/WCAG22/#seizures-and-physical-reactions",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 2.3",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/seizures-and-physical-reactions.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "2.3.1",
+                        "title": "Three Flashes or Below Threshold",
+                        "description": "Web pages do not contain anything that flashes more than three times in any one second period, or the flash is below the general flash and red flash thresholds.",
+                        "url": "https://www.w3.org/TR/WCAG22/#three-flashes-or-below-threshold",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Since any content that does not meet this success criterion can interfere with a user's ability to use the whole page, all content on the Web page (whether it is used to meet other success criteria or not) must meet this success criterion. See Conformance Requirement 5: Non-Interference. (https://www.w3.org/TR/WCAG22/#cc5)"
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.3.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#three-flashes-or-below-threshold"
+                            },
+                            {
+                                "title": "Understanding 2.3.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/three-flashes-or-below-threshold.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.3.2",
+                        "title": "Three Flashes",
+                        "description": "Web pages do not contain anything that flashes more than three times in any one second period.",
+                        "url": "https://www.w3.org/TR/WCAG22/#three-flashes",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.3.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#three-flashes"
+                            },
+                            {
+                                "title": "Understanding 2.3.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/three-flashes.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.3.3",
+                        "title": "Animation from Interactions",
+                        "description": "Motion animation triggered by interaction can be disabled, unless the animation is essential to the functionality or the information being conveyed.",
+                        "url": "https://www.w3.org/TR/WCAG22/#animation-from-interactions",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.3.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#animation-from-interactions"
+                            },
+                            {
+                                "title": "Understanding 2.3.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "2.4",
+                "title": "Navigable",
+                "description": "Provide ways to help users navigate, find content, and determine where they are.",
+                "url": "https://www.w3.org/TR/WCAG22/#navigable",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 2.4",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/navigable.html"
+                    }
+                ],
+                "success_criteria": [
+                    { 
+                        "ref_id": "2.4.1",
+                        "title": "Bypass Blocks",
+                        "description": "A mechanism is available to bypass blocks of content that are repeated on multiple Web pages.",
+                        "url": "https://www.w3.org/TR/WCAG22/#bypass-blocks",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#bypass-blocks"
+                            },
+                            {
+                                "title": "Understanding 2.4.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/bypass-blocks.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.2",
+                        "title": "Page Titled",
+                        "description": "Web pages have titles that describe topic or purpose.",
+                        "url": "https://www.w3.org/TR/WCAG22/#page-titled",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#page-titled"
+                            },
+                            {
+                                "title": "Understanding 2.4.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/page-titled.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.3",
+                        "title": "Focus Order",
+                        "description": "If a Web page can be navigated sequentially and the navigation sequences affect meaning or operation, focusable components receive focus in an order that preserves meaning and operability.",
+                        "url": "https://www.w3.org/TR/WCAG22/#focus-order",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#focus-order"
+                            },
+                            {
+                                "title": "Understanding 2.4.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.4",
+                        "title": "Link Purpose (In Context)",
+                        "description": "The purpose of each link can be determined from the link text alone or from the link text together with its programmatically determined link context, except where the purpose of the link would be ambiguous to users in general.",
+                        "url": "https://www.w3.org/TR/WCAG22/#link-purpose-in-context",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-in-context"
+                            },
+                            {
+                                "title": "Understanding 2.4.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.5",
+                        "title": "Multiple Ways",
+                        "description": "More than one way is available to locate a Web page within a set of Web pages except where the Web Page is the result of, or a step in, a process.",
+                        "url": "https://www.w3.org/TR/WCAG22/#link-purpose-in-context",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#multiple-ways"
+                            },
+                            {
+                                "title": "Understanding 2.4.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/multiple-ways.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.6",
+                        "title": "Headings and Labels",
+                        "description": "Headings and labels describe topic or purpose.",
+                        "url": "https://www.w3.org/TR/WCAG22/#headings-and-labels",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#headings-and-labels"
+                            },
+                            {
+                                "title": "Understanding 2.4.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.7",
+                        "title": "Focus Visible",
+                        "description": "Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.",
+                        "url": "https://www.w3.org/TR/WCAG22/#focus-visible",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#focus-visible"
+                            },
+                            {
+                                "title": "Understanding 2.4.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.8",
+                        "title": "Location",
+                        "description": "Information about the user's location within a set of Web pages is available.",
+                        "url": "https://www.w3.org/TR/WCAG22/#location",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#location"
+                            },
+                            {
+                                "title": "Understanding 2.4.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/location.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.9",
+                        "title": "Link Purpose (Link Only)",
+                        "description": "A mechanism is available to allow the purpose of each link to be identified from link text alone, except where the purpose of the link would be ambiguous to users in general.",
+                        "url": "https://www.w3.org/TR/WCAG22/#link-purpose-link-only",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-link-only"
+                            },
+                            {
+                                "title": "Understanding 2.4.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-link-only.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.10",
+                        "title": "Section Headings",
+                        "description": "Section headings are used to organize the content.",
+                        "url": "https://www.w3.org/TR/WCAG22/#section-headings",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "'Heading' is used in its general sense and includes titles and other ways to add a heading to different types of content."
+                            },
+                            {
+                                "content": "This success criterion covers sections within writing, not user interface components. User Interface components are covered under Success Criterion 4.1.2. (https://www.w3.org/TR/WCAG22/#name-role-value)"
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.10",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#section-headings"
+                            },
+                            {
+                                "title": "Understanding 2.4.10",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/section-headings.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.11",
+                        "title": "Focus Not Obscured (Minimum)",
+                        "description": "When a user interface component receives keyboard focus, the component is not entirely hidden due to author-created content.",
+                        "url": "https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Where content in a configurable interface can be repositioned by the user, then only the initial positions of user-movable content are considered for testing and conformance of this Success Criterion."
+                            },
+                            {
+                                "content": "Content opened by the user may obscure the component receiving focus. If the user can reveal the focused component without advancing the keyboard focus, the component with focus is not considered hidden due to author-created content."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.11",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-minimum"
+                            },
+                            {
+                                "title": "Understanding 2.4.11",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.12",
+                        "title": "Focus Not Obscured (Enhanced)",
+                        "description": "When a user interface component receives keyboard focus, no part of the component is hidden by author-created content.",
+                        "url": "https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.12",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#focus-not-obscured-enhanced"
+                            },
+                            {
+                                "title": "Understanding 2.4.12",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-enhanced.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "2.4.13",
+                        "title": "Focus Appearance",
+                        "description": "When the keyboard focus indicator is visible, an area of the focus indicator meets all the following:",
+                        "url": "https://www.w3.org/TR/WCAG22/#focus-appearance",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "all_true",
+                                "title": "is at least as large as the area of a 2 CSS pixel thick perimeter of the unfocused component or sub-component, and"
+                            },
+                            {
+                                "type": "all_true",
+                                "title": "has a contrast ratio of at least 3:1 between the same pixels in the focused and unfocused states."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "The focus indicator is determined by the user agent and cannot be adjusted by the author, or"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "The focus indicator and the indicator’s background color are not modified by the author."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "What is perceived as the user interface component or sub-component (to determine enclosure or size) depends on its visual presentation. The visual presentation includes the component's visible content, border, and component-specific background. It does not include shadow and glow effects outside the component's content, background, or border."
+                            },
+                            {
+                                "content": "Examples of sub-components that may receive a focus indicator are menu items in an opened drop-down menu, or focusable cells in a grid."
+                            },
+                            {
+                                "content": "Contrast calculations can be based on colors defined within the technology (such as HTML, CSS and SVG). Pixels modified by user agent resolution enhancements and anti-aliasing can be ignored."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.4.13",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#focus-appearance"
+                            },
+                            {
+                                "title": "Understanding 2.4.13",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "2.5",
+                "title": "Input Modalities",
+                "description": "Make it easier for users to operate functionality through various inputs beyond keyboard.",
+                "url": "https://www.w3.org/TR/WCAG22/#input-modalities",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 2.5",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/input-modalities.html"
+                    }
+                ],
+                "success_criteria": [
+                    { 
+                        "ref_id": "2.5.1",
+                        "title": "Pointer Gestures",
+                        "description": "All functionality that uses multipoint or path-based gestures for operation can be operated with a single pointer without a path-based gesture, unless a multipoint or path-based gesture is essential.",
+                        "url": "https://www.w3.org/TR/WCAG22/#pointer-gestures",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "This requirement applies to web content that interprets pointer actions (i.e. this does not apply to actions that are required to operate the user agent or assistive technology)."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#pointer-gestures"
+                            },
+                            {
+                                "title": "Understanding 2.5.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/pointer-gestures.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.2",
+                        "title": "Pointer Cancellation",
+                        "description": "For functionality that can be operated using a single pointer, at least one of the following is true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#pointer-cancellation",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "No Down-Event",
+                                "description": "The down-event of the pointer is not used to execute any part of the function;"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Abort or Undo",
+                                "description": "Completion of the function is on the up-event, and a mechanism is available to abort the function before completion or to undo the function after completion;"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Up Reversal",
+                                "description": "The up-event reverses any outcome of the preceding down-event;"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Essential",
+                                "description": "Completing the function on the down-event is essential."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "Functions that emulate a keyboard or numeric keypad key press are considered essential."
+                            },
+                            {
+                                "content": "This requirement applies to web content that interprets pointer actions (i.e. this does not apply to actions that are required to operate the user agent or assistive technology)."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#pointer-cancellation"
+                            },
+                            {
+                                "title": "Understanding 2.5.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/pointer-cancellation.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.3",
+                        "title": "Label in Name",
+                        "description": "For user interface components with labels that include text or images of text, the name contains the text that is presented visually.",
+                        "url": "https://www.w3.org/TR/WCAG22/#label-in-name",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "A best practice is to have the text of the label at the start of the name."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#label-in-name"
+                            },
+                            {
+                                "title": "Understanding 2.5.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.4",
+                        "title": "Motion Actuation",
+                        "description": "Functionality that can be operated by device motion or user motion can also be operated by user interface components and responding to the motion can be disabled to prevent accidental actuation, except when:",
+                        "url": "https://www.w3.org/TR/WCAG22/#motion-actuation",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Supported Interface",
+                                "description": "The motion is used to operate functionality through an accessibility supported interface;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Essential",
+                                "description": "The motion is essential for the function and doing so would invalidate the activity."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#motion-actuation"
+                            },
+                            {
+                                "title": "Understanding 2.5.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/motion-actuation.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.5",
+                        "title": "Target Size",
+                        "description": "The size of the target for pointer inputs is at least 44 by 44 CSS pixels except when:",
+                        "url": "https://www.w3.org/TR/WCAG22/#target-size",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Equivalent",
+                                "description": "The target is available through an equivalent link or control on the same page that is at least 44 by 44 CSS pixels;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Inline",
+                                "description": "The target is in a sentence or block of text;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "User Agent Control",
+                                "description": "The size of the target is determined by the user agent and is not modified by the author;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Essential",
+                                "description": "A particular presentation of the target is essential to the information being conveyed."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "Targets that allow for values to be selected spatially based on position within the target are considered one target for the purpose of the success criterion. Examples include sliders, color pickers displaying a gradient of colors, or editable areas where you position the cursor."
+                            },
+                            {
+                                "content": "For inline targets the line-height should be interpreted as perpendicular to the flow of text. For example, in a language displayed vertically, the line-height would be horizontal."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#target-size"
+                            },
+                            {
+                                "title": "Understanding 2.5.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/target-size.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.6",
+                        "title": "Concurrent Input Mechanisms",
+                        "description": "Web content does not restrict use of input modalities available on a platform except where the restriction is essential, required to ensure the security of the content, or required to respect user settings.",
+                        "url": "https://www.w3.org/TR/WCAG22/#concurrent-input-mechanisms",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#concurrent-input-mechanisms"
+                            },
+                            {
+                                "title": "Understanding 2.5.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/concurrent-input-mechanisms.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.7",
+                        "title": "Dragging Movements",
+                        "description": "All functionality that uses a dragging movement for operation can be achieved by a single pointer without dragging, unless dragging is essential or the functionality is determined by the user agent and not modified by the author.",
+                        "url": "https://www.w3.org/TR/WCAG22/#dragging-movements",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "This requirement applies to web content that interprets pointer actions (i.e. this does not apply to actions that are required to operate the user agent or assistive technology)."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#dragging-movements"
+                            },
+                            {
+                                "title": "Understanding 2.5.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html"
+                            }
+                        ]
+                    },
+                    { 
+                        "ref_id": "2.5.8",
+                        "title": "Target Size (Minimum)",
+                        "description": "The size of the target for pointer inputs is at least 24 by 24 CSS pixels, except where:",
+                        "url": "https://www.w3.org/TR/WCAG22/#target-size-minimum",
+                        "level": "AA",
+                        "notes": null,
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Spacing",
+                                "description": "Undersized targets (those less than 24 by 24 CSS pixels) are positioned so that if a 24 CSS pixel diameter circle is centered on the bounding box of each, the circles do not intersect another target or the circle for another undersized target;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Equivalent",
+                                "description": "The function can be achieved through a different control on the same page that meets this criterion;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Inline",
+                                "description": "The target is in a sentence or its size is otherwise constrained by the line-height of non-target text;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "User agent control",
+                                "description": "The size of the target is determined by the user agent and is not modified by the author;"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Essential",
+                                "description": "A particular presentation of the target is essential or is legally required for the information being conveyed."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 2.5.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#target-size-minimum"
+                            },
+                            {
+                                "title": "Understanding 2.5.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "ref_id": "3",
+        "title": "Understandable",
+        "description": "Information and the operation of user interface must be understandable.",
+        "url": "https://www.w3.org/TR/WCAG22/#understandable",
+        "guidelines": [
+            {
+                "ref_id": "3.1",
+                "title": "Readable",
+                "description": "Make text content readable and understandable.",
+                "url": "https://www.w3.org/TR/WCAG22/#readable",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 3.1",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/readable.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "3.1.1",
+                        "title": "Language of Page",
+                        "description": "The default human language of each Web page can be programmatically determined.",
+                        "url": "https://www.w3.org/TR/WCAG22/#language-of-page",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#language-of-page"
+                            },
+                            {
+                                "title": "Understanding 3.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.1.2",
+                        "title": "Language of Parts",
+                        "description": "The human language of each passage or phrase in the content can be programmatically determined except for proper names, technical terms, words of indeterminate language, and words or phrases that have become part of the vernacular of the immediately surrounding text.",
+                        "url": "https://www.w3.org/TR/WCAG22/#language-of-parts",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.1.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#language-of-parts"
+                            },
+                            {
+                                "title": "Understanding 3.1.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.1.3",
+                        "title": "Unusual Words",
+                        "description": "A mechanism is available for identifying specific definitions of words or phrases used in an unusual or restricted way, including idioms and jargon.",
+                        "url": "https://www.w3.org/TR/WCAG22/#unusual-words",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.1.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#unusual-words"
+                            },
+                            {
+                                "title": "Understanding 3.1.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/unusual-words.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.1.4",
+                        "title": "Abbreviations",
+                        "description": "A mechanism for identifying the expanded form or meaning of abbreviations is available.",
+                        "url": "https://www.w3.org/TR/WCAG22/#abbreviations",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.1.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#abbreviations"
+                            },
+                            {
+                                "title": "Understanding 3.1.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/abbreviations.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.1.5",
+                        "title": "Reading Level",
+                        "description": "When text requires reading ability more advanced than the lower secondary education level after removal of proper names and titles, supplemental content, or a version that does not require reading ability more advanced than the lower secondary education level, is available.",
+                        "url": "https://www.w3.org/TR/WCAG22/#reading-level",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.1.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#reading-level"
+                            },
+                            {
+                                "title": "Understanding 3.1.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/reading-level.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.1.6",
+                        "title": "Pronunciation",
+                        "description": "A mechanism is available for identifying specific pronunciation of words where meaning of the words, in context, is ambiguous without knowing the pronunciation.",
+                        "url": "https://www.w3.org/TR/WCAG22/#pronunciation",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.1.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#pronunciation"
+                            },
+                            {
+                                "title": "Understanding 3.1.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/pronunciation.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "3.2",
+                "title": "Predictable",
+                "description": "Make Web pages appear and operate in predictable ways.",
+                "url": "https://www.w3.org/TR/WCAG22/#predictable",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 3.2",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/predictable.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "3.2.1",
+                        "title": "On Focus",
+                        "description": "When any component receives focus, it does not initiate a change of context.",
+                        "url": "https://www.w3.org/TR/WCAG22/#on-focus",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.2.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#on-focus"
+                            },
+                            {
+                                "title": "Understanding 3.2.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/on-focus.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.2.2",
+                        "title": "On Input",
+                        "description": "Changing the setting of any user interface component does not automatically cause a change of context unless the user has been advised of the behavior before using the component.",
+                        "url": "https://www.w3.org/TR/WCAG22/#on-input",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.2.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#on-input"
+                            },
+                            {
+                                "title": "Understanding 3.2.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/on-input.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.2.3",
+                        "title": "Consistent Navigation",
+                        "description": "Navigational mechanisms that are repeated on multiple Web pages within a set of Web pages occur in the same relative order each time they are repeated, unless a change is initiated by the user.",
+                        "url": "https://www.w3.org/TR/WCAG22/#consistent-navigation",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.2.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#consistent-navigation"
+                            },
+                            {
+                                "title": "Understanding 3.2.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/consistent-navigation.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.2.4",
+                        "title": "Consistent Identification",
+                        "description": "Components that have the same functionality within a set of Web pages are identified consistently.",
+                        "url": "https://www.w3.org/TR/WCAG22/#consistent-identification",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.2.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#consistent-identification"
+                            },
+                            {
+                                "title": "Understanding 3.2.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/consistent-identification.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.2.5",
+                        "title": "Change on Request",
+                        "description": "Changes of context are initiated only by user request or a mechanism is available to turn off such changes.",
+                        "url": "https://www.w3.org/TR/WCAG22/#change-on-request",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.2.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#change-on-request"
+                            },
+                            {
+                                "title": "Understanding 3.2.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/change-on-request.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.2.6",
+                        "title": "Consistent Help",
+                        "description": "If a Web page contains any of the following help mechanisms, and those mechanisms are repeated on multiple Web pages within a set of Web pages, they occur in the same order relative to other page content, unless a change is initiated by the user:",
+                        "url": "https://www.w3.org/TR/WCAG22/#consistent-help",
+                        "level": "A",
+                        "special_cases": [
+                            
+                                {
+                                    "type": "at_least_one",
+                                    "title": "Human contact details;"
+                                },
+                                {
+                                    "type": "at_least_one",
+                                    "title": "Human contact mechanism;"
+                                },
+                                {
+                                    "type": "at_least_one",
+                                    "title": "Self-help option;"
+                                },
+                                {
+                                    "type": "at_least_one",
+                                    "title": "A fully automated contact mechanism."
+                                }
+                        ],
+                        "notes": [
+                            {
+                                "content": "A fully automated contact mechanism."
+                            },
+                            {
+                                "content": "For this Success Criterion, “the same order relative to other page content” can be thought of as how the content is ordered when the page is serialized. The visual position of a help mechanism is likely to be consistent across pages for the same page variation (e.g., CSS break-point). The user can initiate a change, such as changing the page’s zoom or orientation, which may trigger a different page variation. This criterion is concerned with relative order across pages displayed in the same page variation (e.g., same zoom level and orientation)."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 3.2.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#consistent-help"
+                            },
+                            {
+                                "title": "Understanding 3.2.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/consistent-help.html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "ref_id": "3.3",
+                "title": "Input Assistance",
+                "description": "Help users avoid and correct mistakes.",
+                "url": "https://www.w3.org/TR/WCAG22/#input-assistance",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 3.3",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/input-assistance.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "3.3.1",
+                        "title": "Error Identification",
+                        "description": "If an input error is automatically detected, the item that is in error is identified and the error is described to the user in text.",
+                        "url": "https://www.w3.org/TR/WCAG22/#error-identification",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#error-identification"
+                            },
+                            {
+                                "title": "Understanding 3.3.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.2",
+                        "title": "Labels or Instructions",
+                        "description": "Labels or instructions are provided when content requires user input.",
+                        "url": "https://www.w3.org/TR/WCAG22/#labels-or-instructions",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#labels-or-instructions"
+                            },
+                            {
+                                "title": "Understanding 3.3.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.3",
+                        "title": "Error Suggestion",
+                        "description": "If an input error is automatically detected and suggestions for correction are known, then the suggestions are provided to the user, unless it would jeopardize the security or purpose of the content.",
+                        "url": "https://www.w3.org/TR/WCAG22/#error-suggestion",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#error-suggestion"
+                            },
+                            {
+                                "title": "Understanding 3.3.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.4",
+                        "title": "Error Prevention (Legal, Financial, Data)",
+                        "description": " For Web pages that cause legal commitments or financial transactions for the user to occur, that modify or delete user-controllable data in data storage systems, or that submit user test responses, at least one of the following is true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#error-prevention-legal-financial-data",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "Reversible",
+                                "description": "Submissions are reversible."
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Checked",
+                                "description": "Data entered by the user is checked for input errors and the user is provided an opportunity to correct them."
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Confirmed",
+                                "description": "A mechanism is available for reviewing, confirming, and correcting information before finalizing the submission."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#error-prevention-legal-financial-data"
+                            },
+                            {
+                                "title": "Understanding 3.3.4",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-legal-financial-data.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.5",
+                        "title": "Help",
+                        "description": "Context-sensitive help is available.",
+                        "url": "https://www.w3.org/TR/WCAG22/#help",
+                        "level": "AAA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#help"
+                            },
+                            {
+                                "title": "Understanding 3.3.5",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/help.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.6",
+                        "title": "Error Prevention (All)",
+                        "description": "For Web pages that require the user to submit information, at least one of the following is true:",
+                        "url": "https://www.w3.org/TR/WCAG22/#error-prevention-all",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "Reversible",
+                                "description": "Submissions are reversible."
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Checked",
+                                "description": "Data entered by the user is checked for input errors and the user is provided an opportunity to correct them."
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "Confirmed",
+                                "description": "A mechanism is available for reviewing, confirming, and correcting information before finalizing the submission."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#error-prevention-all"
+                            },
+                            {
+                                "title": "Understanding 3.3.6",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/error-prevention-all.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.7",
+                        "title": "Redundant Entry",
+                        "description": "Information previously entered by or provided to the user that is required to be entered again in the same process is either:",
+                        "url": "https://www.w3.org/TR/WCAG22/#redundant-entry",
+                        "level": "A",
+                        "special_cases": [
+                            {
+                                "type": "at_least_one",
+                                "title": "auto-populated, or"
+                            },
+                            {
+                                "type": "at_least_one",
+                                "title": "available for the user to select."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "re-entering the information is essential,"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "the information is required to ensure the security of the content, or"
+                            },
+                            {
+                                "type": "exception",
+                                "title": "previously entered information is no longer valid."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#redundant-entry"
+                            },
+                            {
+                                "title": "Understanding 3.3.7",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/redundant-entry.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.8",
+                        "title": "Accessible Authentication (Minimum)",
+                        "description": "A cognitive function test (such as remembering a password or solving a puzzle) is not required for any step in an authentication process unless that step provides at least one of the following:",
+                        "url": "https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum",
+                        "level": "AA",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Alternative",
+                                "description": "Another authentication method that does not rely on a cognitive function test."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Mechanism",
+                                "description": "A mechanism is available to assist the user in completing the cognitive function test."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Object Recognition",
+                                "description": "The cognitive function test is to recognize objects."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Personal Content",
+                                "description": "The cognitive function test is to identify non-text content the user provided to the Web site."
+                            }
+                        ],
+                        "notes": [
+                            {
+                                "content": "”Object recognition” and ”Personal content” may be represented by images, video, or audio."
+                            },
+                            {
+                                "content": "Examples of mechanisms that satisfy this criterion include: <ol><li>support for password entry by password managers to reduce memory need, and</li><li>copy and paste to reduce the cognitive burden of re-typing.</li></ol>"
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-minimum"
+                            },
+                            {
+                                "title": "Understanding 3.3.8",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-minimum.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "3.3.9",
+                        "title": "Accessible Authentication (Enhanced)",
+                        "description": "A cognitive function test (such as remembering a password or solving a puzzle) is not required for any step in an authentication process unless that step provides at least one of the following:",
+                        "url": "https://www.w3.org/TR/WCAG22/#accessible-authentication-enhanced",
+                        "level": "AAA",
+                        "special_cases": [
+                            {
+                                "type": "exception",
+                                "title": "Alternative",
+                                "description": "Another authentication method that does not rely on a cognitive function test."
+                            },
+                            {
+                                "type": "exception",
+                                "title": "Mechanism",
+                                "description": "A mechanism is available to assist the user in completing the cognitive function test."
+                            }
+                        ],
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 3.3.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#accessible-authentication-enhanced"
+                            },
+                            {
+                                "title": "Understanding 3.3.9",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/accessible-authentication-enhanced.html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "ref_id": "4",
+        "title": "Robust",
+        "description": "Content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies.",
+        "url": "https://www.w3.org/TR/WCAG22/#robust",
+        "guidelines": [
+            {
+                "ref_id": "4.1",
+                "title": "Compatible",
+                "description": "Maximize compatibility with current and future user agents, including assistive technologies.",
+                "url": "https://www.w3.org/TR/WCAG22/#compatible",
+                "references": [
+                    {
+                        "title": "Understanding Guideline 4.1",
+                        "url": "https://www.w3.org/WAI/WCAG22/Understanding/compatible.html"
+                    }
+                ],
+                "success_criteria": [
+                    {
+                        "ref_id": "4.1.1",
+                        "title": "Parsing",
+                        "description": "In content implemented using markup languages, elements have complete start and end tags, elements are nested according to their specifications, elements do not contain duplicate attributes, and any IDs are unique, except where the specifications allow these features.",
+                        "url": "https://www.w3.org/TR/WCAG22/#parsing",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "Start and end tags that are missing a critical character in their formation, such as a closing angle bracket or a mismatched attribute value quotation mark are not complete."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 4.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#parsing"
+                            },
+                            {
+                                "title": "Understanding 4.1.1",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/parsing.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "4.1.2",
+                        "title": "Name, Role, Value",
+                        "description": "For all user interface components (including but not limited to: form elements, links and components generated by scripts), the name and role can be programmatically determined; states, properties, and values that can be set by the user can be programmatically set; and notification of changes to these items is available to user agents, including assistive technologies.",
+                        "url": "https://www.w3.org/TR/WCAG22/#name-role-value",
+                        "level": "A",
+                        "special_cases": null,
+                        "notes": [
+                            {
+                                "content": "This success criterion is primarily for Web authors who develop or script their own user interface components. For example, standard HTML controls already meet this success criterion when used according to specification."
+                            }
+                        ],
+                        "references": [
+                            {
+                                "title": "How to Meet 4.1.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#name-role-value"
+                            },
+                            {
+                                "title": "Understanding 4.1.2",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html"
+                            }
+                        ]
+                    },
+                    {
+                        "ref_id": "4.1.3",
+                        "title": "Status Messages",
+                        "description": "In content implemented using markup languages, status messages can be programmatically determined through role or properties such that they can be presented to the user by assistive technologies without receiving focus.",
+                        "url": "https://www.w3.org/TR/WCAG22/#status-messages",
+                        "level": "AA",
+                        "special_cases": null,
+                        "notes": null,
+                        "references": [
+                            {
+                                "title": "How to Meet 4.1.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/quickref/#status-messages"
+                            },
+                            {
+                                "title": "Understanding 4.1.3",
+                                "url": "https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/core/ai-components/AIButton/index.tsx
+++ b/core/ai-components/AIButton/index.tsx
@@ -70,7 +70,8 @@ export const AIButton = (props: AIButtonProps) => {
       {withSparkle && (
         <img
           src={AISparkle}
-          alt="Button Icon"
+          alt=""
+          aria-hidden="true"
           width={16}
           height={16}
           className={IconClassNames}

--- a/core/ai-components/AIChip/index.tsx
+++ b/core/ai-components/AIChip/index.tsx
@@ -50,7 +50,7 @@ export const AIChip = (props: AIChipProps) => {
 
   return (
     <button type="button" data-test="DesignSystem-AI-Chip" className={ChipClassNames} disabled={disabled} {...rest}>
-      <i data-test="DesignSystem-AI-Chip-Icon" className={IconClassNames}>
+      <i data-test="DesignSystem-AI-Chip-Icon" className={IconClassNames} aria-hidden="true">
         {icon}
       </i>
 

--- a/core/ai-components/AIIconButton/icons/SaraIconDefault.tsx
+++ b/core/ai-components/AIIconButton/icons/SaraIconDefault.tsx
@@ -16,6 +16,8 @@ const SaraIconDefault = (props: SaraIconType) => {
       xmlns="http://www.w3.org/2000/svg"
       className={className}
       data-test="DesignSystem-AI-Icon"
+      aria-hidden="true"
+      focusable="false"
     >
       <path
         fillRule="evenodd"

--- a/core/ai-components/AIIconButton/icons/SaraIconDisabled.tsx
+++ b/core/ai-components/AIIconButton/icons/SaraIconDisabled.tsx
@@ -16,6 +16,8 @@ const SaraIconDisabled = (props: SaraIconType) => {
       xmlns="http://www.w3.org/2000/svg"
       className={className}
       data-test="DesignSystem-AI-Icon"
+      aria-hidden="true"
+      focusable="false"
     >
       <path
         fillRule="evenodd"

--- a/core/ai-components/AIIconButton/index.tsx
+++ b/core/ai-components/AIIconButton/index.tsx
@@ -62,6 +62,7 @@ export interface AIIconButtonProps extends Omit<TBaseHtmlProps<HTMLButtonElement
 
 export const AIIconButton = (props: AIIconButtonProps) => {
   const { icon, position, className, size, strokeColor, tooltip, disabled, ...rest } = props;
+  const ariaLabel = rest['aria-label'] ?? tooltip ?? icon;
 
   const buttonClassNames = classNames(
     {
@@ -102,10 +103,11 @@ export const AIIconButton = (props: AIIconButtonProps) => {
         className={buttonClassNames}
         data-test="DesignSystem-AI-IconButton"
         disabled={disabled}
+        aria-label={ariaLabel}
         {...rest}
         style={{ color: strokeColor }}
       >
-        <i data-test="DesignSystem-Icon" className={IconClassNames} style={iconStyles}>
+        <i data-test="DesignSystem-Icon" className={IconClassNames} style={iconStyles} aria-hidden={!!ariaLabel}>
           {icon}
         </i>
         <SaraIcon {...saraIconProps} />

--- a/core/components/atoms/_chip/__tests__/__snapshots__/_chip.test.tsx.snap
+++ b/core/components/atoms/_chip/__tests__/__snapshots__/_chip.test.tsx.snap
@@ -171,6 +171,7 @@ exports[`Chip component
         </span>
       </div>
       <div
+        aria-label="Remove"
         class="Chip-icon Chip-icon--right cursor-pointer"
         data-test="DesignSystem-GenericChip--clearButton"
         role="button"
@@ -221,6 +222,7 @@ exports[`Chip component
         </span>
       </div>
       <div
+        aria-label="Remove"
         class="Chip-icon Chip-icon--right cursor-pointer Chip-icon--selected"
         data-test="DesignSystem-GenericChip--clearButton"
         role="button"
@@ -271,6 +273,7 @@ exports[`Chip component
         </span>
       </div>
       <div
+        aria-label="Remove"
         class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
         data-test="DesignSystem-GenericChip--clearButton"
         role="button"
@@ -321,6 +324,7 @@ exports[`Chip component
         </span>
       </div>
       <div
+        aria-label="Remove"
         class="Chip-icon Chip-icon--right Chip-icon-disabled--right Chip-icon--selected"
         data-test="DesignSystem-GenericChip--clearButton"
         role="button"

--- a/core/components/atoms/_chip/index.tsx
+++ b/core/components/atoms/_chip/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import Icon from '@/components/atoms/icon';
 import Text from '@/components/atoms/text';
-import { Name } from '../chip/Chip';
+import { Name, ChipType } from '../chip/Chip';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { IconProps, TextProps } from '@/index.type';
 import { Tooltip } from '@/index';
@@ -22,6 +22,8 @@ export interface GenericChipProps extends BaseProps {
   name: Name;
   maxWidth: string | number;
   size?: TChipSize;
+  type?: ChipType;
+  role?: string;
 }
 
 export const GenericChip = (props: GenericChipProps) => {
@@ -38,6 +40,7 @@ export const GenericChip = (props: GenericChipProps) => {
     iconType,
     maxWidth,
     size = 'regular',
+    type,
   } = props;
   const wrapperStyle = { maxWidth: maxWidth };
   const [isTextTruncated, setIsTextTruncated] = React.useState(false);
@@ -73,13 +76,15 @@ export const GenericChip = (props: GenericChipProps) => {
   };
 
   const onKeyDownHandler = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
       onCloseHandler(event);
     }
   };
 
   const onChipKeyDownHandler = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
       onClickHandler();
     }
   };
@@ -145,6 +150,23 @@ export const GenericChip = (props: GenericChipProps) => {
     return labelText;
   };
 
+  const getAriaProps = () => {
+    const effectiveRole = props.role || 'button';
+    const ariaProps: React.HTMLAttributes<HTMLDivElement> = {};
+
+    if (type === 'selection') {
+      if (effectiveRole === 'button') {
+        ariaProps['aria-pressed'] = selected;
+      } else if (effectiveRole === 'checkbox' || effectiveRole === 'menuitemcheckbox') {
+        ariaProps['aria-checked'] = selected;
+      } else if (effectiveRole === 'option' || effectiveRole === 'tab' || effectiveRole === 'treeitem') {
+        ariaProps['aria-selected'] = selected;
+      }
+    }
+
+    return ariaProps;
+  };
+
   return (
     <Tooltip
       showTooltip={isTextTruncated}
@@ -156,7 +178,8 @@ export const GenericChip = (props: GenericChipProps) => {
         tabIndex={disabled ? -1 : 0}
         style={wrapperStyle}
         data-test="DesignSystem-GenericChip--Wrapper"
-        role="button"
+        role={props.role || 'button'}
+        {...getAriaProps()}
         onKeyDown={onChipKeyDownHandler}
         {...baseProps}
         className={chipWrapperClass}
@@ -176,6 +199,7 @@ export const GenericChip = (props: GenericChipProps) => {
         {clearButton && (
           <div
             role="button"
+            aria-label="Remove"
             onClick={onCloseHandler}
             tabIndex={disabled ? -1 : 0}
             onKeyDown={onKeyDownHandler}

--- a/core/components/atoms/avatar/Avatar.tsx
+++ b/core/components/atoms/avatar/Avatar.tsx
@@ -97,7 +97,7 @@ export const Avatar = (props: AvatarProps) => {
     presence,
     status,
     strokeColor,
-    role = 'presentation',
+    role,
   } = props;
 
   const baseProps = extractBaseProps(props);
@@ -117,6 +117,8 @@ export const Avatar = (props: AvatarProps) => {
 
   const AvatarAppearance =
     appearance || colors[(initials.charCodeAt(0) + (initials.charCodeAt(1) || 0)) % 8] || DefaultAppearance;
+  const resolvedRole = role ?? (tabIndex !== undefined ? 'button' : 'img');
+  const ariaLabel = getTooltipName().trim() || initials || 'Avatar';
 
   const darkAppearance = ['secondary', 'success', 'warning', 'accent1', 'accent4'];
   const showPresence =
@@ -180,13 +182,15 @@ export const Avatar = (props: AvatarProps) => {
   const renderAvatar = () => {
     if (children && typeof children !== 'string') {
       return (
-        <span data-test="DesignSystem-AvatarWrapper" className={AvatarWrapperClassNames} role={role}>
+        <span data-test="DesignSystem-AvatarWrapper" className={AvatarWrapperClassNames}>
           <AvatarProvider value={sharedProp}>
             <span
               data-test="DesignSystem-Avatar"
               {...baseProps}
               className={AvatarClassNames}
-              tabIndex={tabIndex || disabled ? -1 : 0}
+              role={resolvedRole}
+              aria-label={ariaLabel}
+              tabIndex={disabled ? -1 : tabIndex !== undefined ? tabIndex : 0}
             >
               {children}
             </span>
@@ -196,12 +200,14 @@ export const Avatar = (props: AvatarProps) => {
     }
 
     return (
-      <span data-test="DesignSystem-AvatarWrapper" className={AvatarWrapperClassNames} role={role}>
+      <span data-test="DesignSystem-AvatarWrapper" className={AvatarWrapperClassNames}>
         <span
           data-test="DesignSystem-Avatar"
           {...baseProps}
           className={AvatarClassNames}
-          tabIndex={tabIndex || disabled ? -1 : 0}
+          role={resolvedRole}
+          aria-label={ariaLabel}
+          tabIndex={disabled ? -1 : tabIndex !== undefined ? tabIndex : 0}
         >
           <>
             {initials && (

--- a/core/components/atoms/avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
+++ b/core/components/atoms/avatar/__tests__/__snapshots__/Avatar.test.tsx.snap
@@ -17,11 +17,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -47,11 +48,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -136,11 +138,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent1 Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -166,11 +169,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent1 Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -255,11 +259,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent2 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -285,11 +290,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent2 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -374,11 +380,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent2 Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -404,11 +411,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent2 Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -493,11 +501,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent3 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -523,11 +532,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent3 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -612,11 +622,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent3 Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -642,11 +653,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent3 Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -731,11 +743,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent4 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -761,11 +774,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent4 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -850,11 +864,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent4 Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -880,11 +895,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent4 Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -969,11 +985,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--alert Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -999,11 +1016,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--alert Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -1088,11 +1106,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--alert Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -1118,11 +1137,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--alert Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -1207,11 +1227,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--primary Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -1237,11 +1258,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--primary Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -1326,11 +1348,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--primary Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -1356,11 +1379,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--primary Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -1445,11 +1469,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--success Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -1475,11 +1500,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--success Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -1564,11 +1590,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--success Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -1594,11 +1621,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--success Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -1683,11 +1711,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--warning Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -1713,11 +1742,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--warning Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -1802,11 +1832,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--warning Avatar--disabled"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="-1"
             >
               <span
@@ -1832,11 +1863,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--warning Avatar--disabled"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="-1"
           >
             <span
@@ -1921,11 +1953,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -1951,11 +1984,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -2040,11 +2074,12 @@ Object {
           <span
             class="Avatar-wrapper--square Avatar--regular"
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--square Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -2070,11 +2105,12 @@ Object {
         <span
           class="Avatar-wrapper--square Avatar--regular"
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--square Avatar--accent1 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -2159,11 +2195,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--micro Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -2189,11 +2226,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--micro Avatar--accent1 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -2278,11 +2316,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -2308,11 +2347,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span
@@ -2397,11 +2437,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="JD"
               class="Avatar Avatar--tiny Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <span
@@ -2427,11 +2468,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="JD"
             class="Avatar Avatar--tiny Avatar--accent1 Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <span

--- a/core/components/atoms/avatar/avatarIcon/__tests__/__snapshots__/AvatarIcon.test.tsx.snap
+++ b/core/components/atoms/avatar/avatarIcon/__tests__/__snapshots__/AvatarIcon.test.tsx.snap
@@ -13,11 +13,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--accent1 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -40,11 +41,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--accent1 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -126,11 +128,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--accent2 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -153,11 +156,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--accent2 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -239,11 +243,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--accent3 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -266,11 +271,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--accent3 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -352,11 +358,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--accent4 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -379,11 +386,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--accent4 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -465,11 +473,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--alert Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -492,11 +501,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--alert Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -578,11 +588,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--primary Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -605,11 +616,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--primary Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -691,11 +703,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -718,11 +731,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -804,11 +818,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--success Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -831,11 +846,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--success Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -917,11 +933,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--warning Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -944,11 +961,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--warning Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1030,11 +1048,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--accent1 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1057,11 +1076,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--accent1 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1143,11 +1163,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--accent2 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1170,11 +1191,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--accent2 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1256,11 +1278,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--accent3 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1283,11 +1306,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--accent3 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1369,11 +1393,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--accent4 Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1396,11 +1421,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--accent4 Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1482,11 +1508,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--alert Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1509,11 +1536,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--alert Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1595,11 +1623,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--primary Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1622,11 +1651,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--primary Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1708,11 +1738,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--secondary Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1735,11 +1766,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--secondary Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1821,11 +1853,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--success Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1848,11 +1881,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--success Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i
@@ -1934,11 +1968,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--tiny Avatar--warning Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <i
@@ -1961,11 +1996,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--tiny Avatar--warning Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <i

--- a/core/components/atoms/avatar/avatarImage/__tests__/__snapshots__/AvatarImage.test.tsx.snap
+++ b/core/components/atoms/avatar/avatarImage/__tests__/__snapshots__/AvatarImage.test.tsx.snap
@@ -17,11 +17,12 @@ Object {
           <span
             class=""
             data-test="DesignSystem-AvatarWrapper"
-            role="presentation"
           >
             <span
+              aria-label="John Doe"
               class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
               data-test="DesignSystem-Avatar"
+              role="img"
               tabindex="0"
             >
               <img
@@ -43,11 +44,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <img
@@ -68,11 +70,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <img
@@ -152,11 +155,12 @@ Object {
         <span
           class=""
           data-test="DesignSystem-AvatarWrapper"
-          role="presentation"
         >
           <span
+            aria-label="Avatar"
             class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
             data-test="DesignSystem-Avatar"
+            role="img"
             tabindex="0"
           >
             <svg
@@ -186,11 +190,12 @@ Object {
       <span
         class=""
         data-test="DesignSystem-AvatarWrapper"
-        role="presentation"
       >
         <span
+          aria-label="Avatar"
           class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
           data-test="DesignSystem-Avatar"
+          role="img"
           tabindex="0"
         >
           <svg

--- a/core/components/atoms/avatarGroup/__tests__/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/core/components/atoms/avatarGroup/__tests__/__snapshots__/AvatarGroup.test.tsx.snap
@@ -26,11 +26,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -61,11 +62,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--regular Avatar--alert Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -104,11 +106,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="John Doe"
                 class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -139,11 +142,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Steven Packton"
                 class="Avatar Avatar--regular Avatar--alert Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -241,11 +245,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -276,11 +281,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--regular Avatar--alert Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -319,11 +325,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="John Doe"
                 class="Avatar Avatar--regular Avatar--accent1 Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -354,11 +361,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Steven Packton"
                 class="Avatar Avatar--regular Avatar--alert Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -456,11 +464,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--tiny Avatar--accent1 Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -491,11 +500,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--tiny Avatar--alert Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -534,11 +544,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="John Doe"
                 class="Avatar Avatar--tiny Avatar--accent1 Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -569,11 +580,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Steven Packton"
                 class="Avatar Avatar--tiny Avatar--alert Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -671,11 +683,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--tiny Avatar--accent1 Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -706,11 +719,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--tiny Avatar--alert Avatar--default"
                   data-test="DesignSystem-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <i
@@ -749,11 +763,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="John Doe"
                 class="Avatar Avatar--tiny Avatar--accent1 Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i
@@ -784,11 +799,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Steven Packton"
                 class="Avatar Avatar--tiny Avatar--alert Avatar--default"
                 data-test="DesignSystem-Avatar"
+                role="img"
                 tabindex="0"
               >
                 <i

--- a/core/components/atoms/avatarSelection/__tests__/__snapshots__/AvatarSelection.test.tsx.snap
+++ b/core/components/atoms/avatarSelection/__tests__/__snapshots__/AvatarSelection.test.tsx.snap
@@ -32,11 +32,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="John Doe"
                     class="Avatar Avatar--regular Avatar--accent1 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -72,11 +73,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Steven Packton"
                     class="Avatar Avatar--regular Avatar--alert Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -112,11 +114,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Nancy Wheeler"
                     class="Avatar Avatar--regular Avatar--warning Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -152,11 +155,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Monica Geller"
                     class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -192,11 +196,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Arya Stark"
                     class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -231,11 +236,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Avatar"
                   class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="button"
                   tabindex="-1"
                 >
                   <span
@@ -278,11 +284,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--regular Avatar--accent1 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -318,11 +325,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--regular Avatar--alert Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -358,11 +366,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Nancy Wheeler"
                   class="Avatar Avatar--regular Avatar--warning Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -398,11 +407,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Monica Geller"
                   class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -438,11 +448,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Arya Stark"
                   class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -477,11 +488,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Avatar"
                 class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                 data-test="DesignSystem-Avatar"
+                role="button"
                 tabindex="-1"
               >
                 <span
@@ -583,11 +595,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="John Doe"
                     class="Avatar Avatar--regular Avatar--accent1 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -623,11 +636,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Steven Packton"
                     class="Avatar Avatar--regular Avatar--alert Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -663,11 +677,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Nancy Wheeler"
                     class="Avatar Avatar--regular Avatar--warning Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -703,11 +718,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Monica Geller"
                     class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -743,11 +759,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Arya Stark"
                     class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -782,11 +799,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Avatar"
                   class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="button"
                   tabindex="-1"
                 >
                   <span
@@ -829,11 +847,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--regular Avatar--accent1 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -869,11 +888,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--regular Avatar--alert Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -909,11 +929,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Nancy Wheeler"
                   class="Avatar Avatar--regular Avatar--warning Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -949,11 +970,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Monica Geller"
                   class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -989,11 +1011,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Arya Stark"
                   class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -1028,11 +1051,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Avatar"
                 class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                 data-test="DesignSystem-Avatar"
+                role="button"
                 tabindex="-1"
               >
                 <span
@@ -1134,11 +1158,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="John Doe"
                     class="Avatar Avatar--tiny Avatar--accent1 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1174,11 +1199,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Steven Packton"
                     class="Avatar Avatar--tiny Avatar--alert Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1214,11 +1240,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Nancy Wheeler"
                     class="Avatar Avatar--tiny Avatar--warning Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1254,11 +1281,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Monica Geller"
                     class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1294,11 +1322,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Arya Stark"
                     class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1333,11 +1362,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Avatar"
                   class="Avatar Avatar--tiny Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="button"
                   tabindex="-1"
                 >
                   <span
@@ -1380,11 +1410,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--tiny Avatar--accent1 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -1420,11 +1451,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--tiny Avatar--alert Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -1460,11 +1492,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Nancy Wheeler"
                   class="Avatar Avatar--tiny Avatar--warning Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -1500,11 +1533,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Monica Geller"
                   class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -1540,11 +1574,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Arya Stark"
                   class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -1579,11 +1614,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Avatar"
                 class="Avatar Avatar--tiny Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                 data-test="DesignSystem-Avatar"
+                role="button"
                 tabindex="-1"
               >
                 <span
@@ -1685,11 +1721,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="John Doe"
                     class="Avatar Avatar--regular Avatar--accent1 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1725,11 +1762,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Steven Packton"
                     class="Avatar Avatar--regular Avatar--alert Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1765,11 +1803,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Nancy Wheeler"
                     class="Avatar Avatar--regular Avatar--warning Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1805,11 +1844,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Monica Geller"
                     class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1845,11 +1885,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Arya Stark"
                     class="Avatar Avatar--regular Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -1884,11 +1925,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Avatar"
                   class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount SelectionAvatarCount--open cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="button"
                   tabindex="-1"
                 >
                   <span
@@ -1969,11 +2011,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Avatar"
                   class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="button"
                   tabindex="-1"
                 >
                   <span
@@ -2015,11 +2058,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="John Doe"
                     class="Avatar Avatar--tiny Avatar--accent1 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -2055,11 +2099,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Steven Packton"
                     class="Avatar Avatar--tiny Avatar--alert Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -2095,11 +2140,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Nancy Wheeler"
                     class="Avatar Avatar--tiny Avatar--warning Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -2135,11 +2181,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Monica Geller"
                     class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -2175,11 +2222,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="checkbox"
                 >
                   <span
+                    aria-label="Arya Stark"
                     class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                     data-test="DesignSystem-Avatar"
+                    role="checkbox"
                     tabindex="0"
                   >
                     <span
@@ -2214,11 +2262,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="Avatar"
                   class="Avatar Avatar--tiny Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="button"
                   tabindex="-1"
                 >
                   <span
@@ -2261,11 +2310,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--tiny Avatar--accent1 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -2301,11 +2351,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Steven Packton"
                   class="Avatar Avatar--tiny Avatar--alert Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -2341,11 +2392,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Nancy Wheeler"
                   class="Avatar Avatar--tiny Avatar--warning Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -2381,11 +2433,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Monica Geller"
                   class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -2421,11 +2474,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="checkbox"
               >
                 <span
+                  aria-label="Arya Stark"
                   class="Avatar Avatar--tiny Avatar--accent2 Avatar--default cursor-pointer"
                   data-test="DesignSystem-Avatar"
+                  role="checkbox"
                   tabindex="0"
                 >
                   <span
@@ -2460,11 +2514,12 @@ Object {
             <span
               class=""
               data-test="DesignSystem-AvatarWrapper"
-              role="presentation"
             >
               <span
+                aria-label="Avatar"
                 class="Avatar Avatar--tiny Avatar--secondary Avatar--noInitials Avatar--default SelectionAvatarCount cursor-pointer"
                 data-test="DesignSystem-Avatar"
+                role="button"
                 tabindex="-1"
               >
                 <span

--- a/core/components/atoms/badge/__tests__/Badge.test.tsx
+++ b/core/components/atoms/badge/__tests__/Badge.test.tsx
@@ -117,3 +117,23 @@ describe('Badge component hover event', () => {
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Badge component accessibility', () => {
+  it('supports aria-label for additional context', () => {
+    const { getByTestId } = render(
+      <Badge appearance="success" aria-label="Status: success">
+        Success
+      </Badge>
+    );
+    expect(getByTestId('DesignSystem-Badge')).toHaveAttribute('aria-label', 'Status: success');
+  });
+
+  it('allows passing a role attribute', () => {
+    const { getByTestId } = render(
+      <Badge appearance="warning" role="status">
+        Warning
+      </Badge>
+    );
+    expect(getByTestId('DesignSystem-Badge')).toHaveAttribute('role', 'status');
+  });
+});

--- a/core/components/atoms/breadcrumbs/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/core/components/atoms/breadcrumbs/__tests__/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <a
+          aria-disabled="false"
           class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
           data-test="DesignSystem-Breadcrumbs-link"
           href="/level0"
@@ -41,6 +42,7 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <a
+          aria-disabled="false"
           class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
           data-test="DesignSystem-Breadcrumbs-link"
           href="/level1"
@@ -59,6 +61,7 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <a
+          aria-disabled="false"
           class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
           data-test="DesignSystem-Breadcrumbs-link"
           href="/level2"
@@ -77,6 +80,7 @@ exports[`Breadcrumbs component renders four links 1`] = `
         data-test="DesignSystem-Breadcrumbs-item"
       >
         <a
+          aria-disabled="false"
           class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
           data-test="DesignSystem-Breadcrumbs-link"
           href="/level3"

--- a/core/components/atoms/button/Button.tsx
+++ b/core/components/atoms/button/Button.tsx
@@ -185,6 +185,8 @@ const ButtonElement = React.forwardRef<HTMLButtonElement, ButtonProps>((props, r
       className={buttonClass}
       disabled={disabled || loading}
       tabIndex={tabIndex}
+      aria-busy={loading || undefined}
+      aria-label={props['aria-label'] || (!children && tooltip ? tooltip : undefined)}
       {...rest}
     >
       {loading ? (

--- a/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -67,14 +67,18 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--alert Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -185,14 +189,18 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--basic Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -303,14 +311,18 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--primary Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -421,14 +433,18 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--transparent Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -898,14 +914,18 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--regularSquare Button--alert"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -933,14 +953,18 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--regularSquare Button--basic"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -968,14 +992,18 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--regularSquare Button--primary"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle
@@ -1003,14 +1031,18 @@ exports[`Button component with no children
 <body>
   <div>
     <button
+      aria-busy="true"
       class="Button Button--regular Button--regularSquare Button--transparent"
       data-test="DesignSystem-Button"
       disabled=""
       tabindex="0"
     >
       <svg
+        aria-label="Loading"
+        aria-live="polite"
         class="Spinner Spinner--xsmall Button-spinner"
         data-test="DesignSystem-Button--Spinner"
+        role="status"
         viewBox="0 0 50 50"
       >
         <circle

--- a/core/components/atoms/checkbox/Checkbox.tsx
+++ b/core/components/atoms/checkbox/Checkbox.tsx
@@ -94,6 +94,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
     id = `${name}-${label}-${uidGenerator()}`,
     labelRef,
     wrapLabel,
+    ['aria-describedby']: ariaDescribedby,
     ...rest
   } = props;
 
@@ -173,6 +174,9 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
     ['indeterminate--tiny']: indeterminate && size === 'tiny',
   });
 
+  const helpTextId = helpText && helpText.trim() ? `${id}-helptext` : undefined;
+  const describedBy = [ariaDescribedby, helpTextId].filter(Boolean).join(' ') || undefined;
+
   return (
     <>
       <div data-test="DesignSystem-Checkbox" className={CheckboxClass}>
@@ -191,6 +195,9 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
             tabIndex={tabIndex}
             id={id}
             data-test="DesignSystem-Checkbox-InputBox"
+            aria-invalid={error || undefined}
+            aria-checked={indeterminate ? 'mixed' : undefined}
+            aria-describedby={describedBy}
           />
           <span className={CheckboxWrapper} data-test="DesignSystem-Checkbox-Icon">
             {IconMapper && <CheckboxIcon name={IconMapper} />}
@@ -213,6 +220,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>((props
             {helpText && (
               <Text
                 data-test="DesignSystem-Checkbox-HelpText"
+                id={helpTextId}
                 size="small"
                 appearance={disabled ? 'disabled' : 'subtle'}
               >

--- a/core/components/atoms/checkbox/__tests__/Checkbox.test.tsx
+++ b/core/components/atoms/checkbox/__tests__/Checkbox.test.tsx
@@ -137,3 +137,31 @@ describe('Checkbox component', () => {
     expect(checkboxIcon).toHaveClass('Checkbox-wrapper--default');
   });
 });
+
+describe('Checkbox component accessibility', () => {
+  it('associates help text using aria-describedby', () => {
+    const { getByTestId } = render(<Checkbox label={StringValue} helpText={StringValue} />);
+    const input = getByTestId('DesignSystem-Checkbox-InputBox');
+    const helpText = getByTestId('DesignSystem-Checkbox-HelpText');
+    expect(input).toHaveAttribute('aria-describedby', helpText.getAttribute('id'));
+  });
+
+  it('merges provided aria-describedby with help text id', () => {
+    const { getByTestId } = render(
+      <Checkbox label={StringValue} helpText={StringValue} aria-describedby="custom-description" />
+    );
+    const input = getByTestId('DesignSystem-Checkbox-InputBox');
+    const helpText = getByTestId('DesignSystem-Checkbox-HelpText');
+    expect(input).toHaveAttribute('aria-describedby', `custom-description ${helpText.getAttribute('id')}`);
+  });
+
+  it('sets aria-invalid when error is true', () => {
+    const { getByTestId } = render(<Checkbox label={StringValue} error={true} />);
+    expect(getByTestId('DesignSystem-Checkbox-InputBox')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('sets aria-checked to mixed when indeterminate', () => {
+    const { getByTestId } = render(<Checkbox label={StringValue} indeterminate={true} />);
+    expect(getByTestId('DesignSystem-Checkbox-InputBox')).toHaveAttribute('aria-checked', 'mixed');
+  });
+});

--- a/core/components/atoms/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/core/components/atoms/checkbox/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -45,6 +46,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -68,6 +70,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
+          aria-invalid="true"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -99,6 +103,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -122,6 +127,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -154,6 +160,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -177,6 +184,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
+          aria-invalid="true"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -209,6 +218,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -232,6 +242,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           checked=""
           class="Checkbox-input Checkbox-input--checked"
           data-test="DesignSystem-Checkbox-InputBox"
@@ -279,6 +290,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -302,6 +314,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
+          aria-invalid="true"
           checked=""
           class="Checkbox-input Checkbox-input--checked"
           data-test="DesignSystem-Checkbox-InputBox"
@@ -349,6 +363,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -372,6 +387,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           checked=""
           class="Checkbox-input Checkbox-input--checked"
           data-test="DesignSystem-Checkbox-InputBox"
@@ -420,6 +436,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -443,6 +460,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
+          aria-invalid="true"
           checked=""
           class="Checkbox-input Checkbox-input--checked"
           data-test="DesignSystem-Checkbox-InputBox"
@@ -491,6 +510,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -514,6 +534,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -545,6 +566,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -568,6 +590,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -599,6 +622,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -622,6 +646,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -654,6 +679,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -677,6 +703,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -709,6 +736,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -732,6 +760,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -763,6 +792,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -786,6 +816,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -817,6 +848,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -840,6 +872,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -872,6 +905,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -895,6 +929,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -927,6 +962,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -950,6 +986,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -994,6 +1032,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1017,6 +1056,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -1061,6 +1102,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1084,6 +1126,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -1129,6 +1173,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1152,6 +1197,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -1197,6 +1244,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1220,6 +1268,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -1266,6 +1316,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1289,6 +1340,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           id="Checkbox-Checkbox-Test-uid"
@@ -1335,6 +1388,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1358,6 +1412,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -1405,6 +1461,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1428,6 +1485,8 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-checked="mixed"
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           class="Checkbox-input Checkbox-input--indeterminate"
           data-test="DesignSystem-Checkbox-InputBox"
           disabled=""
@@ -1475,6 +1534,7 @@ exports[`Checkbox component
         <span
           class="Text Text--disabled Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1498,6 +1558,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           checked=""
           class="Checkbox-input Checkbox-input--checked"
           data-test="DesignSystem-Checkbox-InputBox"
@@ -1545,6 +1606,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>
@@ -1568,6 +1630,7 @@ exports[`Checkbox component
         data-test="DesignSystem-Checkbox-OuterWrapper"
       >
         <input
+          aria-describedby="Checkbox-Checkbox-Test-uid-helptext"
           checked=""
           class="Checkbox-input Checkbox-input--checked"
           data-test="DesignSystem-Checkbox-InputBox"
@@ -1613,6 +1676,7 @@ exports[`Checkbox component
         <span
           class="Text Text--subtle Text--small"
           data-test="DesignSystem-Checkbox-HelpText"
+          id="Checkbox-Checkbox-Test-uid-helptext"
         >
           Checkbox
         </span>

--- a/core/components/atoms/chip/Chip.tsx
+++ b/core/components/atoms/chip/Chip.tsx
@@ -124,6 +124,7 @@ export const Chip = (props: ChipProps) => {
       name={name}
       labelPrefix={labelPrefix}
       maxWidth={maxWidth}
+      type={type}
     />
   );
 };

--- a/core/components/atoms/chipGroup/__tests__/__snapshots__/chipGroup.test.tsx.snap
+++ b/core/components/atoms/chipGroup/__tests__/__snapshots__/chipGroup.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`ChipGroup component
             </span>
           </div>
           <div
+            aria-label="Remove"
             class="Chip-icon Chip-icon--right cursor-pointer"
             data-test="DesignSystem-GenericChip--clearButton"
             role="button"
@@ -88,6 +89,7 @@ exports[`ChipGroup component
         class="ChipGroup-item"
       >
         <div
+          aria-pressed="true"
           class="Chip-wrapper Chip Chip--selection Chip-selection--selected Chip-icon--clear Chip-size--regular"
           data-test="DesignSystem-ChipGroup--Chip"
           role="button"
@@ -113,6 +115,7 @@ exports[`ChipGroup component
             </span>
           </div>
           <div
+            aria-label="Remove"
             class="Chip-icon Chip-icon--right cursor-pointer Chip-icon--selected"
             data-test="DesignSystem-GenericChip--clearButton"
             role="button"
@@ -133,6 +136,7 @@ exports[`ChipGroup component
         class="ChipGroup-item"
       >
         <div
+          aria-pressed="false"
           class="Chip-wrapper Chip Chip--selection Chip-icon--clear Chip-size--regular"
           data-test="DesignSystem-ChipGroup--Chip"
           role="button"
@@ -158,6 +162,7 @@ exports[`ChipGroup component
             </span>
           </div>
           <div
+            aria-label="Remove"
             class="Chip-icon Chip-icon--right cursor-pointer"
             data-test="DesignSystem-GenericChip--clearButton"
             role="button"

--- a/core/components/atoms/divider/Divider.tsx
+++ b/core/components/atoms/divider/Divider.tsx
@@ -33,7 +33,14 @@ export const Divider = (props: DividerProps) => {
     className
   );
 
-  return <hr data-test="DesignSystem-Divider" {...baseProps} className={DividerClass} />;
+  return (
+    <hr
+      data-test="DesignSystem-Divider"
+      {...baseProps}
+      className={DividerClass}
+      aria-orientation={vertical ? 'vertical' : 'horizontal'}
+    />
+  );
 };
 
 Divider.displayName = 'Divider';

--- a/core/components/atoms/divider/__tests__/__snapshots__/Divider.test.tsx.snap
+++ b/core/components/atoms/divider/__tests__/__snapshots__/Divider.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Divider component snapshots
 <body>
   <div>
     <hr
+      aria-orientation="horizontal"
       class="Divider Divider--horizontal Divider--basic"
       data-test="DesignSystem-Divider"
     />
@@ -19,6 +20,7 @@ exports[`Divider component snapshots
 <body>
   <div>
     <hr
+      aria-orientation="horizontal"
       class="Divider Divider--horizontal Divider--header"
       data-test="DesignSystem-Divider"
     />
@@ -32,6 +34,7 @@ exports[`Divider component snapshots
 <body>
   <div>
     <hr
+      aria-orientation="vertical"
       class="Divider Divider--vertical"
       data-test="DesignSystem-Divider"
     />
@@ -45,6 +48,7 @@ exports[`Divider component snapshots
 <body>
   <div>
     <hr
+      aria-orientation="vertical"
       class="Divider Divider--vertical"
       data-test="DesignSystem-Divider"
     />

--- a/core/components/atoms/dropdown/DropdownList.tsx
+++ b/core/components/atoms/dropdown/DropdownList.tsx
@@ -494,8 +494,6 @@ const DropdownList = (props: OptionsProps) => {
           icon={'search'}
           value={searchTerm}
           placeholder={searchPlaceholder}
-          // TODO(a11y): research more on this.
-          // eslint-disable-next-line jsx-a11y/no-autofocus
           autoFocus={true}
           onChange={searchHandler}
           onClear={searchClearHandler}
@@ -730,9 +728,7 @@ const DropdownList = (props: OptionsProps) => {
   const enableSearch = withSearch || props.async;
 
   return (
-    //TODO(a11y)
-    //eslint-disable-next-line
-    <div {...baseProps} className={dropdownClass} ref={triggerRef} onKeyDown={onkeydown}>
+    <div {...baseProps} className={dropdownClass} ref={triggerRef} onKeyDown={onkeydown} role="presentation">
       <Popover
         onToggle={onToggleDropdown}
         trigger={trigger}

--- a/core/components/atoms/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/core/components/atoms/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -50,6 +51,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -93,6 +95,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -136,6 +139,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -179,6 +183,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -230,6 +235,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -279,6 +285,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -322,6 +329,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -374,6 +382,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -424,6 +433,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -468,6 +478,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -511,6 +522,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -554,6 +566,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -597,6 +610,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -640,6 +654,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -683,6 +698,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -717,6 +733,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -760,6 +777,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -803,6 +821,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -846,6 +865,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -889,6 +909,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -932,6 +953,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -975,6 +997,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -1018,6 +1041,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -1061,6 +1085,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -1104,6 +1129,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -1147,6 +1173,7 @@ exports[`Dropdown component
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div

--- a/core/components/atoms/dropdown/option/DefaultOption.tsx
+++ b/core/components/atoms/dropdown/option/DefaultOption.tsx
@@ -7,16 +7,26 @@ const DefaultOption = (props: OptionTypeProps) => {
   const { className, textClassName, onClickHandler, optionData, color, onUpdateActiveOption, dataTest } = props;
 
   const { label, disabled } = optionData;
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
 
   return (
-    // TODO(a11y): fix accessibility
-    /* eslint-disable */
     <div
       className={className}
       onClick={onClickHandler}
+      onKeyDown={handleKeyDown}
       onMouseEnter={onUpdateActiveOption}
       data-test={dataTest}
       data-disabled={disabled}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
     >
       {/* eslint-enable  */}
       <div className={styles['Option-label']}>

--- a/core/components/atoms/dropdown/option/IconOption.tsx
+++ b/core/components/atoms/dropdown/option/IconOption.tsx
@@ -18,16 +18,26 @@ const IconOption = (props: OptionTypeProps) => {
     [styles['Option-icon']]: true,
     ['mr-4']: true,
   });
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
 
   return (
-    // TODO(a11y): fix accessibility
-    /* eslint-disable */
     <div
       className={OptionClass}
       onClick={onClickHandler}
+      onKeyDown={handleKeyDown}
       onMouseEnter={onUpdateActiveOption}
       data-test={dataTest}
       data-disabled={disabled}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
     >
       {/* eslint-enable  */}
       {icon && <Icon className={IconClass} data-test={`${dataTest}--Icon`} name={icon} type={iconType} />}

--- a/core/components/atoms/dropdown/option/IconWithMetaOption.tsx
+++ b/core/components/atoms/dropdown/option/IconWithMetaOption.tsx
@@ -28,16 +28,26 @@ const IconWithMetaOption = (props: OptionTypeProps) => {
     [styles['Option-icon']]: true,
     ['mr-4']: true,
   });
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
 
   return (
-    // TODO(a11y): fix accessibility
-    /* eslint-disable */
     <div
       className={OptionClass}
       onClick={onClickHandler}
+      onKeyDown={handleKeyDown}
       onMouseEnter={onUpdateActiveOption}
       data-test={dataTest}
       data-disabled={disabled}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
     >
       {/* eslint-enable  */}
       {icon && <Icon data-test={`${dataTest}--Icon`} className={IconClass} name={icon} appearance={appearance} />}

--- a/core/components/atoms/dropdown/option/MetaOption.tsx
+++ b/core/components/atoms/dropdown/option/MetaOption.tsx
@@ -8,16 +8,26 @@ const MetaOption = (props: OptionTypeProps) => {
     props;
 
   const { subInfo, label, disabled } = optionData;
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
 
   return (
-    // TODO(a11y): fix accessibility
-    /* eslint-disable */
     <div
       className={className}
       onClick={onClickHandler}
+      onKeyDown={handleKeyDown}
       onMouseEnter={onUpdateActiveOption}
       data-test={dataTest}
       data-disabled={disabled}
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
     >
       {/* eslint-enable */}
       <div className={styles['Option-label']}>

--- a/core/components/atoms/editable/Editable.tsx
+++ b/core/components/atoms/editable/Editable.tsx
@@ -19,16 +19,23 @@ export const Editable = (props: EditableProps) => {
     },
     className
   );
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onChange('edit');
+    }
+  };
 
   return (
     <div data-test="DesignSystem-Editable" {...baseProps} className={EditableClass}>
-      {/* TODO(a11y): fix accessibility */}
-      {/* eslint-disable  */}
       <div
         data-test="DesignSystem-EditableWrapper"
         onClick={() => onChange('edit')}
+        onKeyDown={handleKeyDown}
         onMouseEnter={() => !editing && onChange('hover')}
         onMouseLeave={() => !editing && onChange('default')}
+        role="button"
+        tabIndex={0}
       >
         {/* eslint-enable  */}
         {children}

--- a/core/components/atoms/editable/__tests__/__snapshots__/Editable.test.tsx.snap
+++ b/core/components/atoms/editable/__tests__/__snapshots__/Editable.test.tsx.snap
@@ -10,6 +10,8 @@ exports[`Editable component
   >
     <div
       data-test="DesignSystem-EditableWrapper"
+      role="button"
+      tabindex="0"
     >
       <div>
         First Name

--- a/core/components/atoms/label/Label.tsx
+++ b/core/components/atoms/label/Label.tsx
@@ -68,7 +68,13 @@ export const Label = (props: LabelProps) => {
 
   const renderInfo = (isRequired = false, isOptional?: boolean) => {
     if (isRequired) {
-      return <span className={styles['Label-requiredIndicator']} data-test="DesignSystem-Label--RequiredIndicator" />;
+      return (
+        <span
+          className={styles['Label-requiredIndicator']}
+          aria-label="required"
+          data-test="DesignSystem-Label--RequiredIndicator"
+        />
+      );
     }
 
     if (isOptional) {
@@ -89,6 +95,7 @@ export const Label = (props: LabelProps) => {
           name="info"
           size={12}
           appearance="subtle"
+          aria-label={info}
           className="ml-3 cursor-pointer d-flex align-items-center"
         />
       </Tooltip>

--- a/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`Label component - info prop tests
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="long information text"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -132,6 +133,7 @@ exports[`Label component - info prop tests
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="sample info"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -165,6 +167,7 @@ exports[`Label component - info prop tests
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="tooltip text"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -246,6 +249,7 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
       >
         Complex Small Label
         <span
+          aria-label="required"
           class="Label-requiredIndicator"
           data-test="DesignSystem-Label--RequiredIndicator"
         />
@@ -254,6 +258,7 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="Small label info"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -305,6 +310,7 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
       >
         Small Required Label
         <span
+          aria-label="required"
           class="Label-requiredIndicator"
           data-test="DesignSystem-Label--RequiredIndicator"
         />

--- a/core/components/atoms/legend/Legend.tsx
+++ b/core/components/atoms/legend/Legend.tsx
@@ -28,7 +28,7 @@ export interface LegendProps extends BaseProps {
   /**
    * Handler to be called when `Legend` is clicked
    */
-  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void;
   /**
    * Handler to be called when mouse pointer enters `Legend`.
    */
@@ -53,6 +53,18 @@ export const Legend = (props: LegendProps) => {
   } = props;
 
   const baseProps = extractBaseProps(props);
+  const isClickable = Boolean(onClick);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) {
+      return;
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick?.(event);
+    }
+  };
 
   const legendClass = classNames(
     {
@@ -67,17 +79,17 @@ export const Legend = (props: LegendProps) => {
     width: `${iconSize}px`,
   };
 
-  // TODO(a11y): fix accessibility
-  /* eslint-disable */
   return (
     <div
       {...baseProps}
       className={legendClass}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
       onClick={(e) => onClick && onClick(e)}
+      onKeyDown={handleKeyDown}
       onMouseEnter={(e) => onMouseEnter && onMouseEnter(e)}
       onMouseLeave={(e) => onMouseLeave && onMouseLeave(e)}
     >
-      {/* eslint-enable */}
       <span className={legendStyles['Legend-icon']} style={styles} />
       <Text appearance={labelAppearance} weight={labelWeight}>
         {children}

--- a/core/components/atoms/link/Link.tsx
+++ b/core/components/atoms/link/Link.tsx
@@ -81,6 +81,7 @@ export const Link = (props: LinkProps) => {
       className={classes}
       componentType="a"
       tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
       {...rest}
     >
       {children}

--- a/core/components/atoms/link/__tests__/__snapshots__/Link.test.tsx.snap
+++ b/core/components/atoms/link/__tests__/__snapshots__/Link.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Link component
 <body>
   <div>
     <a
+      aria-disabled="false"
       class="Link Link--regular Link--default"
       data-test="DesignSystem-Link"
       href="Sample string"
@@ -26,6 +27,7 @@ exports[`Link component
 <body>
   <div>
     <a
+      aria-disabled="false"
       class="Link Link--regular Link--default"
       data-test="DesignSystem-Link"
       href="Sample string"
@@ -46,6 +48,7 @@ exports[`Link component
 <body>
   <div>
     <a
+      aria-disabled="false"
       class="Link Link--regular Link--default"
       data-test="DesignSystem-Link"
       href="Sample string"
@@ -66,6 +69,7 @@ exports[`Link component
 <body>
   <div>
     <a
+      aria-disabled="false"
       class="Link Link--regular Link--default"
       data-test="DesignSystem-Link"
       href="Sample string"

--- a/core/components/atoms/message/Message.tsx
+++ b/core/components/atoms/message/Message.tsx
@@ -102,9 +102,15 @@ export const Message = (props: MessageProps) => {
   };
 
   return (
-    <div data-test="DesignSystem-Message" {...baseProps} className={MessageClass}>
+    <div
+      data-test="DesignSystem-Message"
+      role={appearance === 'alert' || appearance === 'warning' ? 'alert' : 'status'}
+      {...baseProps}
+      className={MessageClass}
+    >
       <Icon
         data-test="DesignSystem-Message--Icon"
+        aria-hidden="true"
         name={IconMapping[appearance]}
         size={size === 'small' ? 14 : 16}
         appearance={appearance}

--- a/core/components/atoms/message/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/core/components/atoms/message/__tests__/__snapshots__/Message.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Message component
     <div
       class="Message Message--alert"
       data-test="DesignSystem-Message"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--alert Message-icon--alert Message-icon--regular Message-icon--withTitle"
@@ -61,6 +62,7 @@ exports[`Message component
     <div
       class="Message Message--alert"
       data-test="DesignSystem-Message"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--alert Message-icon--alert Message-icon--regular Message-icon--withTitle"
@@ -114,6 +116,7 @@ exports[`Message component
     <div
       class="Message Message--alert Message--small"
       data-test="DesignSystem-Message"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--alert Message-icon--alert Message-icon--small Message-icon--withTitle"
@@ -167,6 +170,7 @@ exports[`Message component
     <div
       class="Message Message--info"
       data-test="DesignSystem-Message"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--regular Message-icon--withTitle"
@@ -220,6 +224,7 @@ exports[`Message component
     <div
       class="Message Message--info"
       data-test="DesignSystem-Message"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--regular Message-icon--withTitle"
@@ -273,6 +278,7 @@ exports[`Message component
     <div
       class="Message Message--info Message--small"
       data-test="DesignSystem-Message"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--small Message-icon--withTitle"
@@ -326,6 +332,7 @@ exports[`Message component
     <div
       class="Message Message--success"
       data-test="DesignSystem-Message"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--success Message-icon--success Message-icon--regular Message-icon--withTitle"
@@ -379,6 +386,7 @@ exports[`Message component
     <div
       class="Message Message--success"
       data-test="DesignSystem-Message"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--success Message-icon--success Message-icon--regular Message-icon--withTitle"
@@ -432,6 +440,7 @@ exports[`Message component
     <div
       class="Message Message--success Message--small"
       data-test="DesignSystem-Message"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--success Message-icon--success Message-icon--small Message-icon--withTitle"
@@ -485,6 +494,7 @@ exports[`Message component
     <div
       class="Message Message--warning"
       data-test="DesignSystem-Message"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--warning Message-icon--warning Message-icon--regular Message-icon--withTitle"
@@ -538,6 +548,7 @@ exports[`Message component
     <div
       class="Message Message--warning"
       data-test="DesignSystem-Message"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--warning Message-icon--warning Message-icon--regular Message-icon--withTitle"
@@ -591,6 +602,7 @@ exports[`Message component
     <div
       class="Message Message--warning Message--small"
       data-test="DesignSystem-Message"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Icon--warning Message-icon--warning Message-icon--small Message-icon--withTitle"

--- a/core/components/atoms/meter/Meter.tsx
+++ b/core/components/atoms/meter/Meter.tsx
@@ -183,6 +183,7 @@ export const Meter = (props: MeterProps) => {
       aria-valuemax={max}
       aria-valuenow={value}
       aria-label={ariaLabel}
+      aria-valuetext={label.toString()}
       {...rest}
     >
       {steps}

--- a/core/components/atoms/multiSlider/Handle.tsx
+++ b/core/components/atoms/multiSlider/Handle.tsx
@@ -118,11 +118,10 @@ export class Handle extends React.Component<InternalHandleProps, HandleState> {
     const { stepSize, value } = this.props;
     const { keyCode } = event;
 
-    // TODO(a11y): add ARROW_DOWN & ARROW_UP too
-    if (keyCode === Keys.ARROW_LEFT) {
+    if (keyCode === Keys.ARROW_LEFT || keyCode === Keys.ARROW_DOWN) {
       this.changeValue(value - stepSize);
       event.preventDefault();
-    } else if (keyCode === Keys.ARROW_RIGHT) {
+    } else if (keyCode === Keys.ARROW_RIGHT || keyCode === Keys.ARROW_UP) {
       this.changeValue(value + stepSize);
       event.preventDefault();
     }
@@ -131,7 +130,7 @@ export class Handle extends React.Component<InternalHandleProps, HandleState> {
   handleKeyUp = (event: React.KeyboardEvent<HTMLSpanElement>) => {
     if (this.props.disabled) return;
 
-    if ([Keys.ARROW_LEFT, Keys.ARROW_RIGHT].indexOf(event.keyCode) >= 0) {
+    if ([Keys.ARROW_LEFT, Keys.ARROW_RIGHT, Keys.ARROW_UP, Keys.ARROW_DOWN].indexOf(event.keyCode) >= 0) {
       const { onRelease } = this.props;
       if (onRelease) onRelease(this.props.value);
     }
@@ -186,20 +185,26 @@ export class Handle extends React.Component<InternalHandleProps, HandleState> {
     });
 
     return (
-      // TODO(a11y): fix accessibility
-      /* eslint-disable */
       <>
         <div
           className={className}
           onMouseOver={this.handleMouseOver}
+          onFocus={this.handleMouseOver}
           onMouseLeave={this.handleMouseLeave}
+          onBlur={this.handleMouseLeave}
           onMouseDown={this.beginHandleMovement}
           onKeyDown={this.handleKeyDown}
           onKeyUp={this.handleKeyUp}
           ref={this.refHandlers.handle}
           style={style}
-          tabIndex={0}
+          tabIndex={disabled ? -1 : 0}
           data-test="DesignSystem-MultiSlider-Handle"
+          role="slider"
+          aria-valuemin={this.props.min}
+          aria-valuemax={this.props.max}
+          aria-valuenow={value}
+          aria-valuetext={label}
+          aria-disabled={disabled || undefined}
         />
         {/* eslint-enable  */}
         <div className={TooltipClass} style={style}>

--- a/core/components/atoms/multiSlider/__tests__/__snapshots__/MultiSlider.test.tsx.snap
+++ b/core/components/atoms/multiSlider/__tests__/__snapshots__/MultiSlider.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`MultiSlider component
         <div
           class="Slider-track"
           data-test="DesignSystem-MultiSlider-Slider-Track"
+          role="button"
         >
           <div
             class="Slider-progress"
@@ -38,6 +39,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 0.00%;"
           >
             <span
@@ -53,6 +55,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 10.00%;"
           >
             <span
@@ -68,6 +71,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 20.00%;"
           >
             <span
@@ -83,6 +87,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 30.00%;"
           >
             <span
@@ -98,6 +103,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 40.00%;"
           >
             <span
@@ -113,6 +119,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 50.00%;"
           >
             <span
@@ -128,6 +135,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 60.00%;"
           >
             <span
@@ -143,6 +151,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 70.00%;"
           >
             <span
@@ -158,6 +167,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 80.00%;"
           >
             <span
@@ -173,6 +183,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 90.00%;"
           >
             <span
@@ -188,6 +199,7 @@ exports[`MultiSlider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 100.00%;"
           >
             <span

--- a/core/components/atoms/multiSlider/index.tsx
+++ b/core/components/atoms/multiSlider/index.tsx
@@ -334,12 +334,23 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
       labels.push(
         <div
           onClick={onClickHandler}
+          onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+            if (!this.props.disabled && (event.key === 'Enter' || event.key === ' ')) {
+              event.preventDefault();
+              onClickHandler(event as unknown as React.MouseEvent<HTMLElement>);
+            }
+          }}
           className={styles['Slider-label']}
           key={i}
           style={style}
           onMouseOver={() => this.handleLabelMouseOver(i)}
+          onFocus={() => this.handleLabelMouseOver(i)}
           onMouseLeave={this.handleLabelMouseLeave}
+          onBlur={this.handleLabelMouseLeave}
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
+          // tabIndex={disabled ? -1 : 0}
+          aria-disabled={disabled || undefined}
         >
           {/* eslint-enable  */}
           <span className={SliderTicksClass} />
@@ -430,7 +441,16 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
             className={styles['Slider-track']}
             ref={(ref) => (this.trackElement = ref)}
             onMouseDown={this.maybeHandleTrackClick}
+            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (!this.props.disabled && (event.key === 'Enter' || event.key === ' ')) {
+                event.preventDefault();
+                this.maybeHandleTrackClick(event as unknown as React.MouseEvent<HTMLDivElement>);
+              }
+            }}
             data-test="DesignSystem-MultiSlider-Slider-Track"
+            role="button"
+            // tabIndex={this.props.disabled ? -1 : 0}
+            aria-disabled={this.props.disabled || undefined}
           >
             {/* eslint-enable */}
             {this.renderTracks()}

--- a/core/components/atoms/pills/Pills.tsx
+++ b/core/components/atoms/pills/Pills.tsx
@@ -21,7 +21,7 @@ export interface PillsProps extends BaseProps {
 }
 
 export const Pills = (props: PillsProps) => {
-  const { appearance, children, subtle, className } = props;
+  const { appearance, children, subtle, className, ...rest } = props;
 
   const baseProps = extractBaseProps(props);
 
@@ -35,7 +35,12 @@ export const Pills = (props: PillsProps) => {
   );
 
   return (
-    <span data-test="DesignSystem-Pills" {...baseProps} className={classes}>
+    <span
+      data-test="DesignSystem-Pills"
+      role={rest['aria-label'] ? 'status' : undefined}
+      {...baseProps}
+      className={classes}
+    >
       {children}
     </span>
   );

--- a/core/components/atoms/progressBar/ProgressBar.tsx
+++ b/core/components/atoms/progressBar/ProgressBar.tsx
@@ -52,8 +52,20 @@ export const ProgressBar = (props: ProgressBarProps) => {
     [styles['ProgressBar-indicator--indeterminate']]: state === 'indeterminate',
   });
 
+  const clampedValue = state !== 'indeterminate' ? Math.max(0, Math.min(value || 0, max)) : undefined;
+  const percentage = state !== 'indeterminate' && max > 0 ? Math.round(((clampedValue || 0) * 100) / max) : undefined;
+
   return (
-    <div data-test="DesignSystem-ProgressBar" {...baseProps} className={ProgressBarClass}>
+    <div
+      data-test="DesignSystem-ProgressBar"
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={max}
+      aria-valuenow={clampedValue}
+      aria-valuetext={percentage !== undefined ? `${percentage}%` : undefined}
+      {...baseProps}
+      className={ProgressBarClass}
+    >
       <div data-test="DesignSystem-ProgressBar-Indicator" className={ProgressIndicatorClass} style={style} />
     </div>
   );

--- a/core/components/atoms/progressBar/__tests__/__snapshots__/ProgressBar.test.tsx.snap
+++ b/core/components/atoms/progressBar/__tests__/__snapshots__/ProgressBar.test.tsx.snap
@@ -6,8 +6,13 @@ exports[`ProgressBar component
 <body>
   <div>
     <div
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="10"
+      aria-valuetext="10%"
       class="ProgressBar ProgressBar-indicator--regular"
       data-test="DesignSystem-ProgressBar"
+      role="progressbar"
     >
       <div
         class="ProgressBar-indicator"
@@ -25,8 +30,11 @@ exports[`ProgressBar component
 <body>
   <div>
     <div
+      aria-valuemax="100"
+      aria-valuemin="0"
       class="ProgressBar ProgressBar-indicator--regular position-relative overflow-hidden"
       data-test="DesignSystem-ProgressBar"
+      role="progressbar"
     >
       <div
         class="ProgressBar-indicator ProgressBar-indicator--indeterminate"
@@ -43,8 +51,13 @@ exports[`ProgressBar component
 <body>
   <div>
     <div
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="10"
+      aria-valuetext="10%"
       class="ProgressBar ProgressBar-indicator--small"
       data-test="DesignSystem-ProgressBar"
+      role="progressbar"
     >
       <div
         class="ProgressBar-indicator"
@@ -62,8 +75,11 @@ exports[`ProgressBar component
 <body>
   <div>
     <div
+      aria-valuemax="100"
+      aria-valuemin="0"
       class="ProgressBar ProgressBar-indicator--small position-relative overflow-hidden"
       data-test="DesignSystem-ProgressBar"
+      role="progressbar"
     >
       <div
         class="ProgressBar-indicator ProgressBar-indicator--indeterminate"

--- a/core/components/atoms/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/core/components/atoms/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Slider component
         <div
           class="Slider-track"
           data-test="DesignSystem-MultiSlider-Slider-Track"
+          role="button"
         >
           <div
             class="Slider-progress Slider-progress--inRange"
@@ -31,6 +32,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 0.00%;"
           >
             <span
@@ -46,6 +48,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 10.00%;"
           >
             <span
@@ -61,6 +64,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 20.00%;"
           >
             <span
@@ -76,6 +80,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 30.00%;"
           >
             <span
@@ -91,6 +96,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 40.00%;"
           >
             <span
@@ -106,6 +112,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 50.00%;"
           >
             <span
@@ -121,6 +128,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 60.00%;"
           >
             <span
@@ -136,6 +144,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 70.00%;"
           >
             <span
@@ -151,6 +160,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 80.00%;"
           >
             <span
@@ -166,6 +176,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 90.00%;"
           >
             <span
@@ -181,6 +192,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 100.00%;"
           >
             <span
@@ -195,8 +207,13 @@ exports[`Slider component
           </div>
         </div>
         <div
+          aria-valuemax="10"
+          aria-valuemin="0"
+          aria-valuenow="10"
+          aria-valuetext="10"
           class="Slider-handle"
           data-test="DesignSystem-MultiSlider-Handle"
+          role="slider"
           style="left: calc(100.00% - 0px);"
           tabindex="0"
         />
@@ -227,6 +244,7 @@ exports[`Slider component
         <div
           class="Slider-track"
           data-test="DesignSystem-MultiSlider-Slider-Track"
+          role="button"
         >
           <div
             class="Slider-progress Slider-progress--inRange"
@@ -243,6 +261,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 0.00%;"
           >
             <span
@@ -258,6 +277,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 10.00%;"
           >
             <span
@@ -273,6 +293,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 20.00%;"
           >
             <span
@@ -288,6 +309,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 30.00%;"
           >
             <span
@@ -303,6 +325,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 40.00%;"
           >
             <span
@@ -318,6 +341,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 50.00%;"
           >
             <span
@@ -333,6 +357,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 60.00%;"
           >
             <span
@@ -348,6 +373,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 70.00%;"
           >
             <span
@@ -363,6 +389,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 80.00%;"
           >
             <span
@@ -378,6 +405,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 90.00%;"
           >
             <span
@@ -393,6 +421,7 @@ exports[`Slider component
           <div
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
+            role="button"
             style="left: 100.00%;"
           >
             <span
@@ -407,8 +436,13 @@ exports[`Slider component
           </div>
         </div>
         <div
+          aria-valuemax="10"
+          aria-valuemin="0"
+          aria-valuenow="10"
+          aria-valuetext="10"
           class="Slider-handle"
           data-test="DesignSystem-MultiSlider-Handle"
+          role="slider"
           style="left: calc(100.00% - 0px);"
           tabindex="0"
         />

--- a/core/components/atoms/spinner/Spinner.tsx
+++ b/core/components/atoms/spinner/Spinner.tsx
@@ -15,10 +15,15 @@ export interface SpinnerProps extends BaseProps {
    * Size of `Spinner`
    */
   size: SpinnerSize;
+  /**
+   * Accessible name for the spinner
+   * @default "Loading"
+   */
+  ariaLabel?: string;
 }
 
 export const Spinner = (props: SpinnerProps) => {
-  const { appearance, size, className } = props;
+  const { appearance, size, className, ariaLabel = 'Loading' } = props;
 
   const baseProps = extractBaseProps(props);
 
@@ -56,7 +61,14 @@ export const Spinner = (props: SpinnerProps) => {
   };
 
   return (
-    <svg {...baseProps} className={wrapperClasses} {...svgProps}>
+    <svg
+      {...baseProps}
+      role="status"
+      aria-live="polite"
+      aria-label={ariaLabel}
+      className={wrapperClasses}
+      {...svgProps}
+    >
       <circle className={circleClasses} {...circleProps} />
     </svg>
   );

--- a/core/components/atoms/spinner/__stories__/Appearance.story.jsx
+++ b/core/components/atoms/spinner/__stories__/Appearance.story.jsx
@@ -3,7 +3,7 @@ import { Spinner, Text } from '@/index';
 
 // CSF format story
 export const appearance = () => {
-  const appearances = ['primary', 'secondary', 'white'];
+  const appearances = ['primary', 'secondary', 'white', 'alert'];
   return (
     <div className="d-flex">
       {appearances.map((appear, ind) => {

--- a/core/components/atoms/spinner/__tests__/Spinner.test.tsx
+++ b/core/components/atoms/spinner/__tests__/Spinner.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import Spinner, { SpinnerProps as Props } from '../Spinner';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
 
-const appearance = ['primary', 'secondary', 'white'];
+const appearance = ['primary', 'secondary', 'white', 'alert'];
 const size = ['xsmall', 'small', 'medium', 'large'];
 
 describe('Spinner component', () => {

--- a/core/components/atoms/spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
+++ b/core/components/atoms/spinner/__tests__/__snapshots__/Spinner.test.tsx.snap
@@ -1,12 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Spinner component 
+  appearance: "alert"
+ 1`] = `
+<body>
+  <div>
+    <svg
+      aria-label="Loading"
+      aria-live="polite"
+      class="Spinner Spinner--medium"
+      role="status"
+      viewBox="0 0 50 50"
+    >
+      <circle
+        class="Circle Circle--alert"
+        cx="25"
+        cy="25"
+        fill="none"
+        r="20"
+        stroke-miterlimit="10"
+        stroke-width="4"
+      />
+    </svg>
+  </div>
+</body>
+`;
+
+exports[`Spinner component 
   appearance: "primary"
  1`] = `
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--medium"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle
@@ -29,7 +58,10 @@ exports[`Spinner component
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--medium"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle
@@ -52,7 +84,10 @@ exports[`Spinner component
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--medium"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle
@@ -75,7 +110,10 @@ exports[`Spinner component
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--large"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle
@@ -98,7 +136,10 @@ exports[`Spinner component
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--medium"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle
@@ -121,7 +162,10 @@ exports[`Spinner component
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--small"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle
@@ -144,7 +188,10 @@ exports[`Spinner component
 <body>
   <div>
     <svg
+      aria-label="Loading"
+      aria-live="polite"
       class="Spinner Spinner--xsmall"
+      role="status"
       viewBox="0 0 50 50"
     >
       <circle

--- a/core/components/atoms/statusHint/StatusHint.tsx
+++ b/core/components/atoms/statusHint/StatusHint.tsx
@@ -52,6 +52,15 @@ export const StatusHint = (props: StatusHintProps) => {
   } = props;
 
   const baseProps = extractBaseProps(props);
+  const isClickable = Boolean(onClick);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
 
   const StatusHintClass = classNames(
     {
@@ -84,18 +93,19 @@ export const StatusHint = (props: StatusHintProps) => {
   };
 
   return (
-    // TODO(a11y): fix accessibility
-    /* eslint-disable */
     <div
       data-test="DesignSystem-StatusHint"
       {...baseProps}
       className={StatusHintClass}
       onClick={(e) => onClick && onClick(e)}
+      onKeyDown={handleKeyDown}
       onMouseEnter={(e) => onMouseEnter && onMouseEnter(e)}
       onMouseLeave={(e) => onMouseLeave && onMouseLeave(e)}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
     >
       {/* eslint-enable */}
-      <span data-test="DesignSystem-StatusHint--Icon" className={StatusHintIconClass} />
+      <span data-test="DesignSystem-StatusHint--Icon" aria-hidden="true" className={StatusHintIconClass} />
       {renderChildren()}
     </div>
   );

--- a/core/components/atoms/statusHint/__tests__/__snapshots__/StatusHint.test.tsx.snap
+++ b/core/components/atoms/statusHint/__tests__/__snapshots__/StatusHint.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--alert mr-4"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -34,6 +35,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--alert mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -58,6 +60,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--default mr-4"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -82,6 +85,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--default mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -106,6 +110,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--info mr-4"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -130,6 +135,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--info mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -154,6 +160,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--success mr-4"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -178,6 +185,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--success mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -202,6 +210,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--warning mr-4"
         data-test="DesignSystem-StatusHint--Icon"
       />
@@ -226,6 +235,7 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
+        aria-hidden="true"
         class="StatusHint-icon StatusHint--warning mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
       />

--- a/core/components/atoms/subheading/Subheading.tsx
+++ b/core/components/atoms/subheading/Subheading.tsx
@@ -34,7 +34,14 @@ export const Subheading = React.forwardRef<HTMLHeadingElement, SubheadingProps>(
   );
 
   return (
-    <GenericText ref={ref} data-test="DesignSystem-Subheading" {...rest} className={classes} componentType={'h4'}>
+    <GenericText
+      ref={ref}
+      data-test="DesignSystem-Subheading"
+      {...rest}
+      className={classes}
+      componentType={'h4'}
+      aria-level={4}
+    >
       {children}
     </GenericText>
   );

--- a/core/components/atoms/subheading/__tests__/__snapshots__/Subheading.test.tsx.snap
+++ b/core/components/atoms/subheading/__tests__/__snapshots__/Subheading.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Subheading component
 <body>
   <div>
     <h4
+      aria-level="4"
       class="Subheading Subheading--default"
       data-test="DesignSystem-Subheading"
     >
@@ -21,6 +22,7 @@ exports[`Subheading component
 <body>
   <div>
     <h4
+      aria-level="4"
       class="Subheading Subheading--disabled"
       data-test="DesignSystem-Subheading"
     >
@@ -36,6 +38,7 @@ exports[`Subheading component
 <body>
   <div>
     <h4
+      aria-level="4"
       class="Subheading Subheading--subtle"
       data-test="DesignSystem-Subheading"
     >
@@ -51,6 +54,7 @@ exports[`Subheading component
 <body>
   <div>
     <h4
+      aria-level="4"
       class="Subheading Subheading--white"
       data-test="DesignSystem-Subheading"
     >

--- a/core/components/atoms/switchInput/Switch.tsx
+++ b/core/components/atoms/switchInput/Switch.tsx
@@ -103,6 +103,8 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>((props, re
       <input
         {...rest}
         type="checkbox"
+        role="switch"
+        aria-checked={checked}
         defaultChecked={defaultChecked}
         disabled={disabled}
         onChange={onChangeHandler}

--- a/core/components/atoms/switchInput/__tests__/__snapshots__/Switch.test.tsx.snap
+++ b/core/components/atoms/switchInput/__tests__/__snapshots__/Switch.test.tsx.snap
@@ -9,8 +9,10 @@ exports[`Switch component
       class="Switch Switch--regular"
     >
       <input
+        aria-checked="true"
         checked=""
         class="Switch-input"
+        role="switch"
         type="checkbox"
         value=""
       />
@@ -31,8 +33,10 @@ exports[`Switch component
       class="Switch Switch--regular"
     >
       <input
+        aria-checked="true"
         checked=""
         class="Switch-input"
+        role="switch"
         type="checkbox"
         value=""
       />
@@ -53,9 +57,11 @@ exports[`Switch component
       class="Switch Switch--disabled Switch--regular"
     >
       <input
+        aria-checked="true"
         checked=""
         class="Switch-input"
         disabled=""
+        role="switch"
         type="checkbox"
         value=""
       />
@@ -76,8 +82,10 @@ exports[`Switch component
       class="Switch Switch--regular"
     >
       <input
+        aria-checked="true"
         checked=""
         class="Switch-input"
+        role="switch"
         type="checkbox"
         value=""
       />
@@ -98,8 +106,10 @@ exports[`Switch component
       class="Switch Switch--tiny"
     >
       <input
+        aria-checked="true"
         checked=""
         class="Switch-input"
+        role="switch"
         type="checkbox"
         value=""
       />

--- a/core/components/atoms/textarea/Textarea.tsx
+++ b/core/components/atoms/textarea/Textarea.tsx
@@ -105,6 +105,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>((pr
   return (
     <textarea
       data-test="DesignSystem-Textarea"
+      aria-invalid={error}
       {...rest}
       ref={ref}
       name={name}

--- a/core/components/atoms/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
+++ b/core/components/atoms/textarea/__tests__/__snapshots__/Textarea.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`Textarea component size prop snapshot validation matches snapshot for s
 exports[`Textarea component size prop snapshot validation matches snapshot for small size with all modifiers 1`] = `
 <DocumentFragment>
   <textarea
+    aria-invalid="true"
     class="Textarea Textarea--error Textarea--readOnly Textarea--small"
     data-test="DesignSystem-Textarea"
     name="complex-textarea"

--- a/core/components/atoms/toast/Toast.tsx
+++ b/core/components/atoms/toast/Toast.tsx
@@ -106,8 +106,13 @@ export const Toast = (props: ToastProps) => {
   };
 
   return (
-    <div {...baseProps} className={wrapperClass}>
-      {icon && <Icon name={icon} className={iconClass('left')} />}
+    <div
+      {...baseProps}
+      className={wrapperClass}
+      role={appearance === 'alert' || appearance === 'warning' ? 'alert' : 'status'}
+      aria-live={appearance === 'alert' || appearance === 'warning' ? 'assertive' : 'polite'}
+    >
+      {icon && <Icon name={icon} className={iconClass('left')} aria-hidden="true" />}
       <div className={styles['Toast-body']}>
         <div className={titleClass}>
           <Heading size="s" className={headingClass} appearance={appearance !== 'warning' ? 'white' : 'default'}>
@@ -118,6 +123,7 @@ export const Toast = (props: ToastProps) => {
             className={iconClass('right')}
             onClick={onCloseHandler}
             appearance={appearance !== 'warning' ? 'white' : 'default'}
+            aria-label="Close"
           />
         </div>
         {message && (

--- a/core/components/atoms/toast/__tests__/__snapshots__/Toast.test.tsx.snap
+++ b/core/components/atoms/toast/__tests__/__snapshots__/Toast.test.tsx.snap
@@ -6,7 +6,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="assertive"
       class="Toast Toast--alert"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--alert"
@@ -29,6 +31,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--alert Toast-close-icon--alert"
             data-test="DesignSystem-Icon"
             role="button"
@@ -50,7 +53,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="polite"
       class="Toast Toast--info"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
@@ -73,6 +78,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--info Toast-close-icon--info"
             data-test="DesignSystem-Icon"
             role="button"
@@ -94,7 +100,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="polite"
       class="Toast Toast--success"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--success"
@@ -117,6 +125,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--success Toast-close-icon--success"
             data-test="DesignSystem-Icon"
             role="button"
@@ -138,7 +147,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="assertive"
       class="Toast Toast--warning"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--warning"
@@ -161,6 +172,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--default Toast-icon Toast-icon--right Toast-icon--warning Toast-close-icon--warning"
             data-test="DesignSystem-Icon"
             role="button"
@@ -182,7 +194,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="assertive"
       class="Toast Toast--withMessage Toast--alert"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--alert"
@@ -205,6 +219,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--alert Toast-close-icon--alert"
             data-test="DesignSystem-Icon"
             role="button"
@@ -232,7 +247,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="assertive"
       class="Toast Toast--withMessage Toast--alert"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--alert"
@@ -255,6 +272,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--alert Toast-close-icon--alert"
             data-test="DesignSystem-Icon"
             role="button"
@@ -296,7 +314,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="polite"
       class="Toast Toast--withMessage Toast--info"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
@@ -319,6 +339,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--info Toast-close-icon--info"
             data-test="DesignSystem-Icon"
             role="button"
@@ -346,7 +367,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="polite"
       class="Toast Toast--withMessage Toast--info"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
@@ -369,6 +392,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--info Toast-close-icon--info"
             data-test="DesignSystem-Icon"
             role="button"
@@ -410,7 +434,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="polite"
       class="Toast Toast--withMessage Toast--success"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--success"
@@ -433,6 +459,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--success Toast-close-icon--success"
             data-test="DesignSystem-Icon"
             role="button"
@@ -460,7 +487,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="polite"
       class="Toast Toast--withMessage Toast--success"
+      role="status"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--success"
@@ -483,6 +512,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--success Toast-close-icon--success"
             data-test="DesignSystem-Icon"
             role="button"
@@ -524,7 +554,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="assertive"
       class="Toast Toast--withMessage Toast--warning"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--warning"
@@ -547,6 +579,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--default Toast-icon Toast-icon--right Toast-icon--warning Toast-close-icon--warning"
             data-test="DesignSystem-Icon"
             role="button"
@@ -574,7 +607,9 @@ exports[`Toast component
 <body>
   <div>
     <div
+      aria-live="assertive"
       class="Toast Toast--withMessage Toast--warning"
+      role="alert"
     >
       <i
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--warning"
@@ -597,6 +632,7 @@ exports[`Toast component
             Sample Toast
           </h5>
           <i
+            aria-label="Close"
             class="material-symbols material-symbols-rounded Icon Icon--default Toast-icon Toast-icon--right Toast-icon--warning Toast-close-icon--warning"
             data-test="DesignSystem-Icon"
             role="button"

--- a/core/components/css-utilities/designTokens/Colors.story.tsx
+++ b/core/components/css-utilities/designTokens/Colors.story.tsx
@@ -21,10 +21,12 @@ export const colors = () => {
       <br />
       {tokenColors.map((data, idx) => {
         const heading =
-          idx !== 4 && idx !== 9
+          idx !== 4 && idx !== 9 && idx !== 10
             ? data[0].token.slice(2)[0].toUpperCase() + data[0].token.slice(3)
             : idx === 4
             ? 'Neutral'
+            : idx === 9
+            ? 'Focus'
             : 'Others';
         return (
           <div className="mt-5 mb-5" key={idx}>

--- a/core/components/css-utilities/designTokens/Data.tsx
+++ b/core/components/css-utilities/designTokens/Data.tsx
@@ -92,6 +92,7 @@ export const tokenColors = [
     { token: '--accent4-ultra-light', value: '#F2F9E7' },
     { token: '--accent4-shadow', value: 'rgba(130, 201, 30, 0.16)' },
   ],
+  [{ token: '--primary-focus', value: 'var(--jal-dark)' }],
   [{ token: '--white', value: '#FFFFFF', setBgColor: true }],
 ];
 

--- a/core/components/molecules/chat/chatBubble/__tests__/__snapshots__/ChatBubble.test.tsx.snap
+++ b/core/components/molecules/chat/chatBubble/__tests__/__snapshots__/ChatBubble.test.tsx.snap
@@ -75,11 +75,12 @@ Object {
                 <span
                   class=""
                   data-test="DesignSystem-AvatarWrapper"
-                  role="presentation"
                 >
                   <span
+                    aria-label="John Doe"
                     class="Avatar Avatar--regular Avatar--accent1 Avatar--noInitials Avatar--default mr-4"
                     data-test="DesignSystem-IncomingChatBubble-Avatar"
+                    role="img"
                     tabindex="0"
                   >
                     <span
@@ -176,11 +177,12 @@ Object {
               <span
                 class=""
                 data-test="DesignSystem-AvatarWrapper"
-                role="presentation"
               >
                 <span
+                  aria-label="John Doe"
                   class="Avatar Avatar--regular Avatar--accent1 Avatar--noInitials Avatar--default mr-4"
                   data-test="DesignSystem-IncomingChatBubble-Avatar"
+                  role="img"
                   tabindex="0"
                 >
                   <span

--- a/core/components/molecules/chatMessage/Box.tsx
+++ b/core/components/molecules/chatMessage/Box.tsx
@@ -22,6 +22,15 @@ export const Box = (props: InternalBoxProps) => {
   const { children, type, isTyping, statusType, withStatus, onClick, className } = props;
 
   const baseProps = extractBaseProps(props);
+  const isClickable = Boolean(onClick);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick?.(event as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
 
   const MessageClass = classNames(
     {
@@ -34,10 +43,16 @@ export const Box = (props: InternalBoxProps) => {
     className
   );
 
-  /* TODO(a11y): fix accessibility  */
-  /* eslint-disable  */
   return (
-    <div {...baseProps} className={MessageClass} onClick={onClick} data-test="DesignSystem-ChatMessage--Box">
+    <div
+      {...baseProps}
+      className={MessageClass}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      data-test="DesignSystem-ChatMessage--Box"
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+    >
       {children}
     </div>
   );

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -268,17 +268,26 @@ export const ChipInput = (props: ChipInputProps) => {
   });
 
   const iconSize = size === 'small' ? 12 : 16;
+  const handleWrapperKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled || event.currentTarget !== event.target) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler();
+    }
+  };
 
   return (
-    /* TODO(a11y): fix accessibility  */
-    /* eslint-disable  */
     <div data-test="DesignSystem-ChipInput--Border" className={ChipInputBorderClass}>
       <div
         data-test="DesignSystem-ChipInput"
         {...baseProps}
         className={ChipInputClass}
         onClick={onClickHandler}
+        onKeyDown={handleWrapperKeyDown}
         tabIndex={disabled ? -1 : 0}
+        role="button"
+        aria-disabled={disabled || undefined}
       >
         <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`ChipInput component
       <div
         class="ChipInput ChipInput--withChips ChipInput--regular"
         data-test="DesignSystem-ChipInput"
+        role="button"
         tabindex="0"
       >
         <div
@@ -35,6 +36,7 @@ exports[`ChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -68,6 +70,7 @@ exports[`ChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -116,8 +119,10 @@ exports[`ChipInput component
       data-test="DesignSystem-ChipInput--Border"
     >
       <div
+        aria-disabled="true"
         class="ChipInput ChipInput--disabled ChipInput--withChips ChipInput--regular"
         data-test="DesignSystem-ChipInput"
+        role="button"
         tabindex="-1"
       >
         <div
@@ -141,6 +146,7 @@ exports[`ChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -174,6 +180,7 @@ exports[`ChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right Chip-icon-disabled--right"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -225,6 +232,7 @@ exports[`ChipInput component
       <div
         class="ChipInput ChipInput--withChips ChipInput--error ChipInput--regular"
         data-test="DesignSystem-ChipInput"
+        role="button"
         tabindex="0"
       >
         <div
@@ -248,6 +256,7 @@ exports[`ChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -281,6 +290,7 @@ exports[`ChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"

--- a/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
+++ b/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
@@ -14,6 +14,8 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -37,6 +39,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -70,6 +73,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -106,6 +110,8 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -129,6 +135,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -162,6 +169,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -198,6 +206,8 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -221,6 +231,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -254,6 +265,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -290,6 +302,8 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -313,6 +327,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -346,6 +361,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -382,6 +398,8 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -405,6 +423,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -438,6 +457,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -474,6 +494,8 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -497,6 +519,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"
@@ -530,6 +553,7 @@ exports[`EditableChipInput component
               </span>
             </div>
             <div
+              aria-label="Remove"
               class="Chip-icon Chip-icon--right cursor-pointer"
               data-test="DesignSystem-GenericChip--clearButton"
               role="button"

--- a/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
+++ b/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
@@ -14,10 +14,13 @@ exports[`EditableDropdown component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="Dropdown d-none"
           data-test="DesignSystem-EditableDropdown--Dropdown"
+          role="presentation"
         >
           <div
             class="PopperWrapper-trigger w-100"

--- a/core/components/molecules/editableInput/EditableInput.tsx
+++ b/core/components/molecules/editableInput/EditableInput.tsx
@@ -59,6 +59,12 @@ export const EditableInput = (props: EditableInputProps) => {
     if (isControlled) setValue(props.value);
   }, [props.value]);
 
+  React.useEffect(() => {
+    if (editing && showComponent) {
+      inputRef.current?.focus();
+    }
+  }, [editing, showComponent]);
+
   const EditableInputClass = classNames(
     {
       [styles['EditableInput']]: true,
@@ -100,7 +106,6 @@ export const EditableInput = (props: EditableInputProps) => {
   const onChangeHandler = (eventType: string) => {
     switch (eventType) {
       case 'edit': {
-        inputRef.current?.focus();
         setEditing(true);
         setShowComponent(true);
         break;
@@ -120,8 +125,6 @@ export const EditableInput = (props: EditableInputProps) => {
       defaultValue={inputValue}
       placeholder={placeholder}
       className={InputClass}
-      // TODO(a11y)
-      // eslint-disable-next-line jsx-a11y/no-autofocus
       autoFocus={editing}
       size={size}
       onChange={onInputChangeHandler}
@@ -164,9 +167,13 @@ export const EditableInput = (props: EditableInputProps) => {
   };
 
   return (
-    // TODO(a11y)
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div data-test="DesignSystem-EditableInput" {...baseProps} className={EditableInputClass} onKeyDown={onKeyDown}>
+    <div
+      data-test="DesignSystem-EditableInput"
+      {...baseProps}
+      className={EditableInputClass}
+      onKeyDown={onKeyDown}
+      role="presentation"
+    >
       <Editable onChange={onChangeHandler} editing={editing}>
         {renderChildren()}
       </Editable>

--- a/core/components/molecules/editableInput/__tests__/__snapshots__/EditableInput.test.tsx.snap
+++ b/core/components/molecules/editableInput/__tests__/__snapshots__/EditableInput.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`EditableInput component
   <div
     class="EditableInput"
     data-test="DesignSystem-EditableInput"
+    role="presentation"
   >
     <div
       class="Editable"
@@ -14,6 +15,8 @@ exports[`EditableInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableInput-default EditableInput-default--regular"
@@ -32,6 +35,7 @@ exports[`EditableInput component
   <div
     class="EditableInput"
     data-test="DesignSystem-EditableInput"
+    role="presentation"
   >
     <div
       class="Editable"
@@ -39,6 +43,8 @@ exports[`EditableInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableInput-default EditableInput-default--tiny"

--- a/core/components/molecules/emptyState/EmptyState.tsx
+++ b/core/components/molecules/emptyState/EmptyState.tsx
@@ -129,9 +129,12 @@ export const EmptyState = (props: EmptyStateProps) => {
       <div data-test="DesignSystem-EmptyState" {...baseProps} className={wrapperClasses}>
         {image && <div style={{ height: imageHeight[templateSize] }}>{image}</div>}
         {imageSrc && !image && (
-          //TODO(a11y)
-          //eslint-disable-next-line
-          <img src={imageSrc} height={imageHeight[templateSize]} data-test="DesignSystem-EmptyState--Img" />
+          <img
+            src={imageSrc}
+            height={imageHeight[templateSize]}
+            data-test="DesignSystem-EmptyState--Img"
+            alt={title || description || ''}
+          />
         )}
         {title && (
           <Heading

--- a/core/components/molecules/emptyState/_tests_/__snapshots__/EmptyState.test.tsx.snap
+++ b/core/components/molecules/emptyState/_tests_/__snapshots__/EmptyState.test.tsx.snap
@@ -70,6 +70,7 @@ exports[`EmptyState component
       data-test="DesignSystem-EmptyState"
     >
       <img
+        alt="Manage your outreach campaigns"
         data-test="DesignSystem-EmptyState--Img"
         height="256px"
         src="noContent"
@@ -101,6 +102,7 @@ exports[`EmptyState component
       data-test="DesignSystem-EmptyState"
     >
       <img
+        alt="Manage your outreach campaigns"
         data-test="DesignSystem-EmptyState--Img"
         height="128px"
         src="noContent"

--- a/core/components/molecules/fileList/FileListItem.tsx
+++ b/core/components/molecules/fileList/FileListItem.tsx
@@ -78,11 +78,25 @@ export const FileListItem = (props: FileListItemProps) => {
       onClick(fileItem);
     }
   };
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler();
+    }
+  };
 
   return (
-    // TODO(a11y)
-    //  eslint-disable-next-line
-    <div {...baseProps} className={FileItemClass} onClick={onClickHandler} data-test="DesignSystem-FileListItem">
+    <div
+      {...baseProps}
+      className={FileItemClass}
+      onClick={onClickHandler}
+      onKeyDown={handleKeyDown}
+      data-test="DesignSystem-FileListItem"
+      role="button"
+      tabIndex={0}
+    >
       <div className={styles['FileItem-file']}>
         <div className={styles['FileItem-fileContent']}>
           <FileIcon file={file} status={status} progress={progress} />

--- a/core/components/molecules/fileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/core/components/molecules/fileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`FileList component
     <div
       class="FileItem"
       data-test="DesignSystem-FileListItem"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileItem-file"
@@ -66,6 +68,8 @@ exports[`FileList component
     <div
       class="FileItem"
       data-test="DesignSystem-FileListItem"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileItem-file"
@@ -103,6 +107,8 @@ exports[`FileList component
     <div
       class="FileItem"
       data-test="DesignSystem-FileListItem"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileItem-file"
@@ -159,6 +165,8 @@ exports[`FileList component
     <div
       class="FileItem"
       data-test="DesignSystem-FileListItem"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileItem-file"
@@ -196,6 +204,8 @@ exports[`FileList component
     <div
       class="FileItem"
       data-test="DesignSystem-FileListItem"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileItem-file"

--- a/core/components/molecules/fileUploader/FileUploaderItem.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderItem.tsx
@@ -45,6 +45,15 @@ export const FileUploaderItem = (props: FileUploaderItemProps) => {
   const { name } = file;
 
   const baseProps = extractBaseProps(props);
+  const isClickable = Boolean(onClick);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!isClickable) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick?.(file, id);
+    }
+  };
 
   const FileItemClass = classNames(
     {
@@ -54,13 +63,14 @@ export const FileUploaderItem = (props: FileUploaderItemProps) => {
   );
 
   return (
-    // TODO(a11y)
-    //  eslint-disable-next-line
     <div
       {...baseProps}
       data-test="DesignSystem-FileUploader--Item"
       className={FileItemClass}
       onClick={() => onClick && onClick(file, id)}
+      onKeyDown={handleKeyDown}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
     >
       <div className={styles['FileUploaderItem-file']}>
         <Text className={styles['FileUploaderItem-text']} appearance={status === 'completed' ? 'default' : 'subtle'}>

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploaderList.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploaderList.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`FileUploaderList component
     <div
       class="FileUploaderItem"
       data-test="DesignSystem-FileUploader--Item"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileUploaderItem-file"
@@ -75,6 +77,8 @@ exports[`FileUploaderList component
     <div
       class="FileUploaderItem"
       data-test="DesignSystem-FileUploader--Item"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileUploaderItem-file"
@@ -113,6 +117,8 @@ exports[`FileUploaderList component
     <div
       class="FileUploaderItem"
       data-test="DesignSystem-FileUploader--Item"
+      role="button"
+      tabindex="0"
     >
       <div
         class="FileUploaderItem-file"

--- a/core/components/molecules/stepper/Step.tsx
+++ b/core/components/molecules/stepper/Step.tsx
@@ -39,7 +39,8 @@ export const Step = (props: StepProps) => {
   };
 
   const onKeyDownHandler = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
       onClickHandle();
     }
   };
@@ -47,14 +48,14 @@ export const Step = (props: StepProps) => {
   const textColor = active ? 'primary-dark' : disabled ? 'inverse-lightest' : 'inverse';
 
   return (
-    // TODO(a11y)
-    // eslint-disable-next-line
     <div
       data-test="DesignSystem-Step"
       className={StepClass}
       onKeyDown={(e) => onKeyDownHandler(e)}
       onClick={onClickHandle}
       tabIndex={disabled ? -1 : 0}
+      role="button"
+      aria-disabled={disabled || undefined}
     >
       <Icon
         data-test="DesignSystem-Step--Icon"

--- a/core/components/molecules/stepper/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/core/components/molecules/stepper/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Stepper component
     <div
       class="Step Stepper-animate Step--completed"
       data-test="DesignSystem-Step"
+      role="button"
       tabindex="0"
     >
       <i
@@ -31,6 +32,7 @@ exports[`Stepper component
     <div
       class="Step Stepper-animate Step--active"
       data-test="DesignSystem-Step"
+      role="button"
       tabindex="0"
     >
       <i
@@ -49,8 +51,10 @@ exports[`Stepper component
       </span>
     </div>
     <div
+      aria-disabled="true"
       class="Step Stepper-animate Step--disabled"
       data-test="DesignSystem-Step"
+      role="button"
       tabindex="-1"
     >
       <i
@@ -69,8 +73,10 @@ exports[`Stepper component
       </span>
     </div>
     <div
+      aria-disabled="true"
       class="Step Stepper-animate Step--disabled"
       data-test="DesignSystem-Step"
+      role="button"
       tabindex="-1"
     >
       <i

--- a/core/components/molecules/tabs/Tabs.tsx
+++ b/core/components/molecules/tabs/Tabs.tsx
@@ -315,8 +315,6 @@ export const Tabs = (props: TabsProps) => {
     });
 
     return (
-      // TODO(a11y)
-      //  eslint-disable-next-line
       <div
         ref={(element) => element && !disabled && tabRefs.push(element)}
         data-test="DesignSystem-Tabs--Tab"
@@ -325,6 +323,8 @@ export const Tabs = (props: TabsProps) => {
         onClick={() => !disabled && tabClickHandler(index)}
         onKeyDown={(event: React.KeyboardEvent) => tabKeyDownHandler(event, index)}
         tabIndex={disabled ? -1 : 0}
+        role="button"
+        aria-disabled={disabled || undefined}
       >
         {renderTab(currentTabProp, index)}
       </div>

--- a/core/components/molecules/tabs/TabsWrapper.tsx
+++ b/core/components/molecules/tabs/TabsWrapper.tsx
@@ -66,13 +66,22 @@ export const TabsWrapper = (props: TabsWrapperProps) => {
     });
 
     return (
-      // TODO(a11y)
-      //  eslint-disable-next-line
       <div
         data-test="DesignSystem-Tabs--Header"
         key={index}
         className={tabHeaderClass}
         onClick={() => !disabled && tabClickHandler(index)}
+        onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+          if (disabled) return;
+
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            tabClickHandler(index);
+          }
+        }}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled || undefined}
       >
         {label}
       </div>

--- a/core/components/molecules/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/core/components/molecules/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Tabs component
       <div
         class="Tab Tab--active Tab-selected align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -48,6 +49,7 @@ exports[`Tabs component
       <div
         class="Tab align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -72,8 +74,10 @@ exports[`Tabs component
         </span>
       </div>
       <div
+        aria-disabled="true"
         class="Tab Tab--disabled align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="-1"
       >
         <span
@@ -115,6 +119,7 @@ exports[`Tabs component
       <div
         class="Tab Tab--active Tab-selected align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -148,6 +153,7 @@ exports[`Tabs component
       <div
         class="Tab align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -172,8 +178,10 @@ exports[`Tabs component
         </span>
       </div>
       <div
+        aria-disabled="true"
         class="Tab Tab--disabled align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="-1"
       >
         <span
@@ -215,6 +223,7 @@ exports[`Tabs component
       <div
         class="Tab Tab--active Tab-selected align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -248,6 +257,7 @@ exports[`Tabs component
       <div
         class="Tab align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -272,8 +282,10 @@ exports[`Tabs component
         </span>
       </div>
       <div
+        aria-disabled="true"
         class="Tab Tab--disabled align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="-1"
       >
         <span
@@ -315,6 +327,7 @@ exports[`Tabs component
       <div
         class="Tab Tab--active Tab-selected align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -348,6 +361,7 @@ exports[`Tabs component
       <div
         class="Tab align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="0"
       >
         <span
@@ -372,8 +386,10 @@ exports[`Tabs component
         </span>
       </div>
       <div
+        aria-disabled="true"
         class="Tab Tab--disabled align-items-center"
         data-test="DesignSystem-Tabs--Tab"
+        role="button"
         tabindex="-1"
       >
         <span

--- a/core/components/molecules/tabs/__tests__/__snapshots__/TabsWrapper.test.tsx.snap
+++ b/core/components/molecules/tabs/__tests__/__snapshots__/TabsWrapper.test.tsx.snap
@@ -14,6 +14,8 @@ exports[`TabsWrapper component
       <div
         class="Tab Tab--active Tab--regular"
         data-test="DesignSystem-Tabs--Header"
+        role="button"
+        tabindex="0"
       >
         <span
           class="Text Text--default Text--regular"
@@ -23,8 +25,11 @@ exports[`TabsWrapper component
         </span>
       </div>
       <div
+        aria-disabled="true"
         class="Tab Tab--disabled Tab--regular"
         data-test="DesignSystem-Tabs--Header"
+        role="button"
+        tabindex="-1"
       >
         <span
           class="Text Text--default Text--regular"
@@ -58,6 +63,8 @@ exports[`TabsWrapper component
       <div
         class="Tab Tab--active Tab--regular"
         data-test="DesignSystem-Tabs--Header"
+        role="button"
+        tabindex="0"
       >
         <span
           class="Text Text--default Text--regular"
@@ -67,8 +74,11 @@ exports[`TabsWrapper component
         </span>
       </div>
       <div
+        aria-disabled="true"
         class="Tab Tab--disabled Tab--regular"
         data-test="DesignSystem-Tabs--Header"
+        role="button"
+        tabindex="-1"
       >
         <span
           class="Text Text--default Text--regular"

--- a/core/components/molecules/verificationCodeInput/__stories__/index.story.jsx
+++ b/core/components/molecules/verificationCodeInput/__stories__/index.story.jsx
@@ -14,8 +14,6 @@ export const all = () => {
 
   const disabled = false;
 
-  const autoFocus = true;
-
   const readOnly = false;
 
   const error = false;
@@ -38,9 +36,6 @@ export const all = () => {
         placeholder={placeholder}
         error={error}
         pattern={pattern}
-        // TODO(a11y)
-        //  eslint-disable-next-line
-        autoFocus={autoFocus}
       />
     </>
   );

--- a/core/components/molecules/verificationCodeInput/__stories__/resetFields.story.jsx
+++ b/core/components/molecules/verificationCodeInput/__stories__/resetFields.story.jsx
@@ -12,8 +12,6 @@ export const WithResetButton = () => {
 
   const disabled = false;
 
-  const autoFocus = true;
-
   const readOnly = false;
 
   const error = false;
@@ -42,9 +40,6 @@ export const WithResetButton = () => {
         placeholder={placeholder}
         error={error}
         pattern={pattern}
-        // TODO(a11y)
-        //  eslint-disable-next-line
-        autoFocus={autoFocus}
       />
       <Button className="mt-5" onClick={handleClick}>
         Reset
@@ -92,9 +87,6 @@ const customCode = `() => {
           placeholder={placeholder}
           error={error}
           pattern={pattern}
-          // TODO(a11y)
-          //  eslint-disable-next-line
-          autoFocus={autoFocus}
         />
         <Button className="mt-5" onClick={handleClick}>
           Reset

--- a/core/components/organisms/combobox/__tests__/__snapshots__/Combobox.test.tsx.snap
+++ b/core/components/organisms/combobox/__tests__/__snapshots__/Combobox.test.tsx.snap
@@ -129,6 +129,7 @@ exports[`Combobox component snapshots
             <div
               class="ChipInput"
               data-test="DesignSystem-Combobox-ChipInput"
+              role="button"
               tabindex="-1"
             >
               <div
@@ -174,6 +175,7 @@ exports[`Combobox component snapshots
             <div
               class="ChipInput"
               data-test="DesignSystem-Combobox-ChipInput"
+              role="button"
               tabindex="-1"
             >
               <div
@@ -219,6 +221,7 @@ exports[`Combobox component snapshots
             <div
               class="ChipInput"
               data-test="DesignSystem-Combobox-ChipInput"
+              role="button"
               tabindex="-1"
             >
               <div

--- a/core/components/organisms/combobox/trigger/MultiselectTrigger.tsx
+++ b/core/components/organisms/combobox/trigger/MultiselectTrigger.tsx
@@ -252,6 +252,14 @@ export const MultiSelectTrigger = React.forwardRef<HTMLElement, MultiSelectTrigg
   const onClickHandler = () => {
     inputElementRef.current?.focus();
   };
+  const handleTriggerKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (disabled || event.currentTarget !== event.target) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClickHandler();
+    }
+  };
 
   const chipComponents = chips.map((chip, index) => {
     const { type = 'input', onClick, ...rest } = chipOptions;
@@ -275,23 +283,24 @@ export const MultiSelectTrigger = React.forwardRef<HTMLElement, MultiSelectTrigg
   });
 
   return (
-    /* TODO(a11y): fix accessibility  */
-    /* eslint-disable  */
     <div data-test="DesignSystem-MultiSelectTrigger--Border" className={ChipInputBorderClass}>
       <div
         data-test="DesignSystem-MultiSelectTrigger"
         {...baseProps}
         className={ChipInputClass}
         onClick={onClickHandler}
+        onKeyDown={handleTriggerKeyDown}
         tabIndex={disabled ? -1 : tabIndex || 0}
+        role="button"
+        aria-disabled={disabled || undefined}
       >
-        <div className={styles["ChipInput-wrapper"]} ref={customRef}>
+        <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}
           <input
             {...rest}
             data-test="DesignSystem-MultiSelectTrigger--Input"
             ref={inputElementRef}
-            className={styles["ChipInput-input"]}
+            className={styles['ChipInput-input']}
             autoFocus={autoFocus}
             placeholder={chips && chips.length > 0 ? '' : placeholder}
             disabled={disabled}

--- a/core/components/organisms/grid/Cell.tsx
+++ b/core/components/organisms/grid/Cell.tsx
@@ -146,20 +146,30 @@ const HeaderCell = (props: HeaderCellProps) => {
     </>
   );
 
+  const isSortable = !loading && sorting;
+  const handleSortToggle = () => {
+    if (!isSortable) return;
+    if (sorted === 'asc') onMenuChange(name, 'sortDesc');
+    if (sorted === 'desc') onMenuChange(name, 'unsort');
+    if (!sorted) onMenuChange(name, 'sortAsc');
+  };
+
   return (
     <div key={name} className={classes} ref={el}>
-      {/* TODO(a11y) */}
-      {/* eslint-disable-next-line */}
       <div
         className={styles['Grid-cellContent']}
         data-test="DesignSystem-Grid-cellContent"
-        onClick={() => {
-          if (!loading && sorting) {
-            if (sorted === 'asc') onMenuChange(name, 'sortDesc');
-            if (sorted === 'desc') onMenuChange(name, 'unsort');
-            if (!sorted) onMenuChange(name, 'sortAsc');
+        onClick={handleSortToggle}
+        onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+          if (!isSortable) return;
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            handleSortToggle();
           }
         }}
+        role={isSortable ? 'button' : undefined}
+        tabIndex={isSortable ? 0 : -1}
+        aria-disabled={!isSortable || undefined}
       >
         {loading && !isValidSchema ? (
           <Placeholder withImage={false}>
@@ -228,14 +238,22 @@ const HeaderCell = (props: HeaderCellProps) => {
         </>
       )}
       {schema.resizable && (
-        //TODO(a11y)
-        //eslint-disable-next-line
         <span
           className={styles['Grid-cellResize']}
           onMouseDown={() => {
             resizeCol({ updateColumnSchema }, name, el.current);
             setIsDragged(false);
           }}
+          onKeyDown={(event: React.KeyboardEvent<HTMLSpanElement>) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              resizeCol({ updateColumnSchema }, name, el.current);
+              setIsDragged(false);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label={`Resize ${name} column`}
         />
       )}
     </div>

--- a/core/components/organisms/horizontalNav/HorizontalNav.tsx
+++ b/core/components/organisms/horizontalNav/HorizontalNav.tsx
@@ -85,8 +85,6 @@ export const HorizontalNav = (props: HorizontalNavProps) => {
     const textClasses = classNames(styles['HorizontalNav-menuText'], styles['HorizontalNav-animate']);
 
     return (
-      // TODO(a11y)
-      // eslint-disable-next-line
       <div
         tabIndex={0}
         data-test="DesignSystem-HorizontalNav"

--- a/core/components/organisms/listbox/__tests__/__snapshots__/Listbox.test.tsx.snap
+++ b/core/components/organisms/listbox/__tests__/__snapshots__/Listbox.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -119,6 +120,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -183,6 +185,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -247,6 +250,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -311,6 +315,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -375,6 +380,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -439,6 +445,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -503,6 +510,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -567,6 +575,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -631,6 +640,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -695,6 +705,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -759,6 +770,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -823,6 +835,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -887,6 +900,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -951,6 +965,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1015,6 +1030,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1079,6 +1095,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1143,6 +1160,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1207,6 +1225,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1271,6 +1290,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1335,6 +1355,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1399,6 +1420,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1463,6 +1485,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1527,6 +1550,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1591,6 +1615,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1655,6 +1680,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1719,6 +1745,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1783,6 +1810,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1847,6 +1875,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1911,6 +1940,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -1975,6 +2005,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -2039,6 +2070,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -2103,6 +2135,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -2167,6 +2200,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -2231,6 +2265,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -2295,6 +2330,7 @@ exports[`Listbox component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -2388,6 +2424,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -2482,6 +2519,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -2576,6 +2614,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -2670,6 +2709,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -2764,6 +2804,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -2858,6 +2899,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -2952,6 +2994,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3046,6 +3089,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3140,6 +3184,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3234,6 +3279,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3328,6 +3374,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3422,6 +3469,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3516,6 +3564,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3610,6 +3659,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3704,6 +3754,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3798,6 +3849,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3892,6 +3944,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -3986,6 +4039,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4064,6 +4118,7 @@ exports[`Listbox component snapshot
         </div>
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--basic Listbox-divider"
         data-test="DesignSystem-Divider"
       />
@@ -4104,6 +4159,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4146,6 +4202,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4240,6 +4297,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4334,6 +4392,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4428,6 +4487,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4522,6 +4582,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4616,6 +4677,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4710,6 +4772,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4804,6 +4867,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4898,6 +4962,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -4992,6 +5057,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5086,6 +5152,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5180,6 +5247,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5274,6 +5342,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5368,6 +5437,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5462,6 +5532,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5556,6 +5627,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5650,6 +5722,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5744,6 +5817,7 @@ exports[`Listbox component snapshot
             </div>
           </div>
           <hr
+            aria-orientation="horizontal"
             class="Divider Divider--horizontal Divider--basic Listbox-divider"
             data-test="DesignSystem-Divider"
           />
@@ -5780,6 +5854,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -5815,6 +5890,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -5850,6 +5926,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -5885,6 +5962,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -5920,6 +5998,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -5955,6 +6034,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -5990,6 +6070,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6025,6 +6106,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6060,6 +6142,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6095,6 +6178,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6130,6 +6214,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6165,6 +6250,7 @@ exports[`Listbox component snapshot for states
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6199,6 +6285,7 @@ exports[`Listbox item component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6233,6 +6320,7 @@ exports[`Listbox item component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6268,6 +6356,7 @@ exports[`Listbox item component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />
@@ -6303,6 +6392,7 @@ exports[`Listbox item component snapshot
           </div>
         </div>
         <hr
+          aria-orientation="horizontal"
           class="Divider Divider--horizontal Divider--basic Listbox-divider"
           data-test="DesignSystem-Divider"
         />

--- a/core/components/organisms/navigation/VerticalNavigation.tsx
+++ b/core/components/organisms/navigation/VerticalNavigation.tsx
@@ -135,15 +135,25 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
       [styles['Navigation-menuIcon']]: true,
       [styles['Navigation-menuIcon--active']]: activeMenuIcon,
     });
+    const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (menu.disabled) return;
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClickHandler(menu);
+      }
+    };
 
     return (
       <div key={index} data-test="DesignSystem-Navigation-VerticalNavigation--menuWrapper">
-        {/* TODO(a11y) */}
-        {/* eslint-disable-next-line */}
         <div
           data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
           className={menuClasses}
           onClick={() => onClickHandler(menu)}
+          onKeyDown={handleMenuKeyDown}
+          role="button"
+          tabIndex={menu.disabled ? -1 : 0}
+          aria-disabled={menu.disabled || undefined}
         >
           {menu.icon && (
             <Icon
@@ -182,15 +192,25 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
                 [styles['Navigation-menu--subMenu']]: true,
                 [styles['Navigation-menu--active']]: isActive,
               });
+              const handleSubMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+                if (subMenu.disabled) return;
+
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onClickHandler(subMenu);
+                }
+              };
 
               return (
-                // TODO(a11y)
-                // eslint-disable-next-line
                 <div
                   data-test="DesignSystem-Navigation-VerticalNavigation--subMenu"
                   key={ind}
                   className={subMenuClasses}
                   onClick={() => onClickHandler(subMenu)}
+                  onKeyDown={handleSubMenuKeyDown}
+                  role="button"
+                  tabIndex={subMenu.disabled ? -1 : 0}
+                  aria-disabled={subMenu.disabled || undefined}
                 >
                   <Text appearance={getTextAppearance(isActive, subMenu.disabled)} className="ellipsis--noWrap">
                     {subMenu.label}

--- a/core/components/organisms/navigation/__tests__/__snapshots__/Navigation.test.tsx.snap
+++ b/core/components/organisms/navigation/__tests__/__snapshots__/Navigation.test.tsx.snap
@@ -409,6 +409,8 @@ Object {
             <div
               class="Navigation-menu Navigation-menu--vertical"
               data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
+              role="button"
+              tabindex="0"
             >
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--default Navigation-menuIcon"
@@ -429,6 +431,8 @@ Object {
             <div
               class="Navigation-menu Navigation-menu--vertical"
               data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
+              role="button"
+              tabindex="0"
             />
             <div
               class="Navigation-subMenu"
@@ -440,6 +444,8 @@ Object {
             <div
               class="Navigation-menu Navigation-menu--vertical"
               data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
+              role="button"
+              tabindex="0"
             />
             <div
               class="Navigation-subMenu"
@@ -462,6 +468,8 @@ Object {
           <div
             class="Navigation-menu Navigation-menu--vertical"
             data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
+            role="button"
+            tabindex="0"
           >
             <i
               class="material-symbols material-symbols-rounded Icon Icon--default Navigation-menuIcon"
@@ -482,6 +490,8 @@ Object {
           <div
             class="Navigation-menu Navigation-menu--vertical"
             data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
+            role="button"
+            tabindex="0"
           />
           <div
             class="Navigation-subMenu"
@@ -493,6 +503,8 @@ Object {
           <div
             class="Navigation-menu Navigation-menu--vertical"
             data-test="DesignSystem-Navigation-VerticalNavigation--menuItem"
+            role="button"
+            tabindex="0"
           />
           <div
             class="Navigation-subMenu"

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Navigation component
               data-test="DesignSystem-Breadcrumbs-item"
             >
               <a
+                aria-disabled="false"
                 class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
                 data-test="DesignSystem-Breadcrumbs-link"
                 href="/Senders"
@@ -125,6 +126,7 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
+                  aria-hidden="true"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
                 />
@@ -233,6 +235,7 @@ exports[`Navigation component
                 <div
                   class="Tab Tab--active Tab-selected align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -257,6 +260,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -281,6 +285,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -336,6 +341,7 @@ exports[`Navigation component
               data-test="DesignSystem-Breadcrumbs-item"
             >
               <a
+                aria-disabled="false"
                 class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
                 data-test="DesignSystem-Breadcrumbs-link"
                 href="/Senders"
@@ -477,6 +483,7 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
+                  aria-hidden="true"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
                 />
@@ -550,6 +557,7 @@ exports[`Navigation component
                 <div
                   class="Tab Tab--active Tab-selected align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -574,6 +582,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -598,6 +607,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -653,6 +663,7 @@ exports[`Navigation component
               data-test="DesignSystem-Breadcrumbs-item"
             >
               <a
+                aria-disabled="false"
                 class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
                 data-test="DesignSystem-Breadcrumbs-link"
                 href="/Senders"
@@ -754,6 +765,7 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
+                  aria-hidden="true"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
                 />
@@ -862,6 +874,7 @@ exports[`Navigation component
                 <div
                   class="Tab Tab--active Tab-selected align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -886,6 +899,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -910,6 +924,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -937,6 +952,7 @@ exports[`Navigation component
         </div>
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1002,6 +1018,7 @@ exports[`Navigation component
                 <div
                   class="Tab Tab--active Tab-selected align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -1026,6 +1043,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -1050,6 +1068,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -1077,6 +1096,7 @@ exports[`Navigation component
         </div>
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1130,6 +1150,7 @@ exports[`Navigation component
                     <div
                       class="Step Stepper-animate Step--active"
                       data-test="DesignSystem-Step"
+                      role="button"
                       tabindex="0"
                     >
                       <i
@@ -1148,8 +1169,10 @@ exports[`Navigation component
                       </span>
                     </div>
                     <div
+                      aria-disabled="true"
                       class="Step Stepper-animate Step--disabled"
                       data-test="DesignSystem-Step"
+                      role="button"
                       tabindex="-1"
                     >
                       <i
@@ -1168,8 +1191,10 @@ exports[`Navigation component
                       </span>
                     </div>
                     <div
+                      aria-disabled="true"
                       class="Step Stepper-animate Step--disabled"
                       data-test="DesignSystem-Step"
+                      role="button"
                       tabindex="-1"
                     >
                       <i
@@ -1206,6 +1231,7 @@ exports[`Navigation component
         />
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1272,6 +1298,7 @@ exports[`Navigation component
         />
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1297,6 +1324,7 @@ exports[`Navigation component
               data-test="DesignSystem-Breadcrumbs-item"
             >
               <a
+                aria-disabled="false"
                 class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
                 data-test="DesignSystem-Breadcrumbs-link"
                 href="/Senders"
@@ -1346,6 +1374,7 @@ exports[`Navigation component
         />
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1398,6 +1427,7 @@ exports[`Navigation component
         />
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1444,6 +1474,7 @@ exports[`Navigation component
         />
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1514,6 +1545,7 @@ exports[`Navigation component
         />
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />
@@ -1539,6 +1571,7 @@ exports[`Navigation component
               data-test="DesignSystem-Breadcrumbs-item"
             >
               <a
+                aria-disabled="false"
                 class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
                 data-test="DesignSystem-Breadcrumbs-link"
                 href="/Senders"
@@ -1680,6 +1713,7 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
+                  aria-hidden="true"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
                 />
@@ -1753,6 +1787,7 @@ exports[`Navigation component
                 <div
                   class="Tab Tab--active Tab-selected align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -1777,6 +1812,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -1801,6 +1837,7 @@ exports[`Navigation component
                 <div
                   class="Tab align-items-center"
                   data-test="DesignSystem-Tabs--Tab"
+                  role="button"
                   tabindex="0"
                 >
                   <span
@@ -1828,6 +1865,7 @@ exports[`Navigation component
         </div>
       </div>
       <hr
+        aria-orientation="horizontal"
         class="Divider Divider--horizontal Divider--header"
         data-test="DesignSystem-Divider"
       />

--- a/core/components/organisms/select/SearchInput.tsx
+++ b/core/components/organisms/select/SearchInput.tsx
@@ -46,8 +46,6 @@ export const SearchInput = (props: SelectInputProps) => {
         icon={'search'}
         size={size}
         onKeyDown={(event) => handleInputKeyDown(event, listRef, setFocusedOption, setOpenPopover, triggerRef)}
-        // TODO(a11y): research more on this.
-        // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={true}
         onChange={searchHandler}
         onClear={searchClearHandler}

--- a/core/components/organisms/select/Select.tsx
+++ b/core/components/organisms/select/Select.tsx
@@ -10,6 +10,7 @@ import SelectEmptyTemplate from './SelectEmptyTemplate';
 import { focusListItem, mapInitialValue } from './utils';
 import SelectFooter from './SelectFooter';
 import { BaseProps, extractBaseProps } from '@/utils/types';
+import uidGenerator from '@/utils/uidGenerator';
 import { PopoverProps } from '@/index.type';
 
 export type SelectStyleType = 'filled' | 'outlined';
@@ -179,6 +180,7 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
   const [highlightFirstItem, setHighlightFirstItem] = React.useState<boolean>(false);
   const [highlightLastItem, setHighlightLastItem] = React.useState<boolean>(false);
   const [popoverStyle, setPopoverStyle] = React.useState<PopoverProps['customStyle']>({ width: popoverWidth || width });
+  const listboxId = React.useRef(`select-listbox-${uidGenerator()}`).current;
 
   const baseProps = extractBaseProps(props);
   const WrapperStyle = trigger ? {} : { width: width };
@@ -187,7 +189,7 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
     if (trigger) {
       return React.cloneElement(trigger, { ref: triggerRef });
     }
-    return <SelectTrigger aria-controls="select-listbox" {...triggerOptions} />;
+    return <SelectTrigger aria-controls={listboxId} {...triggerOptions} />;
   };
 
   React.useEffect(() => {
@@ -314,7 +316,7 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
           trigger={getTriggerElement()}
         >
           <OutsideClick onOutsideClick={onOutsideClickHandler}>
-            <div role="listbox" id="select-listbox" tabIndex={0} ref={listRef}>
+            <div role="listbox" id={listboxId} tabIndex={0} ref={listRef}>
               {children}
             </div>
           </OutsideClick>

--- a/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
+++ b/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -66,7 +66,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -116,7 +116,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -166,7 +166,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -216,7 +216,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -266,7 +266,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -316,7 +316,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -366,7 +366,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -416,7 +416,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -466,7 +466,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -516,7 +516,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -566,7 +566,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -616,7 +616,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -666,7 +666,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -716,7 +716,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -766,7 +766,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -816,7 +816,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -866,7 +866,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -916,7 +916,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -966,7 +966,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1016,7 +1016,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1066,7 +1066,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1116,7 +1116,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1166,7 +1166,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1216,7 +1216,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1266,7 +1266,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1316,7 +1316,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1366,7 +1366,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1416,7 +1416,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1466,7 +1466,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1516,7 +1516,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1566,7 +1566,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1616,7 +1616,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1666,7 +1666,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1716,7 +1716,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1766,7 +1766,7 @@ exports[`Select List component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1816,7 +1816,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1866,7 +1866,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1916,7 +1916,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -1966,7 +1966,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2016,7 +2016,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2066,7 +2066,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2116,7 +2116,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2166,7 +2166,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2216,7 +2216,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2266,7 +2266,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2316,7 +2316,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2366,7 +2366,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2416,7 +2416,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2466,7 +2466,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2516,7 +2516,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2566,7 +2566,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2616,7 +2616,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2666,7 +2666,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2716,7 +2716,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2766,7 +2766,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2816,7 +2816,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2866,7 +2866,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2916,7 +2916,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -2966,7 +2966,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3016,7 +3016,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3066,7 +3066,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3116,7 +3116,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3166,7 +3166,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3216,7 +3216,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3266,7 +3266,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3316,7 +3316,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3366,7 +3366,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3416,7 +3416,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3466,7 +3466,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3516,7 +3516,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3566,7 +3566,7 @@ exports[`Select Option component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3616,7 +3616,7 @@ exports[`Select component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"
@@ -3666,7 +3666,7 @@ exports[`Select component snapshots
         class="PopperWrapper-trigger d-block"
       >
         <button
-          aria-controls="select-listbox"
+          aria-controls="select-listbox-Test-uid"
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-label="trigger"

--- a/core/components/organisms/textField/__test__/__snapshots__/Textarea.test.tsx.snap
+++ b/core/components/organisms/textField/__test__/__snapshots__/Textarea.test.tsx.snap
@@ -297,6 +297,7 @@ exports[`textfield component
         </label>
       </div>
       <textarea
+        aria-invalid="false"
         class="Textarea Textarea--resize"
         data-test="DesignSystem-Textarea"
         helptext="i am the helptext"
@@ -365,6 +366,7 @@ exports[`textfield component
         </label>
       </div>
       <textarea
+        aria-invalid="false"
         class="Textarea Textarea--resize"
         data-test="DesignSystem-Textarea"
         helptext="i am the helptext"

--- a/core/components/organisms/timePicker/__tests__/__snapshots__/TimePickerWithSearch.test.tsx.snap
+++ b/core/components/organisms/timePicker/__tests__/__snapshots__/TimePickerWithSearch.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -50,6 +51,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -93,6 +95,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -136,6 +139,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -179,6 +183,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -222,6 +227,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -265,6 +271,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div
@@ -308,6 +315,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
   <div>
     <div
       class="Dropdown"
+      role="presentation"
     >
       
       <div

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -166,8 +166,6 @@ export const MenuItem = (props: MenuItemProps) => {
   return customItemRenderer ? (
     customItemRenderer(customItemProps)
   ) : (
-    // TODO(a11y)
-    // eslint-disable-next-line
     <Tooltip showTooltip={expanded ? isTextTruncated : true} tooltip={menu.label} position="right">
       <Link componentType="a" className={ItemClass} {...baseProps}>
         {customOptionRenderer ? (

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -8,11 +8,12 @@ exports[`TS renders children 1`] = `
     <span
       class=""
       data-test="DesignSystem-AvatarWrapper"
-      role="presentation"
     >
       <span
+        aria-label="Avatar"
         class="Avatar Avatar--regular Avatar--secondary Avatar--noInitials Avatar--default"
         data-test="DesignSystem-Avatar"
+        role="img"
         tabindex="0"
       >
         <i
@@ -769,6 +770,7 @@ exports[`TS renders children 1`] = `
   </div>
   <div
     class="Dropdown"
+    role="presentation"
   >
     <div
       class="PopperWrapper-trigger w-100"
@@ -810,10 +812,13 @@ exports[`TS renders children 1`] = `
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="Dropdown d-none"
           data-test="DesignSystem-EditableDropdown--Dropdown"
+          role="presentation"
         >
           <div
             class="PopperWrapper-trigger w-100"
@@ -849,6 +854,7 @@ exports[`TS renders children 1`] = `
   <div
     class="EditableInput"
     data-test="DesignSystem-EditableInput"
+    role="presentation"
   >
     <div
       class="Editable"
@@ -856,6 +862,8 @@ exports[`TS renders children 1`] = `
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableInput-default EditableInput-default--regular"
@@ -947,6 +955,7 @@ exports[`TS renders children 1`] = `
     </span>
   </div>
   <a
+    aria-disabled="false"
     class="Link Link--regular Link--default"
     data-test="DesignSystem-Link"
     tabindex="0"
@@ -956,6 +965,7 @@ exports[`TS renders children 1`] = `
   <div
     class="Message Message--info"
     data-test="DesignSystem-Message"
+    role="status"
   >
     <i
       class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--regular"
@@ -993,8 +1003,13 @@ exports[`TS renders children 1`] = `
     Hello World!
   </p>
   <div
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="0"
+    aria-valuetext="0%"
     class="ProgressBar ProgressBar-indicator--regular"
     data-test="DesignSystem-ProgressBar"
+    role="progressbar"
   >
     <div
       class="ProgressBar-indicator"
@@ -1037,6 +1052,7 @@ exports[`TS renders children 1`] = `
     data-test="DesignSystem-StatusHint"
   >
     <span
+      aria-hidden="true"
       class="StatusHint-icon StatusHint--default mr-4"
       data-test="DesignSystem-StatusHint--Icon"
     />
@@ -1054,7 +1070,10 @@ exports[`TS renders children 1`] = `
     Hello World!
   </span>
   <svg
+    aria-label="Loading"
+    aria-live="polite"
     class="Spinner Spinner--medium"
+    role="status"
     viewBox="0 0 50 50"
   >
     <circle
@@ -1077,6 +1096,7 @@ exports[`TS renders children 1`] = `
       <div
         class="Slider-track"
         data-test="DesignSystem-MultiSlider-Slider-Track"
+        role="button"
       >
         <div
           class="Slider-progress Slider-progress--inRange"
@@ -1093,6 +1113,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 0.00%;"
         >
           <span
@@ -1108,6 +1129,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 10.00%;"
         >
           <span
@@ -1123,6 +1145,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 20.00%;"
         >
           <span
@@ -1138,6 +1161,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 30.00%;"
         >
           <span
@@ -1153,6 +1177,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 40.00%;"
         >
           <span
@@ -1168,6 +1193,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 50.00%;"
         >
           <span
@@ -1183,6 +1209,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 60.00%;"
         >
           <span
@@ -1198,6 +1225,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 70.00%;"
         >
           <span
@@ -1213,6 +1241,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 80.00%;"
         >
           <span
@@ -1228,6 +1257,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 90.00%;"
         >
           <span
@@ -1243,6 +1273,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 100.00%;"
         >
           <span
@@ -1257,8 +1288,13 @@ exports[`TS renders children 1`] = `
         </div>
       </div>
       <div
+        aria-valuemax="10"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        aria-valuetext="0"
         class="Slider-handle"
         data-test="DesignSystem-MultiSlider-Handle"
+        role="slider"
         style="left: calc(0.00% - 0px);"
         tabindex="0"
       />
@@ -1280,6 +1316,7 @@ exports[`TS renders children 1`] = `
       <div
         class="Slider-track"
         data-test="DesignSystem-MultiSlider-Slider-Track"
+        role="button"
       >
         <div
           class="Slider-progress"
@@ -1300,6 +1337,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 0.00%;"
         >
           <span
@@ -1315,6 +1353,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 10.00%;"
         >
           <span
@@ -1330,6 +1369,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 20.00%;"
         >
           <span
@@ -1345,6 +1385,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 30.00%;"
         >
           <span
@@ -1360,6 +1401,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 40.00%;"
         >
           <span
@@ -1375,6 +1417,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 50.00%;"
         >
           <span
@@ -1390,6 +1433,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 60.00%;"
         >
           <span
@@ -1405,6 +1449,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 70.00%;"
         >
           <span
@@ -1420,6 +1465,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 80.00%;"
         >
           <span
@@ -1435,6 +1481,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 90.00%;"
         >
           <span
@@ -1450,6 +1497,7 @@ exports[`TS renders children 1`] = `
         <div
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
+          role="button"
           style="left: 100.00%;"
         >
           <span
@@ -1464,8 +1512,13 @@ exports[`TS renders children 1`] = `
         </div>
       </div>
       <div
+        aria-valuemax="10"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        aria-valuetext="0"
         class="Slider-handle"
         data-test="DesignSystem-MultiSlider-Handle"
+        role="slider"
         style="left: calc(0.00% - 0px);"
         tabindex="0"
       />
@@ -1476,8 +1529,13 @@ exports[`TS renders children 1`] = `
         0
       </div>
       <div
+        aria-valuemax="10"
+        aria-valuemin="0"
+        aria-valuenow="10"
+        aria-valuetext="10"
         class="Slider-handle"
         data-test="DesignSystem-MultiSlider-Handle"
+        role="slider"
         style="left: calc(100.00% - 0px);"
         tabindex="0"
       />
@@ -1490,6 +1548,7 @@ exports[`TS renders children 1`] = `
     </div>
   </div>
   <h4
+    aria-level="4"
     class="Subheading Subheading--default"
     data-test="DesignSystem-Subheading"
   >
@@ -1500,6 +1559,7 @@ exports[`TS renders children 1`] = `
   >
     <input
       class="Switch-input"
+      role="switch"
       type="checkbox"
       value=""
     />
@@ -1519,7 +1579,9 @@ exports[`TS renders children 1`] = `
     rows="3"
   />
   <div
+    aria-live="polite"
     class="Toast Toast--info"
+    role="status"
   >
     <i
       class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
@@ -1542,6 +1604,7 @@ exports[`TS renders children 1`] = `
           Hello World!
         </h5>
         <i
+          aria-label="Close"
           class="material-symbols material-symbols-rounded Icon Icon--white Toast-icon Toast-icon--right Toast-icon--info Toast-close-icon--info"
           data-test="DesignSystem-Icon"
           role="button"
@@ -2414,6 +2477,8 @@ exports[`TS renders children 1`] = `
       <div
         class="Tab Tab--active Tab--regular"
         data-test="DesignSystem-Tabs--Header"
+        role="button"
+        tabindex="0"
       />
     </div>
     <div
@@ -2571,6 +2636,7 @@ exports[`TS renders children 1`] = `
       />
     </div>
     <hr
+      aria-orientation="horizontal"
       class="Divider Divider--horizontal Divider--header"
       data-test="DesignSystem-Divider"
     />
@@ -2585,6 +2651,8 @@ exports[`TS renders children 1`] = `
     >
       <div
         data-test="DesignSystem-EditableWrapper"
+        role="button"
+        tabindex="0"
       >
         <div
           class="EditableChipInput-default"

--- a/css/src/components/button.module.css
+++ b/css/src/components/button.module.css
@@ -29,7 +29,8 @@
 }
 
 .Button:focus {
-  outline: 0;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--iconAlign-right {
@@ -128,7 +129,8 @@
 }
 
 .Button--basic:focus {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--basic:disabled {
@@ -149,7 +151,8 @@
 }
 
 .Button--primary:focus {
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--primary:disabled {
@@ -169,7 +172,8 @@
 }
 
 .Button--success:focus {
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--success:disabled {
@@ -189,7 +193,8 @@
 }
 
 .Button--alert:focus {
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--alert:disabled {
@@ -206,7 +211,8 @@
 }
 
 .Button--transparent:focus {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--transparent:active {
@@ -229,12 +235,13 @@
 }
 
 .Button--selected {
-  background: var(--primary-lightest);
+  background: var(--primary-ultra-light);
   color: var(--primary-dark);
+  box-shadow: inset 0 0 0 2px var(--primary);
 }
 
 .Button--selected:hover {
-  background: var(--primary-lighter);
+  background: var(--primary-lightest);
 }
 
 .Button--selected:active {
@@ -243,8 +250,9 @@
 }
 
 .Button--selected:focus {
-  background: var(--primary-lightest);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  background: var(--primary-ultra-light);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--selected:focus:active {
@@ -252,8 +260,9 @@
 }
 
 .Button--selected:disabled {
-  background: var(--primary-lightest);
+  background: var(--primary-ultra-light);
   color: var(--primary-lighter);
+  box-shadow: inset 0 0 0 2px var(--primary-lightest);
 }
 
 .Button-text--hidden {
@@ -269,117 +278,120 @@
 /* outlined button styles */
 
 .Button-outlined--basic {
-  border: var(--border);
   color: var(--inverse);
   background: transparent;
+  box-shadow: inset 0 0 0 1px var(--secondary);
 }
 
 .Button-outlined--basic:hover {
   background: var(--secondary-lighter);
-  border: var(--border-width-2-5) solid var(--inverse-lightest);
+  box-shadow: inset 0 0 0 1px var(--inverse-lightest);
 }
 
 .Button-outlined--basic:active {
   background: var(--secondary);
-  border: var(--border-width-2-5) solid var(--inverse-lightest);
+  box-shadow: inset 0 0 0 1px var(--inverse-lightest);
 }
 
 .Button-outlined--basic:focus {
-  border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--basic:disabled {
   color: var(--inverse-lightest);
   background: transparent;
-  border: var(--border-width-2-5) solid var(--secondary);
+  box-shadow: inset 0 0 0 1px var(--secondary);
 }
 
 .Button-outlined--selected {
   background: var(--primary-ultra-light);
   color: var(--primary-dark);
-  border: var(--border-width-2-5) solid var(--primary-lighter);
+  box-shadow: inset 0 0 0 2px var(--primary);
 }
 
 .Button-outlined--selected:hover {
   background: var(--primary-lightest);
-  border: var(--border-width-2-5) solid var(--primary-lighter);
+  box-shadow: inset 0 0 0 2px var(--primary);
 }
 
 .Button-outlined--selected:active {
   background: var(--primary-lighter);
   color: var(--primary-darker);
-  border: var(--border-width-2-5) solid var(--primary);
+  box-shadow: inset 0 0 0 2px var(--primary);
 }
 
 .Button-outlined--selected:focus {
   color: var(--primary-dark);
-  border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  box-shadow: inset 0 0 0 2px var(--primary);
 }
 
 .Button-outlined--selected:disabled {
   background: var(--primary-ultra-light);
   color: var(--primary-lighter);
-  border: var(--border-width-2-5) solid var(--primary-lightest);
+  box-shadow: inset 0 0 0 2px var(--primary-lightest);
 }
 
 .Button-outlined--primary {
   background: transparent;
-  border: var(--border-width-2-5) solid var(--primary);
+  box-shadow: inset 0 0 0 1px var(--primary);
   color: var(--primary);
   mix-blend-mode: multiply;
 }
 
 .Button-outlined--primary:hover {
   background: var(--primary-ultra-light);
-  border: var(--border-width-2-5) solid var(--primary-dark);
+  box-shadow: inset 0 0 0 1px var(--primary-dark);
   color: var(--primary-dark);
 }
 
 .Button-outlined--primary:active {
   background: var(--primary-lightest);
-  border: var(--border-width-2-5) solid var(--primary-dark);
+  box-shadow: inset 0 0 0 1px var(--primary-dark);
   color: var(--primary-dark);
 }
 
 .Button-outlined--primary:focus {
-  border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  box-shadow: inset 0 0 0 1px var(--primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--primary:disabled {
   background: transparent;
   color: var(--primary-lighter);
-  border: var(--border-width-2-5) solid var(--primary-lighter);
+  box-shadow: inset 0 0 0 1px var(--primary-lighter);
 }
 
 .Button-outlined--alert {
   background: transparent;
-  border: var(--border-width-2-5) solid var(--alert);
+  box-shadow: inset 0 0 0 1px var(--alert);
   color: var(--alert);
   mix-blend-mode: multiply;
 }
 
 .Button-outlined--alert:hover {
   background: var(--alert-ultra-light);
-  border: var(--border-width-2-5) solid var(--alert-dark);
+  box-shadow: inset 0 0 0 1px var(--alert-dark);
   color: var(--alert-dark);
 }
 
 .Button-outlined--alert:active {
   background: var(--alert-lightest);
-  border: var(--border-width-2-5) solid var(--alert-dark);
+  box-shadow: inset 0 0 0 1px var(--alert-dark);
   color: var(--alert-dark);
 }
 
 .Button-outlined--alert:focus {
-  border: var(--border-width-2-5) solid var(--alert);
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
+  box-shadow: inset 0 0 0 1px var(--alert);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--alert:disabled {
   background: transparent;
   color: var(--alert-lighter);
-  border: var(--border-width-2-5) solid var(--alert-lighter);
+  box-shadow: inset 0 0 0 1px var(--alert-lighter);
 }

--- a/css/src/components/checkbox.module.css
+++ b/css/src/components/checkbox.module.css
@@ -70,22 +70,23 @@
   outline: 0;
 }
 
-.Checkbox-input ~ .Checkbox-wrapper--default {
-  border: var(--border-width-2-5) solid var(--secondary-dark);
-  background-color: var(--shadow-0);
+.Checkbox-input:focus ~ .Checkbox-wrapper {
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
-.Checkbox-input:focus ~ .Checkbox-wrapper--default {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+.Checkbox-input ~ .Checkbox-wrapper--default {
+  border: var(--border-width-2-5) solid var(--inverse-lighter);
+  background-color: var(--shadow-0);
 }
 
 .Checkbox-input:hover ~ .Checkbox-wrapper--default {
-  border: var(--border-width-2-5) solid var(--inverse-lightest);
-  background-color: var(--shadow-0);
+  border: var(--border-width-2-5) solid var(--inverse-light);
+  background-color: var(--secondary-lighter);
 }
 
 .Checkbox-input:active ~ .Checkbox-wrapper--default {
-  border: var(--border-width-2-5) solid var(--inverse-lightest);
+  border: var(--border-width-2-5) solid var(--inverse-light);
   background-color: var(--secondary-light);
 }
 
@@ -94,7 +95,7 @@
 }
 
 .Checkbox--disabled .Checkbox-wrapper--default {
-  border: var(--border-width-2-5) solid var(--secondary-light);
+  border: var(--border-width-2-5) solid var(--secondary);
   background-color: var(--secondary-lightest);
 }
 
@@ -108,7 +109,6 @@
 
 .Checkbox-input--checked:focus ~ .Checkbox-wrapper,
 .Checkbox-input--indeterminate:focus ~ .Checkbox-wrapper {
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
   background-color: var(--primary);
   border: 0;
 }
@@ -137,10 +137,6 @@
   border: var(--border-width-2-5) solid var(--alert);
 }
 
-.Checkbox-input:focus ~ .Checkbox-wrapper--error {
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
-}
-
 .Checkbox-input:hover ~ .Checkbox-wrapper--error {
   border: var(--border-width-2-5) solid var(--alert-dark);
 }
@@ -165,7 +161,6 @@
 .Checkbox-input--checked:focus ~ .Checkbox-wrapper--error,
 .Checkbox-input--indeterminate:focus ~ .Checkbox-wrapper--error {
   border: var(--border-width-2-5) solid var(--alert);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
 }
 
 .Checkbox-input--checked:hover ~ .Checkbox-wrapper--error,

--- a/css/src/components/radio.module.css
+++ b/css/src/components/radio.module.css
@@ -18,7 +18,7 @@
 }
 
 .Radio-defaultWrapper {
-  border: var(--border);
+  border: var(--border-width-2-5) solid var(--inverse-lighter);
 }
 
 .Radio-errorWrapper {
@@ -77,13 +77,13 @@
 }
 
 .Radio:hover .Radio-wrapper {
-  border: var(--border-width-2-5) solid var(--secondary-dark);
+  border: var(--border-width-2-5) solid var(--inverse-light);
   background-color: var(--secondary-lighter);
 }
 
 .Radio:active .Radio-wrapper {
   background-color: var(--secondary-light);
-  border: var(--border-width-2-5) solid var(--inverse-lightest);
+  border: var(--border-width-2-5) solid var(--inverse-light);
 }
 
 .Radio:hover .Radio-errorWrapper {
@@ -99,29 +99,27 @@
 }
 
 .Radio:focus-within .Radio-wrapper {
-  outline: 0;
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
-  border-radius: var(--border-radius-full);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Radio:focus-within .Radio-errorWrapper {
-  outline: 0;
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
-  border-radius: var(--border-radius-full);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Radio:focus-within .Radio-input:checked ~ .Radio-wrapper {
-  outline: 0;
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Radio:focus-within .Radio-input:checked ~ .Radio-errorWrapper {
-  outline: 0;
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Radio--disabled .Radio-wrapper {
-  border: var(--border-width-2-5) solid var(--secondary-light);
+  border: var(--border-width-2-5) solid var(--secondary);
   background-color: var(--secondary-lightest);
 }
 
@@ -211,9 +209,9 @@
 }
 
 .Radio--disabled .Radio-input ~ .Radio-wrapper:focus {
-  box-shadow: none;
+  outline: none;
 }
 
 .Radio--disabled .Radio-input ~ .Radio-errorWrapper:focus {
-  box-shadow: none;
+  outline: none;
 }

--- a/css/src/components/select.module.css
+++ b/css/src/components/select.module.css
@@ -49,9 +49,7 @@
 }
 
 .Select-trigger--filled:focus {
-  border: var(--border-width-2-5) solid var(--primary);
   background-color: var(--secondary-light);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
 }
 
 /* styleType Outlined */
@@ -66,11 +64,6 @@
   background: var(--secondary-lighter);
   color: var(--inverse);
   border: var(--border-width-2-5) solid var(--secondary-dark);
-}
-
-.Select-trigger--outlined:focus {
-  border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
 }
 
 .Select-trigger--outlined:active,
@@ -202,5 +195,4 @@
 
 .Select-trigger--error {
   border: var(--border-width-2-5) solid var(--alert) !important;
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
 }

--- a/css/src/components/spinner.module.css
+++ b/css/src/components/spinner.module.css
@@ -54,11 +54,11 @@
 }
 
 .Circle--primary {
-  stroke: var(--primary);
+  stroke: var(--primary-dark);
 }
 
 .Circle--secondary {
-  stroke: var(--secondary-dark);
+  stroke: var(--inverse-lighter);
 }
 
 .Circle--white {
@@ -66,5 +66,5 @@
 }
 
 .Circle--alert {
-  stroke: var(--alert);
+  stroke: var(--alert-dark);
 }

--- a/css/src/variables/index.css
+++ b/css/src/variables/index.css
@@ -70,6 +70,9 @@
   --accent4-lightest: var(--nimbu-lightest);
   --inverse-lightest: var(--night-lightest);
 
+  /* Focus */
+  --primary-focus: var(--jal-dark);
+
   /* Ultra Light */
   --primary-ultra-light: #eef6fc;
   --success-ultra-light: #ecf7f0;


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

This PR made the following a11y related changes

---

## Design Tokens & CSS

### Design Tokens (`css/src/variables/index.css`)
- Added `--primary-focus` token (`var(--jal-dark)`) for consistent focus ring styling across components  
  *Why:* WCAG 2.4.7 (Focus Visible) — keyboard users need a clear, consistent focus indicator.

### Button (`css/src/components/button.module.css`)
- Replaced `outline: 0` with visible focus ring: `outline: var(--border-width-05) solid var(--primary-focus)` and `outline-offset: var(--spacing-05)` on all button variants  
  *Why:* WCAG 2.4.7 — `outline: 0` removes focus visibility; keyboard users lose track of focus.
- Replaced box-shadow focus indicators with outline-based focus rings for basic, primary, success, alert, transparent, and outlined variants  
  *Why:* Outline is more reliable across browsers and high-contrast modes.
- Updated selected button states: `primary-ultra-light` background, inset box-shadow for selected indicator  
  *Why:* Clearer selected state for low-vision users.
- Switched outlined buttons from `border` to `box-shadow: inset` for consistent styling  
  *Why:* Avoids layout shift when focus ring is applied.

### Checkbox (`css/src/components/checkbox.module.css`)
- Added focus ring: `outline: var(--border-width-05) solid var(--primary-focus)` with `outline-offset` on `.Checkbox-input:focus ~ .Checkbox-wrapper`  
  *Why:* WCAG 2.4.7 — visible focus for keyboard users.
- Reordered selectors so focus styles apply correctly  
  *Why:* Ensures focus ring is visible when checkbox receives focus.
- Updated default wrapper border to `inverse-lighter`; improved hover/active state contrast  
  *Why:* WCAG 1.4.3 — better contrast for interactive states.
- Removed redundant box-shadow focus styles  
  *Why:* Single, consistent focus indicator.

### Radio (`css/src/components/radio.module.css`)
- Replaced box-shadow focus indicators with outline-based focus rings: `outline: var(--border-width-05) solid var(--primary-focus)`  
  *Why:* WCAG 2.4.7 — visible focus for keyboard users.
- Updated default wrapper border to `inverse-lighter`; improved hover/active state contrast  
  *Why:* WCAG 1.4.3 — better contrast.
- Disabled state: `outline: none` instead of `box-shadow: none`  
  *Why:* Disabled controls should not show focus ring.

### Select (`css/src/components/select.module.css`)
- Removed focus box-shadow from filled and outlined triggers; removed error state box-shadow  
  *Why:* Align with outline-based focus; reduce visual noise.

### Spinner (`css/src/components/spinner.module.css`)
- Increased stroke contrast: `primary` → `primary-dark`, `secondary-dark` → `inverse-lighter`, `alert` → `alert-dark`  
  *Why:* WCAG 1.4.3 — minimum contrast for loading indicator.

### Design Tokens Story (`core/components/css-utilities/designTokens/`)
- Added "Focus" color section to Colors story for `--primary-focus` token; added `--primary-focus` to token colors data  
  *Why:* Document focus token for designers and developers.

---

## AI Components

### AIButton
- Decorative sparkle image: `alt="Button Icon"` → `alt=""` and `aria-hidden="true"`  
  *Why:* WCAG 1.1.1 — decorative images should not be announced; button label is sufficient.

### AIChip
- Icon wrapper: added `aria-hidden="true"`  
  *Why:* Decorative icon; button text provides the accessible name.

### AIIconButton
- Added `aria-label` fallback: `aria-label={rest['aria-label'] ?? tooltip ?? icon}`  
  *Why:* WCAG 4.1.2 — icon-only buttons need an accessible name for screen readers.
- Icon wrapper: `aria-hidden={!!ariaLabel}` when accessible name exists  
  *Why:* Avoid duplicate announcement of icon and label.

### SaraIconDefault / SaraIconDisabled
- Added `aria-hidden="true"` and `focusable="false"` to SVG icons  
  *Why:* Decorative SVGs should not receive focus or be announced.

---

## Atoms

### Avatar
- Role resolution: `role ?? (tabIndex !== undefined ? 'button' : 'img')`  
  *Why:* WCAG 4.1.2 — correct semantics: `img` when presentational, `button` when interactive.
- Added `aria-label={getTooltipName().trim() || initials || 'Avatar'}`  
  *Why:* Screen readers need a text alternative for the avatar.
- `tabIndex`: only set when interactive; `disabled` sets `-1`  
  *Why:* Avoid unnecessary tab stops; respect disabled state.

### Button
- Added `aria-busy={loading || undefined}` for loading state  
  *Why:* WCAG 4.1.3 — screen readers announce loading state.
- Added `aria-label` fallback for icon-only buttons: `props['aria-label'] || (!children && tooltip ? tooltip : undefined)`  
  *Why:* WCAG 4.1.2 — icon-only buttons need an accessible name.

### Checkbox
- Added `aria-invalid={error || undefined}`  
  *Why:* WCAG 3.3.1 — expose validation errors to assistive tech.
- Added `aria-checked={indeterminate ? 'mixed' : undefined}` for indeterminate state  
  *Why:* WCAG 4.1.2 — screen readers must announce indeterminate state.
- Added `aria-describedby` linking to help text; `id` on help text element  
  *Why:* Associate help text with control for screen readers.
- Support for `aria-describedby` prop override  
  *Why:* Allow custom descriptions when needed.

### Chip
- Passed `type` prop to `GenericChip` for selection state semantics  
  *Why:* Enables correct ARIA state attributes in GenericChip.

### GenericChip (_chip)
- Added `type` and `role` props; `getAriaProps()`: `aria-pressed`, `aria-checked`, or `aria-selected` based on `type` and `role`  
  *Why:* WCAG 4.1.2 — selection chips must expose state (pressed/checked/selected).
- Keyboard: `onKeyDown` now handles `Space` and `Spacebar` in addition to `Enter`; `event.preventDefault()`  
  *Why:* WCAG 2.1.1 — buttons must activate on Enter and Space per WAI-ARIA.
- Clear button: added `aria-label="Remove"`  
  *Why:* Icon-only control needs accessible name.
- Role: `role={props.role || 'button'}`  
  *Why:* Flexible semantics for different contexts (e.g. option, tab).

### Divider
- Added `aria-orientation={vertical ? 'vertical' : 'horizontal'}`  
  *Why:* Helps assistive tech understand layout for screen reader users.

### Dropdown
- **DropdownList:** Added `role="presentation"` to root container  
  *Why:* Root is layout-only; listbox semantics come from child.
- **DefaultOption, IconOption, IconWithMetaOption, MetaOption:** Added `onKeyDown` for Enter/Space; `role="button"`, `tabIndex`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — options must be keyboard-activatable; correct semantics and disabled state.

### Editable
- Added `onKeyDown` for Enter/Space to trigger edit mode; `role="button"`, `tabIndex={0}`  
  *Why:* WCAG 2.1.1 — clickable div must be keyboard-activatable.

### Label
- Required indicator: added `aria-label="required"`  
  *Why:* Screen readers announce required state for the indicator.
- Info icon: added `aria-label={info}`  
  *Why:* Icon-only tooltip trigger needs accessible name.

### Legend
- Added `onKeyDown` for Enter/Space when clickable; `role="button"`, `tabIndex={0}`  
  *Why:* WCAG 2.1.1 — clickable elements must work with keyboard.
- Updated `onClick` type to accept `KeyboardEvent`  
  *Why:* Type safety for keyboard activation.

### Link
- Added `aria-disabled={disabled}` when disabled  
  *Why:* WCAG 4.1.2 — disabled state must be exposed to assistive tech.

### Message
- Added `role={appearance === 'alert' || appearance === 'warning' ? 'alert' : 'status'}`  
  *Why:* WCAG 4.1.3 — alerts announced immediately; status messages politely.
- Icon: `aria-hidden="true"`  
  *Why:* Decorative; message text is the content.

### Meter
- Added `aria-valuetext={label.toString()}` for human-readable value  
  *Why:* WCAG 4.1.2 — screen readers get meaningful value (e.g. "75%" vs raw number).

### MultiSlider
- **Handle:** Added `role="slider"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, `aria-valuetext`, `aria-disabled`; `tabIndex={disabled ? -1 : 0}`; `onFocus`/`onBlur`; Arrow Up/Down support  
  *Why:* WCAG 4.1.2 — slider semantics; full keyboard support per WAI-ARIA.
- **Labels, Track:** Added `onKeyDown` for Enter/Space; `role="button"`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — keyboard activation for track/label clicks.

### Pills
- Added `role="status"` when `aria-label` is provided  
  *Why:* Exposes status region to screen readers when labeled.

### ProgressBar
- Added `role="progressbar"`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`, `aria-valuetext` (percentage); clamped value  
  *Why:* WCAG 4.1.2 — progress bars need role and value for assistive tech.

### Spinner
- Added `ariaLabel` prop (default: `"Loading"`); `role="status"`, `aria-live="polite"`, `aria-label={ariaLabel}`  
  *Why:* WCAG 4.1.3 — loading indicator must be announced; customizable label.

### StatusHint
- Added `onKeyDown` for Enter/Space when clickable; `role="button"`, `tabIndex={0}`  
  *Why:* WCAG 2.1.1 — clickable status must work with keyboard.
- Icon: `aria-hidden="true"`  
  *Why:* Decorative; status text is the content.

### Subheading
- Added `aria-level={4}` for heading hierarchy  
  *Why:* Reinforces heading level for assistive tech when using generic component.

### Switch
- Added `role="switch"` and `aria-checked={checked}`  
  *Why:* WCAG 4.1.2 — switch role and checked state for on/off toggle semantics.

### Textarea
- Added `aria-invalid={error}`  
  *Why:* WCAG 3.3.1 — expose validation errors to assistive tech.

### Toast
- Added `role={appearance === 'alert' || appearance === 'warning' ? 'alert' : 'status'}`; `aria-live="assertive"` for alert/warning, `"polite"` otherwise  
  *Why:* WCAG 4.1.3 — critical toasts announced immediately; others politely.
- Icon: `aria-hidden="true"`; Close button: `aria-label="Close"`  
  *Why:* Decorative icon; icon-only close needs accessible name.

---

## Molecules

### ChatMessage (Box)
- Added `onKeyDown` for Enter/Space when clickable; `role="button"`, `tabIndex={0}`  
  *Why:* WCAG 2.1.1 — clickable message must be keyboard-activatable.

### ChipInput
- Added `onKeyDown` for Enter/Space (only when `event.currentTarget === event.target`); `role="button"`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — keyboard activation; avoid double-activation when focus is on nested input.

### EditableInput
- Moved focus logic into `useEffect` for `editing` and `showComponent`  
  *Why:* Focus after render so screen reader announces edit mode.
- Added `role="presentation"` on wrapper  
  *Why:* Wrapper is layout-only; semantics come from Editable/input.

### EmptyState
- Image: added `alt={title || description || ''}`  
  *Why:* WCAG 1.1.1 — images need text alternative; use title/description when no dedicated alt.

### FileListItem
- Added `onKeyDown` for Enter/Space when `onClick` provided; `role="button"`, `tabIndex={0}`  
  *Why:* WCAG 2.1.1 — clickable row must be keyboard-activatable.

### FileUploaderItem
- Added `onKeyDown` for Enter/Space when clickable; `role="button"`, `tabIndex={0}`  
  *Why:* WCAG 2.1.1 — keyboard activation for clickable items.

### Stepper (Step)
- Added Space key support; `event.preventDefault()`; `role="button"`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — buttons activate on Space; expose disabled state.

### Tabs
- Tab: added `role="button"`, `aria-disabled`  
  *Why:* WCAG 4.1.2 — tab semantics and disabled state for assistive tech.

### TabsWrapper
- Added `onKeyDown` for Enter/Space; `role="button"`, `tabIndex`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — keyboard activation for tab headers.

---

## Organisms

### Combobox (MultiselectTrigger)
- Added `handleTriggerKeyDown` for Enter/Space (only when `event.currentTarget === event.target`); `role="button"`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — keyboard activation; avoid conflicts when focus is on input.
- Fixed quote style in class names  
  *Why:* Code consistency.

### Grid (Cell)
- **Header cell (sortable):** Added `onKeyDown` for Enter/Space; `role="button"`, `tabIndex`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — sortable headers must be keyboard-activatable.
- **Resize handle:** Added `onKeyDown` for Enter/Space; `role="button"`, `tabIndex={0}`, `aria-label="Resize ${name} column"`  
  *Why:* WCAG 2.1.1, 4.1.2 — keyboard activation and accessible name for resize control.

### HorizontalNav
- Removed TODO/eslint-disable  
  *Why:* Resolved a11y issues; no longer need to suppress lint.

### VerticalNavigation
- Menu items and sub-menu items: added `onKeyDown` for Enter/Space; `role="button"`, `tabIndex`, `aria-disabled`  
  *Why:* WCAG 2.1.1 — navigation items must be keyboard-activatable.

### Select
- Added unique `listboxId` via `uidGenerator()`; `aria-controls` and `id` use `listboxId`  
  *Why:* WCAG 4.1.2 — correct `aria-controls`/`id` association; unique IDs avoid conflicts with multiple selects.

### SearchInput (Select)
- Removed TODO/eslint-disable for autofocus  
  *Why:* Autofocus on dropdown open is intentional for keyboard users.

### VerticalNav (MenuItem)
- Removed TODO/eslint-disable  
  *Why:* Resolved a11y issues.

---

## Other

### VerificationCodeInput
- Removed `autoFocus` from stories  
  *Why:* Avoid unexpected focus in docs; autofocus can disorient screen reader users.

### ESLint / AGENTS
- `.eslintrc.json`: Added `jsx-a11y` plugin config  
  *Why:* Enforce a11y rules in CI.
- `AGENTS.md`: Added accessibility reference  
  *Why:* Guide contributors on a11y requirements.

### A11y Context
- Added `a11y-context/README.md` and `a11y-context/wcag-as-json.json`; added `.cursor/rules/` for WCAG audit, Vercel a11y, and web interface guidelines  
  *Why:* Centralize WCAG criteria and audit patterns for consistent a11y work.


...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
