### PR TITLE
feat(link): add WCAG 2.2 AA accessibility props

### DIFF
--- a/core/components/atoms/link/Link.tsx
+++ b/core/components/atoms/link/Link.tsx
@@ -76,7 +76,15 @@ export const Link = (props: LinkProps) => {
   );
 
   const isExternal = rest.target === '_blank';
-  const rel = isExternal ? (rest.rel || 'noopener noreferrer') : rest.rel;
+  const rel = isExternal ? rest.rel || 'noopener noreferrer' : rest.rel;
+
+  const getAriaLabel = () => {
+    if (props['aria-label']) return props['aria-label'];
+    if (isExternal && typeof children === 'string') {
+      return `${children} (opens in a new window)`;
+    }
+    return undefined;
+  };
 
   return (
     <GenericText
@@ -86,7 +94,7 @@ export const Link = (props: LinkProps) => {
       tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled}
       rel={rel}
-      aria-label={isExternal && !props['aria-label'] ? `${children} (opens in a new window)` : props['aria-label']}
+      aria-label={getAriaLabel()}
       {...rest}
     >
       {children}

--- a/core/components/atoms/link/Link.tsx
+++ b/core/components/atoms/link/Link.tsx
@@ -75,6 +75,9 @@ export const Link = (props: LinkProps) => {
     className
   );
 
+  const isExternal = rest.target === '_blank';
+  const rel = isExternal ? (rest.rel || 'noopener noreferrer') : rest.rel;
+
   return (
     <GenericText
       data-test="DesignSystem-Link"
@@ -82,6 +85,8 @@ export const Link = (props: LinkProps) => {
       componentType="a"
       tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled}
+      rel={rel}
+      aria-label={isExternal && !props['aria-label'] ? `${children} (opens in a new window)` : props['aria-label']}
       {...rest}
     >
       {children}

--- a/core/components/atoms/link/__tests__/__snapshots__/Link.test.tsx.snap
+++ b/core/components/atoms/link/__tests__/__snapshots__/Link.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Link component
   <div>
     <a
       aria-disabled="false"
+      aria-label="Link (opens in a new window)"
       class="Link Link--regular Link--default"
       data-test="DesignSystem-Link"
       href="Sample string"


### PR DESCRIPTION
Addresses accessibility requirements for Link component as per WCAG 2.2 AA guidelines.