### PR TITLE
feat(tooltip): close tooltip on Escape key for WCAG

### DIFF
--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -38,6 +38,8 @@ export interface PopperWrapperProps {
    * Holds `Popover` on hover
    *
    * **Use only if you are using `on = 'hover'`**
+   *
+   * Avoid setting this to false to keep the tooltip accessible and compliant with WCAG "Content on Hover or Focus" requirements.
    */
   hoverable: boolean;
   /**
@@ -151,10 +153,14 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     this.handleMouseEnter = this.handleMouseEnter.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.boundaryScrollHandler = this.boundaryScrollHandler.bind(this);
+    this.handleEscapeKey = this.handleEscapeKey.bind(this);
   }
 
   componentDidMount() {
     this.addBoundaryScrollHandler();
+    if (this.props.open) {
+      this.addEscapeKeyHandler();
+    }
     const triggerElement = this.triggerRef.current;
     const zIndex = this.getZIndexForLayer(triggerElement);
     this.setState({
@@ -168,6 +174,11 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
       this.addBoundaryScrollHandler();
     }
     if (prevProps.open !== this.props.open) {
+      if (this.props.open) {
+        this.addEscapeKeyHandler();
+      } else {
+        this.removeEscapeKeyHandler();
+      }
       this._throttleWait = false;
       this.setState({
         animationKeyframe: '',
@@ -190,6 +201,7 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
 
   componentWillUnmount() {
     this.removeBoundaryScrollHandler();
+    this.removeEscapeKeyHandler();
   }
 
   boundaryScrollHandler() {
@@ -214,6 +226,34 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     if (this.props.boundaryElement && this.props.boundaryElement.removeEventListener) {
       this.props.boundaryElement.removeEventListener('scroll', this.boundaryScrollHandler);
     }
+  }
+
+  handleEscapeKey(event: KeyboardEvent) {
+    if (event.key !== 'Escape' || !this.props.open) return;
+
+    const openLayers = document.querySelectorAll('[data-opened="true"]');
+    if (openLayers.length === 0) return;
+
+    const ourEl = this.popupRef.current;
+    const ourZ = ourEl ? parseInt(window.getComputedStyle(ourEl).zIndex || '0', 10) : 0;
+    const maxZ = Math.max(
+      ...Array.from(openLayers).map((el) => parseInt(window.getComputedStyle(el).zIndex || '0', 10) || 0)
+    );
+
+    if (ourZ >= maxZ) {
+      this.togglePopper('escapeKeypress', false);
+      this.setState({ isOpen: false });
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  addEscapeKeyHandler() {
+    document.addEventListener('keydown', this.handleEscapeKey);
+  }
+
+  removeEscapeKeyHandler() {
+    document.removeEventListener('keydown', this.handleEscapeKey);
   }
 
   mouseMoveHandler() {

--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -265,9 +265,6 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     const overlayEl = this._overlayElement || this.popupRef.current;
     if (!overlayEl || !OverlayManager.isTopOverlay(overlayEl)) return;
 
-    OverlayManager.remove(overlayEl);
-    this._overlayElement = null;
-    this.removeEscapeKeyHandler();
     this.togglePopper('escapeKeypress', false);
     event.preventDefault();
     event.stopImmediatePropagation();

--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -169,6 +169,7 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
       if (this.popupRef.current && this.props.open) {
         this._overlayElement = this.popupRef.current;
         OverlayManager.add(this._overlayElement);
+        this.addEscapeKeyHandler();
       }
     }, 0);
   }
@@ -183,7 +184,6 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
   componentDidMount() {
     this.addBoundaryScrollHandler();
     if (this.props.open) {
-      this.addEscapeKeyHandler();
       this.scheduleOverlayAdd();
     }
     const triggerElement = this.triggerRef.current;
@@ -200,7 +200,6 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     }
     if (prevProps.open !== this.props.open) {
       if (this.props.open) {
-        this.addEscapeKeyHandler();
         this.scheduleOverlayAdd();
       } else {
         this.removeEscapeKeyHandler();

--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -5,6 +5,7 @@ import { OutsideClick } from '@/index';
 import classNames from 'classnames';
 import { PositionType } from '@/common.type';
 import { flushSync } from 'react-dom';
+import OverlayManager from '@/utils/OverlayManager';
 
 type ActionType = 'click' | 'hover';
 type Offset = 'small' | 'medium' | 'large';
@@ -117,6 +118,7 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
   hoverableDelay?: number;
   _timer?: number;
   _throttleWait?: boolean;
+  _overlayAddTimer?: number;
   offsetMapping: Record<Offset, string>;
 
   static defaultProps = {
@@ -156,10 +158,31 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     this.handleEscapeKey = this.handleEscapeKey.bind(this);
   }
 
+  scheduleOverlayAdd() {
+    if (this._overlayAddTimer != null) {
+      window.clearTimeout(this._overlayAddTimer);
+      this._overlayAddTimer = undefined;
+    }
+    this._overlayAddTimer = window.setTimeout(() => {
+      this._overlayAddTimer = undefined;
+      if (this.popupRef.current && this.props.open) {
+        OverlayManager.add(this.popupRef.current);
+      }
+    }, 0);
+  }
+
+  clearOverlayAddTimer() {
+    if (this._overlayAddTimer != null) {
+      window.clearTimeout(this._overlayAddTimer);
+      this._overlayAddTimer = undefined;
+    }
+  }
+
   componentDidMount() {
     this.addBoundaryScrollHandler();
     if (this.props.open) {
       this.addEscapeKeyHandler();
+      this.scheduleOverlayAdd();
     }
     const triggerElement = this.triggerRef.current;
     const zIndex = this.getZIndexForLayer(triggerElement);
@@ -176,8 +199,11 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     if (prevProps.open !== this.props.open) {
       if (this.props.open) {
         this.addEscapeKeyHandler();
+        this.scheduleOverlayAdd();
       } else {
         this.removeEscapeKeyHandler();
+        this.clearOverlayAddTimer();
+        OverlayManager.remove(this.popupRef.current);
       }
       this._throttleWait = false;
       this.setState({
@@ -202,6 +228,8 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
   componentWillUnmount() {
     this.removeBoundaryScrollHandler();
     this.removeEscapeKeyHandler();
+    this.clearOverlayAddTimer();
+    OverlayManager.remove(this.popupRef.current);
   }
 
   boundaryScrollHandler() {
@@ -230,22 +258,12 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
 
   handleEscapeKey(event: KeyboardEvent) {
     if (event.key !== 'Escape' || !this.props.open) return;
+    if (!this.popupRef.current || !OverlayManager.isTopOverlay(this.popupRef.current)) return;
 
-    const openLayers = document.querySelectorAll('[data-opened="true"]');
-    if (openLayers.length === 0) return;
-
-    const ourEl = this.popupRef.current;
-    const ourZ = ourEl ? parseInt(window.getComputedStyle(ourEl).zIndex || '0', 10) : 0;
-    const maxZ = Math.max(
-      ...Array.from(openLayers).map((el) => parseInt(window.getComputedStyle(el).zIndex || '0', 10) || 0)
-    );
-
-    if (ourZ >= maxZ) {
-      this.togglePopper('escapeKeypress', false);
-      this.setState({ isOpen: false });
-      event.preventDefault();
-      event.stopImmediatePropagation();
-    }
+    this.togglePopper('escapeKeypress', false);
+    this.setState({ isOpen: false });
+    event.preventDefault();
+    event.stopImmediatePropagation();
   }
 
   addEscapeKeyHandler() {

--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -269,7 +269,6 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     this._overlayElement = null;
     this.removeEscapeKeyHandler();
     this.togglePopper('escapeKeypress', false);
-    this.setState({ isOpen: false });
     event.preventDefault();
     event.stopImmediatePropagation();
   }

--- a/core/components/atoms/popperWrapper/PopperWrapper.tsx
+++ b/core/components/atoms/popperWrapper/PopperWrapper.tsx
@@ -119,6 +119,7 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
   _timer?: number;
   _throttleWait?: boolean;
   _overlayAddTimer?: number;
+  _overlayElement: HTMLDivElement | null = null;
   offsetMapping: Record<Offset, string>;
 
   static defaultProps = {
@@ -166,7 +167,8 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     this._overlayAddTimer = window.setTimeout(() => {
       this._overlayAddTimer = undefined;
       if (this.popupRef.current && this.props.open) {
-        OverlayManager.add(this.popupRef.current);
+        this._overlayElement = this.popupRef.current;
+        OverlayManager.add(this._overlayElement);
       }
     }, 0);
   }
@@ -203,7 +205,8 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
       } else {
         this.removeEscapeKeyHandler();
         this.clearOverlayAddTimer();
-        OverlayManager.remove(this.popupRef.current);
+        OverlayManager.remove(this._overlayElement);
+        this._overlayElement = null;
       }
       this._throttleWait = false;
       this.setState({
@@ -229,7 +232,8 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
     this.removeBoundaryScrollHandler();
     this.removeEscapeKeyHandler();
     this.clearOverlayAddTimer();
-    OverlayManager.remove(this.popupRef.current);
+    OverlayManager.remove(this._overlayElement);
+    this._overlayElement = null;
   }
 
   boundaryScrollHandler() {
@@ -258,8 +262,12 @@ export class PopperWrapper extends React.Component<PopperWrapperProps, PopperWra
 
   handleEscapeKey(event: KeyboardEvent) {
     if (event.key !== 'Escape' || !this.props.open) return;
-    if (!this.popupRef.current || !OverlayManager.isTopOverlay(this.popupRef.current)) return;
+    const overlayEl = this._overlayElement || this.popupRef.current;
+    if (!overlayEl || !OverlayManager.isTopOverlay(overlayEl)) return;
 
+    OverlayManager.remove(overlayEl);
+    this._overlayElement = null;
+    this.removeEscapeKeyHandler();
     this.togglePopper('escapeKeypress', false);
     this.setState({ isOpen: false });
     event.preventDefault();

--- a/core/components/molecules/modal/Modal.tsx
+++ b/core/components/molecules/modal/Modal.tsx
@@ -178,7 +178,9 @@ class Modal extends React.Component<ModalProps, ModalState> {
   };
 
   activateFocusTrap = () => {
-    this.previousActiveElement = document.activeElement as HTMLElement | null;
+    if (!this.previousActiveElement || !this.modalRef.current?.contains(document.activeElement)) {
+      this.previousActiveElement = document.activeElement as HTMLElement | null;
+    }
     const container = this.modalContentRef.current;
     if (!container) return;
 

--- a/core/components/molecules/modal/Modal.tsx
+++ b/core/components/molecules/modal/Modal.tsx
@@ -13,6 +13,7 @@ import {
   closeOnEscapeKeypress,
   getFocusableElements,
   handleFocusTrapKeyDown,
+  restoreFocusToElementIfConnected,
 } from '@/utils/overlayHelper';
 import OverlayManager from '@/utils/OverlayManager';
 import { FooterOptions } from '@/common.type';
@@ -211,9 +212,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
     const elementToFocus = this.previousActiveElement;
     this.previousActiveElement = null;
 
-    if (elementToFocus?.focus && OverlayManager.isTopOverlay(this.modalRef.current)) {
-      window.requestAnimationFrame(() => elementToFocus.focus({ preventScroll: true }));
-    }
+    restoreFocusToElementIfConnected(elementToFocus);
   };
 
   componentDidMount() {

--- a/core/components/molecules/popover/__stories__/variants/DismissOrder.story.jsx
+++ b/core/components/molecules/popover/__stories__/variants/DismissOrder.story.jsx
@@ -3,7 +3,7 @@ import { Text, Button, Popover, Tooltip } from '@/index';
 import '../style.css';
 
 /**
- * **Dismiss order (Overlay Manager)**  
+ * **Dismiss order (Overlay Manager)**
  * When multiple overlays are open (e.g. one on click, one on hover), the Overlay Manager
  * controls stacking and dismiss order: the topmost overlay closes first (Escape, backdrop click).
  * Open both popovers to see the behavior.
@@ -11,47 +11,49 @@ import '../style.css';
 export const DismissOrderOverlayManager = () => {
   return (
     <div className="p-6 flex align-items-center flex-nowrap">
-        <span style={{ marginRight: 120 }}>
-          <Popover
-            position="bottom"
-            on="click"
-            trigger={<Button appearance="basic">1. Click here</Button>}
-            closeOnBackdropClick
-          >
-            <div className="p-5 pb-6 pr-10">
-              <Text weight="strong">3. Press escape</Text>
-              <br />
-              <Tooltip position="right" tooltip="Hover me for tooltip text that appears in the tooltip when the line is truncated.">
-                <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 180 }}>
-                  Hover me for tooltip text that appears in the tooltip when the line is truncated.
-                </Text>
-              </Tooltip>
-              <Popover
-                position="right"
-                on="click"
-                trigger={<Button appearance="basic" className="mt-4">Open inner popover</Button>}
-                closeOnBackdropClick
-              >
-                <div className="p-5 pb-6 pr-10">
-                  <Text weight="strong">Inner (higher z)</Text>
-                  <Text className="mt-4 d-block">Escape closes this first, then the parent.</Text>
-                </div>
-              </Popover>
-            </div>
-          </Popover>
-        </span>
-
+      <span style={{ marginRight: 120 }}>
         <Popover
           position="bottom"
-          on="hover"
-          trigger={<Button appearance="basic">2. Hover here</Button>}
-          hoverable
+          on="click"
+          trigger={<Button appearance="basic">1. Click here</Button>}
+          closeOnBackdropClick
         >
           <div className="p-5 pb-6 pr-10">
-            <Text weight="strong">2. Hover here</Text>
-            <Text className="mt-4 d-block">Opened by hover. Closes on Escape or mouse leave.</Text>
+            <Text weight="strong">3. Press escape</Text>
+            <br />
+            <Tooltip
+              position="right"
+              tooltip="Hover me for tooltip text that appears in the tooltip when the line is truncated."
+            >
+              <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 180 }}>
+                Hover me for tooltip text that appears in the tooltip when the line is truncated.
+              </Text>
+            </Tooltip>
+            <Popover
+              position="right"
+              on="click"
+              trigger={
+                <Button appearance="basic" className="mt-4">
+                  Open inner popover
+                </Button>
+              }
+              closeOnBackdropClick
+            >
+              <div className="p-5 pb-6 pr-10">
+                <Text weight="strong">Inner (higher z)</Text>
+                <Text className="mt-4 d-block">Escape closes this first, then the parent.</Text>
+              </div>
+            </Popover>
           </div>
         </Popover>
+      </span>
+
+      <Popover position="bottom" on="hover" trigger={<Button appearance="basic">2. Hover here</Button>} hoverable>
+        <div className="p-5 pb-6 pr-10">
+          <Text weight="strong">2. Hover here</Text>
+          <Text className="mt-4 d-block">Opened by hover. Closes on Escape or mouse leave.</Text>
+        </div>
+      </Popover>
     </div>
   );
 };
@@ -95,8 +97,7 @@ export default {
     docs: {
       docPage: {
         title: 'Popover Dismiss Order',
-        description:
-          'When several popovers (or tooltips) are open, the topmost overlay closes first on Escape.',
+        description: 'When several popovers (or tooltips) are open, the topmost overlay closes first on Escape.',
         customCode,
         props: {
           exclude: ['offset'],

--- a/core/components/molecules/popover/__stories__/variants/DismissOrder.story.jsx
+++ b/core/components/molecules/popover/__stories__/variants/DismissOrder.story.jsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { Text, Button, Popover, Tooltip } from '@/index';
+import '../style.css';
+
+/**
+ * **Dismiss order (Overlay Manager)**  
+ * When multiple overlays are open (e.g. one on click, one on hover), the Overlay Manager
+ * controls stacking and dismiss order: the topmost overlay closes first (Escape, backdrop click).
+ * Open both popovers to see the behavior.
+ */
+export const DismissOrderOverlayManager = () => {
+  return (
+    <div className="p-6 flex align-items-center flex-nowrap">
+        <span style={{ marginRight: 120 }}>
+          <Popover
+            position="bottom"
+            on="click"
+            trigger={<Button appearance="basic">1. Click here</Button>}
+            closeOnBackdropClick
+          >
+            <div className="p-5 pb-6 pr-10">
+              <Text weight="strong">3. Press escape</Text>
+              <br />
+              <Tooltip position="right" tooltip="Hover me for tooltip text that appears in the tooltip when the line is truncated.">
+                <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 180 }}>
+                  Hover me for tooltip text that appears in the tooltip when the line is truncated.
+                </Text>
+              </Tooltip>
+              <Popover
+                position="right"
+                on="click"
+                trigger={<Button appearance="basic" className="mt-4">Open inner popover</Button>}
+                closeOnBackdropClick
+              >
+                <div className="p-5 pb-6 pr-10">
+                  <Text weight="strong">Inner (higher z)</Text>
+                  <Text className="mt-4 d-block">Escape closes this first, then the parent.</Text>
+                </div>
+              </Popover>
+            </div>
+          </Popover>
+        </span>
+
+        <Popover
+          position="bottom"
+          on="hover"
+          trigger={<Button appearance="basic">2. Hover here</Button>}
+          hoverable
+        >
+          <div className="p-5 pb-6 pr-10">
+            <Text weight="strong">2. Hover here</Text>
+            <Text className="mt-4 d-block">Opened by hover. Closes on Escape or mouse leave.</Text>
+          </div>
+        </Popover>
+    </div>
+  );
+};
+
+DismissOrderOverlayManager.storyName = 'Popover Dismiss Order';
+
+const customCode = `() => (
+  <div className="p-6 flex align-items-center flex-nowrap">
+      <span style={{ marginRight: 120 }}>
+        <Popover position="bottom" on="click" trigger={<Button appearance="basic">1. Click here</Button>} closeOnBackdropClick>
+          <div className="p-5 pb-6 pr-10">
+            <Text weight="strong">3. Press escape</Text>
+            <br />
+            <Tooltip position="right" tooltip="Hover me for tooltip text that appears in the tooltip when the line is truncated.">
+              <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 180 }}>
+                Hover me for tooltip text that appears in the tooltip when the line is truncated.
+              </Text>
+            </Tooltip>
+            <Popover position="right" on="click" trigger={<Button appearance="basic" className="mt-4">Open inner popover</Button>} closeOnBackdropClick>
+              <div className="p-5 pb-6 pr-10">
+                <Text weight="strong">Inner (higher z)</Text>
+                <Text className="mt-4 d-block">Escape closes this first, then the parent.</Text>
+              </div>
+            </Popover>
+          </div>
+        </Popover>
+      </span>
+      <Popover position="bottom" on="hover" trigger={<Button appearance="basic">2. Hover here</Button>} hoverable>
+        <div className="p-5 pb-6 pr-10">
+          <Text weight="strong">2. Hover here</Text>
+          <Text className="mt-4 d-block">Opened by hover. Closes on Escape or mouse leave.</Text>
+        </div>
+      </Popover>
+  </div>
+)`;
+
+export default {
+  title: 'Components/Popover/Popover Dismiss Order',
+  component: Popover,
+  parameters: {
+    docs: {
+      docPage: {
+        title: 'Popover Dismiss Order',
+        description:
+          'When several popovers (or tooltips) are open, the topmost overlay closes first on Escape.',
+        customCode,
+        props: {
+          exclude: ['offset'],
+        },
+      },
+    },
+  },
+};

--- a/core/components/molecules/popover/__stories__/variants/DismissOrder.story.jsx
+++ b/core/components/molecules/popover/__stories__/variants/DismissOrder.story.jsx
@@ -11,7 +11,7 @@ import '../style.css';
 export const DismissOrderOverlayManager = () => {
   return (
     <div className="p-6 flex align-items-center flex-nowrap">
-      <span style={{ marginRight: 120 }}>
+      <span className="mr-12">
         <Popover
           position="bottom"
           on="click"
@@ -25,7 +25,7 @@ export const DismissOrderOverlayManager = () => {
               position="right"
               tooltip="Hover me for tooltip text that appears in the tooltip when the line is truncated."
             >
-              <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 180 }}>
+              <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 'var(--spacing-440)' }}>
                 Hover me for tooltip text that appears in the tooltip when the line is truncated.
               </Text>
             </Tooltip>
@@ -62,13 +62,13 @@ DismissOrderOverlayManager.storyName = 'Popover Dismiss Order';
 
 const customCode = `() => (
   <div className="p-6 flex align-items-center flex-nowrap">
-      <span style={{ marginRight: 120 }}>
+      <span className="mr-12">
         <Popover position="bottom" on="click" trigger={<Button appearance="basic">1. Click here</Button>} closeOnBackdropClick>
           <div className="p-5 pb-6 pr-10">
             <Text weight="strong">3. Press escape</Text>
             <br />
             <Tooltip position="right" tooltip="Hover me for tooltip text that appears in the tooltip when the line is truncated.">
-              <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 180 }}>
+              <Text className="mt-4 d-block ellipsis--noWrap" style={{ maxWidth: 'var(--spacing-440)' }}>
                 Hover me for tooltip text that appears in the tooltip when the line is truncated.
               </Text>
             </Tooltip>

--- a/core/components/molecules/sidesheet/Sidesheet.tsx
+++ b/core/components/molecules/sidesheet/Sidesheet.tsx
@@ -13,6 +13,7 @@ import {
   closeOnEscapeKeypress,
   getFocusableElements,
   handleFocusTrapKeyDown,
+  restoreFocusToElementIfConnected,
 } from '@/utils/overlayHelper';
 import OverlayManager from '@/utils/OverlayManager';
 import { FooterOptions } from '@/common.type';
@@ -223,9 +224,7 @@ class Sidesheet extends React.Component<SidesheetProps, SidesheetState> {
     const elementToFocus = this.previousActiveElement;
     this.previousActiveElement = null;
 
-    if (elementToFocus?.focus && OverlayManager.isTopOverlay(this.sidesheetRef.current)) {
-      window.requestAnimationFrame(() => elementToFocus.focus({ preventScroll: true }));
-    }
+    restoreFocusToElementIfConnected(elementToFocus);
   };
 
   componentDidMount() {

--- a/core/components/molecules/tooltip/Tooltip.tsx
+++ b/core/components/molecules/tooltip/Tooltip.tsx
@@ -170,7 +170,7 @@ Tooltip.useAutoTooltip = function () {
 };
 
 Tooltip.defaultProps = Object.assign({}, filterProps(Popover.defaultProps, tooltipPropsList), {
-  hoverable: false,
+  hoverable: true,
   showTooltip: true,
   showOnTruncation: false,
 });

--- a/core/components/molecules/tooltip/__stories__/AutotooltipWithHook.story.jsx
+++ b/core/components/molecules/tooltip/__stories__/AutotooltipWithHook.story.jsx
@@ -1,21 +1,17 @@
-import { Tooltip } from '@/index';
+import * as React from 'react';
+import { Tooltip, Avatar, Text } from '@/index';
 
-export const autoTooltipWithHook = () => {};
-
-const customCode = `() => {
+export const autoTooltipWithHook = () => {
   const [isFirstTruncated, setIsFirstTruncated] = React.useState(false);
   const [isSecondTruncated, setIsSecondTruncated] = React.useState(false);
-
   const { detectTruncation } = Tooltip.useAutoTooltip();
   const firstContentRef = React.useRef(null);
-  const SecondContentRef = React.useRef(null);
+  const secondContentRef = React.useRef(null);
 
   React.useEffect(() => {
-    const isFirstTruncated = detectTruncation(firstContentRef);
-    const isSecondTruncated = detectTruncation(SecondContentRef);
-    setIsFirstTruncated(isFirstTruncated);
-    setIsSecondTruncated(isSecondTruncated);
-  }, [firstContentRef, SecondContentRef]);
+    setIsFirstTruncated(detectTruncation(firstContentRef));
+    setIsSecondTruncated(detectTruncation(secondContentRef));
+  }, [firstContentRef, secondContentRef]);
 
   return (
     <div className="d-flex justify-content-around">
@@ -33,7 +29,45 @@ const customCode = `() => {
         <Tooltip showTooltip={isSecondTruncated} tooltip="John Doe: Passionate Innovator and Visionary Leader">
           <div className="d-flex ellipsis--noWrap">
             <Avatar appearance="primary" withTooltip={false} firstName="John" lastName="Doe" size="tiny" />
-            <Text ref={SecondContentRef} className="ellipsis--noWrap w-100 ml-3 mt-2">
+            <Text ref={secondContentRef} className="ellipsis--noWrap w-100 ml-3 mt-2">
+              John Doe: Passionate Innovator and Visionary Leader
+            </Text>
+          </div>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+const customCode = `() => {
+  const [isFirstTruncated, setIsFirstTruncated] = React.useState(false);
+  const [isSecondTruncated, setIsSecondTruncated] = React.useState(false);
+  const { detectTruncation } = Tooltip.useAutoTooltip();
+  const firstContentRef = React.useRef(null);
+  const secondContentRef = React.useRef(null);
+
+  React.useEffect(() => {
+    setIsFirstTruncated(detectTruncation(firstContentRef));
+    setIsSecondTruncated(detectTruncation(secondContentRef));
+  }, [firstContentRef, secondContentRef]);
+
+  return (
+    <div className="d-flex justify-content-around">
+      <div>
+        <Tooltip showTooltip={isFirstTruncated} tooltip="John Doe: Passionate Innovator and Visionary Leader">
+          <div className="d-flex ellipsis--noWrap">
+            <Avatar appearance="primary" withTooltip={false} firstName="John" lastName="Doe" size="tiny" />
+            <Text ref={firstContentRef} style={{ maxWidth: 150 }} className="ellipsis--noWrap w-100 ml-3 mt-2">
+              John Doe: Passionate Innovator and Visionary Leader
+            </Text>
+          </div>
+        </Tooltip>
+      </div>
+      <div>
+        <Tooltip showTooltip={isSecondTruncated} tooltip="John Doe: Passionate Innovator and Visionary Leader">
+          <div className="d-flex ellipsis--noWrap">
+            <Avatar appearance="primary" withTooltip={false} firstName="John" lastName="Doe" size="tiny" />
+            <Text ref={secondContentRef} className="ellipsis--noWrap w-100 ml-3 mt-2">
               John Doe: Passionate Innovator and Visionary Leader
             </Text>
           </div>

--- a/core/components/molecules/tooltip/__stories__/AutotooltipWithHook.story.jsx
+++ b/core/components/molecules/tooltip/__stories__/AutotooltipWithHook.story.jsx
@@ -19,7 +19,11 @@ export const autoTooltipWithHook = () => {
         <Tooltip showTooltip={isFirstTruncated} tooltip="John Doe: Passionate Innovator and Visionary Leader">
           <div className="d-flex ellipsis--noWrap">
             <Avatar appearance="primary" withTooltip={false} firstName="John" lastName="Doe" size="tiny" />
-            <Text ref={firstContentRef} style={{ maxWidth: 150 }} className="ellipsis--noWrap w-100 ml-3 mt-2">
+            <Text
+              ref={firstContentRef}
+              style={{ maxWidth: 'var(--spacing-320)' }}
+              className="ellipsis--noWrap w-100 ml-3 mt-2"
+            >
               John Doe: Passionate Innovator and Visionary Leader
             </Text>
           </div>
@@ -57,7 +61,7 @@ const customCode = `() => {
         <Tooltip showTooltip={isFirstTruncated} tooltip="John Doe: Passionate Innovator and Visionary Leader">
           <div className="d-flex ellipsis--noWrap">
             <Avatar appearance="primary" withTooltip={false} firstName="John" lastName="Doe" size="tiny" />
-            <Text ref={firstContentRef} style={{ maxWidth: 150 }} className="ellipsis--noWrap w-100 ml-3 mt-2">
+            <Text ref={firstContentRef} style={{ maxWidth: 'var(--spacing-320)' }} className="ellipsis--noWrap w-100 ml-3 mt-2">
               John Doe: Passionate Innovator and Visionary Leader
             </Text>
           </div>

--- a/core/components/molecules/tooltip/__stories__/index.story.jsx
+++ b/core/components/molecules/tooltip/__stories__/index.story.jsx
@@ -5,12 +5,10 @@ import { Tooltip, Button } from '@/index';
 export const all = () => {
   const position = 'bottom';
   const appendToBody = true;
-  const hoverable = false;
   const tooltip = 'An awesome tooltip';
 
   const options = {
     tooltip,
-    hoverable,
     position,
     appendToBody,
   };

--- a/core/components/molecules/tooltip/__tests__/Tooltip.test.tsx
+++ b/core/components/molecules/tooltip/__tests__/Tooltip.test.tsx
@@ -126,3 +126,36 @@ describe('Tooltip component with size prop', () => {
     expect(tooltipWrapper).toHaveClass('Tooltip');
   });
 });
+
+describe('Tooltip component keyboard accessibility', () => {
+  it('should close tooltip when Escape key is pressed', () => {
+    const { getByRole, queryByText } = render(
+      <Tooltip tooltip="A tooltip">
+        <Button>Hover over me</Button>
+      </Tooltip>
+    );
+    const button = getByRole('button');
+    fireEvent.mouseOver(button);
+    expect(queryByText('A tooltip')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(queryByText('A tooltip')).not.toBeInTheDocument();
+  });
+
+  it('should not close tooltip when other keys are pressed', () => {
+    const { getByRole, queryByText } = render(
+      <Tooltip tooltip="A tooltip">
+        <Button>Hover over me</Button>
+      </Tooltip>
+    );
+    const button = getByRole('button');
+    fireEvent.mouseOver(button);
+    expect(queryByText('A tooltip')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(queryByText('A tooltip')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(queryByText('A tooltip')).toBeInTheDocument();
+  });
+});

--- a/core/components/molecules/tooltip/__tests__/Tooltip.test.tsx
+++ b/core/components/molecules/tooltip/__tests__/Tooltip.test.tsx
@@ -128,7 +128,7 @@ describe('Tooltip component with size prop', () => {
 });
 
 describe('Tooltip component keyboard accessibility', () => {
-  it('should close tooltip when Escape key is pressed', () => {
+  it('should close tooltip when Escape key is pressed', async () => {
     const { getByRole, queryByText } = render(
       <Tooltip tooltip="A tooltip">
         <Button>Hover over me</Button>
@@ -138,6 +138,7 @@ describe('Tooltip component keyboard accessibility', () => {
     fireEvent.mouseOver(button);
     expect(queryByText('A tooltip')).toBeInTheDocument();
 
+    await new Promise((resolve) => setTimeout(resolve, 0));
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(queryByText('A tooltip')).not.toBeInTheDocument();
   });

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -212,6 +212,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
     switch (type) {
       case 'outsideClick':
+      case 'escapeKeypress':
         this.setState({ open: o });
         break;
       case 'onClick':

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -348,6 +348,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
     switch (type) {
       case 'outsideClick':
+      case 'escapeKeypress':
         this.setState({ open: o });
         break;
       case 'onClick':

--- a/core/utils/overlayHelper.ts
+++ b/core/utils/overlayHelper.ts
@@ -106,3 +106,17 @@ export const handleFocusTrapKeyDown = (event: KeyboardEvent, container: HTMLElem
 
   return false;
 };
+
+/**
+ * Returns focus to a previously focused element after an overlay closes.
+ * Does not consult overlay stacking order — dismissal priority and focus restoration are separate concerns.
+ */
+export const restoreFocusToElementIfConnected = (element: HTMLElement | null | undefined): void => {
+  if (!element?.focus || !element.isConnected) return;
+
+  window.requestAnimationFrame(() => {
+    if (element.isConnected) {
+      element.focus({ preventScroll: true });
+    }
+  });
+};

--- a/docs/src/pages/components/tooltip/interactions.mdx
+++ b/docs/src/pages/components/tooltip/interactions.mdx
@@ -211,3 +211,24 @@ import tooltip3 from './images/tooltip-3.gif'
 </Card>
 <br/>
 <br/>
+
+### Keyboard Interactions
+
+<br/>
+
+<table style={{width: "100%"}}>
+  <tbody>
+    <tr>
+      <th style={{width:"33%", textAlign: "left"}}>Initial state</th>
+      <th style={{width:"33%", textAlign: "left"}}>Keyboard Interaction</th>
+      <th style={{width:"33%", textAlign: "left"}}>Final state</th>
+    </tr>
+    <tr style={{verticalAlign: "top"}}>
+      <td>Tooltip is visible (e.g. on hover or focus)</td>
+      <td>&#60;Escape&#62;</td>
+      <td>Tooltip is closed</td>
+    </tr>
+  </tbody>
+</table>
+<br/>
+<br/>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

**Escape key (keyboard accessibility)**  
- Adds Escape key support to close tooltips and other PopperWrapper-based components (e.g., Popover) for WCAG-aligned keyboard dismiss.
- **PopperWrapper:** Document `keydown` listener when open; on Escape, close overlay and remove listener on close/unmount.
- **Tooltip:** Two tests added (Escape closes tooltip; other keys do not).
- **Docs:** Keyboard Interactions table on Tooltip Interactions tab (Escape → closes tooltip).

**Hoverable defaults & docs**  
- **Tooltip:** Default `hoverable` set to `true` (was `false`) so users can keep the tooltip open while moving to it, improving accessibility.
- **Popover:** No change (already `true` via PopperWrapper).
- **Storybook / Props:** JSDoc for the `hoverable` prop (in PopperWrapper) updated to guide on accessibility.

---

### Does this close any currently open issues?

No

---

### Any other comments?

No

---

### Dependent PRs/Commits

None.

---

### Describe breaking changes, if any.

None.

---

### Checklist

- [ ] Merged with latest `master` branch