### PR TITLE
feat(icon): add WCAG 2.2 AA accessibility props

### DIFF
--- a/core/components/atoms/icon/Icon.tsx
+++ b/core/components/atoms/icon/Icon.tsx
@@ -172,7 +172,7 @@ export const Icon = (props: IconProps) => {
       </span>
     );
   }
-  const isInteractive = props.onClick || props.onKeyDown || accessibilityProps.role === 'button';
+  const isInteractive = props.onClick || props.onKeyDown || (props.role && props.role !== 'presentation');
 
   return (
     <i

--- a/core/components/atoms/icon/Icon.tsx
+++ b/core/components/atoms/icon/Icon.tsx
@@ -173,7 +173,14 @@ export const Icon = (props: IconProps) => {
     );
   }
   return (
-    <i data-test="DesignSystem-Icon" {...baseProps} className={iconClass} style={styles} {...accessibilityProps}>
+    <i
+      data-test="DesignSystem-Icon"
+      {...baseProps}
+      className={iconClass}
+      style={styles}
+      aria-hidden={props['aria-label'] ? undefined : 'true'}
+      {...accessibilityProps}
+    >
       {name}
     </i>
   );

--- a/core/components/atoms/icon/Icon.tsx
+++ b/core/components/atoms/icon/Icon.tsx
@@ -172,13 +172,15 @@ export const Icon = (props: IconProps) => {
       </span>
     );
   }
+  const isInteractive = props.onClick || props.onKeyDown || accessibilityProps.role === 'button';
+
   return (
     <i
       data-test="DesignSystem-Icon"
       {...baseProps}
       className={iconClass}
       style={styles}
-      aria-hidden={props['aria-label'] ? undefined : 'true'}
+      aria-hidden={props['aria-label'] || isInteractive ? undefined : 'true'}
       {...accessibilityProps}
     >
       {name}

--- a/core/components/atoms/icon/__tests__/__snapshots__/Icon.test.tsx.snap
+++ b/core/components/atoms/icon/__tests__/__snapshots__/Icon.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent1"
       data-test="DesignSystem-Icon"
       role="button"
@@ -24,6 +25,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent1Dark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -42,6 +44,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent1Darker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -60,6 +63,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent1Lighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -78,6 +82,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent2"
       data-test="DesignSystem-Icon"
       role="button"
@@ -96,6 +101,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent2Dark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -114,6 +120,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent2Darker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -132,6 +139,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent2Lighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -150,6 +158,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent3"
       data-test="DesignSystem-Icon"
       role="button"
@@ -168,6 +177,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent3Dark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -186,6 +196,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent3Darker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -204,6 +215,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent3Lighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -222,6 +234,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent4"
       data-test="DesignSystem-Icon"
       role="button"
@@ -240,6 +253,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent4Dark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -258,6 +272,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent4Darker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -276,6 +291,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--accent4Lighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -294,6 +310,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--alert"
       data-test="DesignSystem-Icon"
       role="button"
@@ -312,6 +329,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--alertDark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -330,6 +348,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -348,6 +367,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--alertLighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -366,6 +386,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--destructive"
       data-test="DesignSystem-Icon"
       role="button"
@@ -384,6 +405,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--disabled"
       data-test="DesignSystem-Icon"
       role="button"
@@ -402,6 +424,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--info"
       data-test="DesignSystem-Icon"
       role="button"
@@ -420,6 +443,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--inverse"
       data-test="DesignSystem-Icon"
       role="button"
@@ -438,6 +462,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--primary"
       data-test="DesignSystem-Icon"
       role="button"
@@ -456,6 +481,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--primaryDark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -474,6 +500,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--primaryDarker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -492,6 +519,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--primaryLighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -510,6 +538,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--subtle"
       data-test="DesignSystem-Icon"
       role="button"
@@ -528,6 +557,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--success"
       data-test="DesignSystem-Icon"
       role="button"
@@ -546,6 +576,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--successDark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -564,6 +595,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--successDarker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -582,6 +614,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--successLighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -600,6 +633,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--warning"
       data-test="DesignSystem-Icon"
       role="button"
@@ -618,6 +652,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--warningDark"
       data-test="DesignSystem-Icon"
       role="button"
@@ -636,6 +671,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--warningDarker"
       data-test="DesignSystem-Icon"
       role="button"
@@ -654,6 +690,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--warningLighter"
       data-test="DesignSystem-Icon"
       role="button"
@@ -672,6 +709,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--white"
       data-test="DesignSystem-Icon"
       role="button"
@@ -690,6 +728,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon"
       data-test="DesignSystem-Icon"
       role="button"
@@ -708,6 +747,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-outlined Icon"
       data-test="DesignSystem-Icon"
       role="button"
@@ -726,6 +766,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-outlined Icon"
       data-test="DesignSystem-Icon"
       role="button"
@@ -744,6 +785,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon"
       data-test="DesignSystem-Icon"
       role="button"
@@ -762,6 +804,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon"
       data-test="DesignSystem-Icon"
       role="button"
@@ -780,6 +823,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-outlined Icon"
       data-test="DesignSystem-Icon"
       role="button"
@@ -798,6 +842,7 @@ exports[`Icon component snapshot
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon"
       data-test="DesignSystem-Icon"
       role="button"


### PR DESCRIPTION
Addresses accessibility requirements for Icon component as per WCAG 2.2 AA guidelines.