### PR TITLE
feat(label): add WCAG 2.2 AA accessibility props

### DIFF
--- a/core/components/atoms/label/Label.tsx
+++ b/core/components/atoms/label/Label.tsx
@@ -95,7 +95,7 @@ export const Label = (props: LabelProps) => {
           name="info"
           size={12}
           appearance="subtle"
-          aria-label="More information"
+          aria-label={info}
           className="ml-3 cursor-pointer d-flex align-items-center"
         />
       </Tooltip>

--- a/core/components/atoms/label/Label.tsx
+++ b/core/components/atoms/label/Label.tsx
@@ -95,6 +95,7 @@ export const Label = (props: LabelProps) => {
           name="info"
           size={12}
           appearance="subtle"
+          aria-label="More information"
           className="ml-3 cursor-pointer d-flex align-items-center"
         />
       </Tooltip>

--- a/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -99,6 +99,7 @@ exports[`Label component - info prop tests
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="More information"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -132,6 +133,7 @@ exports[`Label component - info prop tests
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="More information"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -165,6 +167,7 @@ exports[`Label component - info prop tests
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="More information"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"
@@ -255,6 +258,7 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
           class="PopperWrapper-trigger"
         >
           <i
+            aria-label="More information"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
             role="button"


### PR DESCRIPTION
Addresses accessibility requirements for Label component as per WCAG 2.2 AA guidelines.