### PR TITLE
feat(input): add WCAG 2.2 AA accessibility props

### DIFF
--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -247,6 +247,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
 
   const iconSize = size === 'tiny' ? 14 : sizeMapping[size];
 
+  const inputId = props.id || name;
+  const inlineLabelId = inlineLabel && inputId ? `${inputId}-inlineLabel` : undefined;
+
   return (
     <div
       data-test="DesignSystem-InputWrapper"
@@ -257,7 +260,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
       onBlur={() => setIsInputBlank(!ref.current?.value)}
     >
       {inlineLabel && (
-        <div className={styles['Input-inlineLabel']} id={`${props.id || name}-inlineLabel`}>
+        <div className={styles['Input-inlineLabel']} id={inlineLabelId}>
           <Text appearance="subtle">{inlineLabel}</Text>
         </div>
       )}
@@ -286,7 +289,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
         onFocus={onFocus}
         onPaste={onPaste}
         aria-invalid={error || undefined}
-        aria-labelledby={inlineLabel ? `${props.id || name}-inlineLabel` : undefined}
+        aria-labelledby={inlineLabelId}
         /**
          *for readOnly: true, tab focus from input element is removed. Hence, its tabIndex is set to -1.
          *For rest, "undefined" lets user agent(browser) use the default tabIndex.

--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -257,7 +257,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
       onBlur={() => setIsInputBlank(!ref.current?.value)}
     >
       {inlineLabel && (
-        <div className={styles['Input-inlineLabel']}>
+        <div className={styles['Input-inlineLabel']} id={`${props.id || name}-inlineLabel`}>
           <Text appearance="subtle">{inlineLabel}</Text>
         </div>
       )}
@@ -285,6 +285,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
         onClick={onClick}
         onFocus={onFocus}
         onPaste={onPaste}
+        aria-invalid={error || undefined}
+        aria-labelledby={inlineLabel ? `${props.id || name}-inlineLabel` : undefined}
         /**
          *for readOnly: true, tab focus from input element is removed. Hence, its tabIndex is set to -1.
          *For rest, "undefined" lets user agent(browser) use the default tabIndex.
@@ -305,6 +307,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
           <div className={rightIconClass}>
             <Icon
               data-test="DesignSystem-Input--closeIcon"
+              aria-label="Clear input"
               onClick={(e) => {
                 ref.current?.focus({ preventScroll: true });
                 onClear(e);

--- a/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`Input Component - Disabled State with Icon Snapshot Tests
         class="Input-icon Input-icon--left"
       >
         <i
+          aria-hidden="true"
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
           role="button"
@@ -102,6 +103,7 @@ exports[`Input Component - Disabled State without Change Handler Snapshot Tests
         class="Input-icon Input-icon--left"
       >
         <i
+          aria-hidden="true"
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
           role="button"
@@ -136,6 +138,7 @@ exports[`Input Component - Error State with Icon Snapshot Tests
       style="min-width: 256px;"
     >
       <input
+        aria-invalid="true"
         class="Input-input Input-input--regular"
         data-test="DesignSystem-Input"
         name="name"
@@ -162,6 +165,7 @@ exports[`Input Component - Error State with Icon Snapshot Tests
         class="Input-icon Input-icon--left Input-icon--error"
       >
         <i
+          aria-hidden="true"
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
           role="button"
@@ -171,6 +175,7 @@ exports[`Input Component - Error State with Icon Snapshot Tests
         </i>
       </div>
       <input
+        aria-invalid="true"
         class="Input-input Input-input--regular"
         data-test="DesignSystem-Input"
         name="name"
@@ -221,6 +226,7 @@ exports[`Input Component - Icon and Placeholder Variants Snapshot Tests
         class="Input-icon Input-icon--left Input-icon--inputBlank"
       >
         <i
+          aria-hidden="true"
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
           role="button"
@@ -281,6 +287,7 @@ exports[`Input Component - Icon and Placeholder Variants Snapshot Tests
         class="Input-icon Input-icon--left"
       >
         <i
+          aria-hidden="true"
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
           role="button"
@@ -382,6 +389,7 @@ exports[`Input Component - Number Type with Inline Label Snapshot Tests
     >
       <div
         class="Input-inlineLabel"
+        id="name-inlineLabel"
       >
         <span
           class="Text Text--subtle Text--regular"
@@ -391,6 +399,7 @@ exports[`Input Component - Number Type with Inline Label Snapshot Tests
         </span>
       </div>
       <input
+        aria-labelledby="name-inlineLabel"
         class="Input-input Input-input--large"
         data-test="DesignSystem-Input"
         name="name"
@@ -414,6 +423,7 @@ exports[`Input Component - Number Type with Inline Label Snapshot Tests
     >
       <div
         class="Input-inlineLabel"
+        id="name-inlineLabel"
       >
         <span
           class="Text Text--subtle Text--regular"
@@ -423,6 +433,7 @@ exports[`Input Component - Number Type with Inline Label Snapshot Tests
         </span>
       </div>
       <input
+        aria-labelledby="name-inlineLabel"
         class="Input-input Input-input--regular"
         data-test="DesignSystem-Input"
         name="name"
@@ -446,6 +457,7 @@ exports[`Input Component - Number Type with Inline Label Snapshot Tests
     >
       <div
         class="Input-inlineLabel"
+        id="name-inlineLabel"
       >
         <span
           class="Text Text--subtle Text--regular"
@@ -455,6 +467,7 @@ exports[`Input Component - Number Type with Inline Label Snapshot Tests
         </span>
       </div>
       <input
+        aria-labelledby="name-inlineLabel"
         class="Input-input Input-input--tiny"
         data-test="DesignSystem-Input"
         name="name"
@@ -506,6 +519,7 @@ exports[`Input Component - ReadOnly State with Icon Snapshot Tests
         class="Input-icon Input-icon--left"
       >
         <i
+          aria-hidden="true"
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
           role="button"

--- a/core/components/atoms/input/actionButton/__tests__/__snapshots__/ActionButton.test.tsx.snap
+++ b/core/components/atoms/input/actionButton/__tests__/__snapshots__/ActionButton.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ActionButton component
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon ActionButton"
       data-test="DesignSystem-Input-ActionButton"
       role="button"
@@ -24,6 +25,7 @@ exports[`ActionButton component
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-outlined Icon ActionButton"
       data-test="DesignSystem-Input-ActionButton"
       role="button"
@@ -42,6 +44,7 @@ exports[`ActionButton component
 <body>
   <div>
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon ActionButton"
       data-test="DesignSystem-Input-ActionButton"
       role="button"


### PR DESCRIPTION
Addresses accessibility requirements for Input component as per WCAG 2.2 AA guidelines.