### PR TITLE
feat: add focus styles and token for focus color (primary-dark) in button components

### DIFF
--- a/core/components/css-utilities/designTokens/Colors.story.tsx
+++ b/core/components/css-utilities/designTokens/Colors.story.tsx
@@ -21,10 +21,12 @@ export const colors = () => {
       <br />
       {tokenColors.map((data, idx) => {
         const heading =
-          idx !== 4 && idx !== 9
+          idx !== 4 && idx !== 9 && idx !== 10
             ? data[0].token.slice(2)[0].toUpperCase() + data[0].token.slice(3)
             : idx === 4
             ? 'Neutral'
+            : idx === 9
+            ? 'Focus'
             : 'Others';
         return (
           <div className="mt-5 mb-5" key={idx}>

--- a/core/components/css-utilities/designTokens/Data.tsx
+++ b/core/components/css-utilities/designTokens/Data.tsx
@@ -92,6 +92,7 @@ export const tokenColors = [
     { token: '--accent4-ultra-light', value: '#F2F9E7' },
     { token: '--accent4-shadow', value: 'rgba(130, 201, 30, 0.16)' },
   ],
+  [{ token: '--focus-primary', value: 'var(--primary)' }],
   [{ token: '--white', value: '#FFFFFF', setBgColor: true }],
 ];
 

--- a/core/components/css-utilities/designTokens/Data.tsx
+++ b/core/components/css-utilities/designTokens/Data.tsx
@@ -92,7 +92,7 @@ export const tokenColors = [
     { token: '--accent4-ultra-light', value: '#F2F9E7' },
     { token: '--accent4-shadow', value: 'rgba(130, 201, 30, 0.16)' },
   ],
-  [{ token: '--focus-primary', value: 'var(--primary-dark)' }],
+  [{ token: '--primary-focus', value: 'var(--jal-dark)' }],
   [{ token: '--white', value: '#FFFFFF', setBgColor: true }],
 ];
 

--- a/core/components/css-utilities/designTokens/Data.tsx
+++ b/core/components/css-utilities/designTokens/Data.tsx
@@ -92,7 +92,7 @@ export const tokenColors = [
     { token: '--accent4-ultra-light', value: '#F2F9E7' },
     { token: '--accent4-shadow', value: 'rgba(130, 201, 30, 0.16)' },
   ],
-  [{ token: '--focus-primary', value: 'var(--primary)' }],
+  [{ token: '--focus-primary', value: 'var(--primary-dark)' }],
   [{ token: '--white', value: '#FFFFFF', setBgColor: true }],
 ];
 

--- a/css/src/components/button.module.css
+++ b/css/src/components/button.module.css
@@ -29,7 +29,8 @@
 }
 
 .Button:focus {
-  outline: 0;
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--iconAlign-right {
@@ -128,7 +129,8 @@
 }
 
 .Button--basic:focus {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--basic:disabled {
@@ -149,7 +151,8 @@
 }
 
 .Button--primary:focus {
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--primary:disabled {
@@ -169,7 +172,8 @@
 }
 
 .Button--success:focus {
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--success:disabled {
@@ -189,7 +193,8 @@
 }
 
 .Button--alert:focus {
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--alert:disabled {
@@ -206,7 +211,8 @@
 }
 
 .Button--transparent:focus {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--transparent:active {
@@ -244,7 +250,8 @@
 
 .Button--selected:focus {
   background: var(--primary-lightest);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button--selected:focus:active {
@@ -286,7 +293,8 @@
 
 .Button-outlined--basic:focus {
   border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--basic:disabled {
@@ -315,7 +323,8 @@
 .Button-outlined--selected:focus {
   color: var(--primary-dark);
   border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--selected:disabled {
@@ -345,7 +354,8 @@
 
 .Button-outlined--primary:focus {
   border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--primary:disabled {
@@ -375,7 +385,8 @@
 
 .Button-outlined--alert:focus {
   border: var(--border-width-2-5) solid var(--alert);
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
+  outline: var(--border-width-05) solid var(--focus-primary);
+  outline-offset: var(--spacing-05);
 }
 
 .Button-outlined--alert:disabled {

--- a/css/src/components/button.module.css
+++ b/css/src/components/button.module.css
@@ -29,7 +29,7 @@
 }
 
 .Button:focus {
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -129,7 +129,7 @@
 }
 
 .Button--basic:focus {
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -151,7 +151,7 @@
 }
 
 .Button--primary:focus {
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -172,7 +172,7 @@
 }
 
 .Button--success:focus {
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -193,7 +193,7 @@
 }
 
 .Button--alert:focus {
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -211,7 +211,7 @@
 }
 
 .Button--transparent:focus {
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -250,7 +250,7 @@
 
 .Button--selected:focus {
   background: var(--primary-lightest);
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -293,7 +293,7 @@
 
 .Button-outlined--basic:focus {
   border: var(--border-width-2-5) solid var(--primary);
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -323,7 +323,7 @@
 .Button-outlined--selected:focus {
   color: var(--primary-dark);
   border: var(--border-width-2-5) solid var(--primary);
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -354,7 +354,7 @@
 
 .Button-outlined--primary:focus {
   border: var(--border-width-2-5) solid var(--primary);
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
@@ -385,7 +385,7 @@
 
 .Button-outlined--alert:focus {
   border: var(--border-width-2-5) solid var(--alert);
-  outline: var(--border-width-05) solid var(--focus-primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 

--- a/css/src/variables/index.css
+++ b/css/src/variables/index.css
@@ -3,6 +3,7 @@
 
   /* default */
   --primary: var(--jal);
+  --focus-primary: var(--primary);
   --secondary: var(--stone);
   --success: var(--neem);
   --alert: var(--mirch);

--- a/css/src/variables/index.css
+++ b/css/src/variables/index.css
@@ -3,7 +3,6 @@
 
   /* default */
   --primary: var(--jal);
-  --focus-primary: var(--primary-dark);
   --secondary: var(--stone);
   --success: var(--neem);
   --alert: var(--mirch);
@@ -70,6 +69,9 @@
   --accent3-lightest: var(--neel-lightest);
   --accent4-lightest: var(--nimbu-lightest);
   --inverse-lightest: var(--night-lightest);
+
+  /* Focus */
+  --primary-focus: var(--jal-dark);
 
   /* Ultra Light */
   --primary-ultra-light: #eef6fc;

--- a/css/src/variables/index.css
+++ b/css/src/variables/index.css
@@ -3,7 +3,7 @@
 
   /* default */
   --primary: var(--jal);
-  --focus-primary: var(--primary);
+  --focus-primary: var(--primary-dark);
   --secondary: var(--stone);
   --success: var(--neem);
   --alert: var(--mirch);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Standardizes Button focus states across the design system.
New focus token: Added --focus-primary in css/src/variables/index.css, mapped to var(--primary).
Standardized focus ring: Updated all Button focus states in css/src/components/button.module.css.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

Visual change only: Button focus states now show a 2px outline with 2px offset instead of the previous box-shadow halo. This is a visual update, not a functional breaking change.

### Checklist

Check all those that are applicable and complete.

