### PR TITLE
feat(mcp): add design-system context MCP server

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,39 @@
+# Design System MCP Server
+
+This repository now includes an MCP server that exposes the design-system context needed to build UI consistently.
+
+## Run
+
+```bash
+npm run mcp:server
+```
+
+The server communicates over stdio using JSON-RPC messages (one JSON request per line).
+
+## Exposed resources
+
+- `design-system://components/index` – discovered component inventory with story/test/type paths.
+- `design-system://component/<ComponentName>` – component implementation, types, stories, tests, and `core/index.type.tsx` export context.
+- `design-system://tokens/raw` – `css/src/tokens/index.css`.
+- `design-system://tokens/variables` – `css/src/variables/index.css`.
+- `design-system://css/helpers` – utility CSS files and discovered helper class names.
+- `design-system://a11y/guide` – a11y guide and WCAG JSON mapping.
+
+## Exposed tools
+
+- `search_components({ query })`
+- `get_component_context({ componentName })`
+- `get_tokens_context({})`
+- `get_css_helpers_context({})`
+- `get_accessibility_context({})`
+
+## Typical usage
+
+Use this MCP server in an LLM client to fetch:
+
+- component props/types and examples from stories/tests,
+- accessibility guidelines from `a11y-context/`,
+- design-token values and semantic mappings,
+- utility/helper CSS classes for layout and spacing.
+
+This avoids hard-coding assumptions and keeps generated UI aligned with the codebase source of truth.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "build": "npm run build-css && npm run build-js",
     "version": "./scripts/version.sh",
     "prepare": "husky install",
-    "generate-types": "node node_modules/.bin/dts-bundle-generator --config dts.config.js"
+    "generate-types": "node node_modules/.bin/dts-bundle-generator --config dts.config.js",
+    "mcp:server": "node tools/mcp/design-system-mcp-server.js"
   },
   "author": "Innovaccer",
   "license": "MIT",

--- a/tools/mcp/design-system-mcp-server.js
+++ b/tools/mcp/design-system-mcp-server.js
@@ -1,0 +1,527 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const CORE_COMPONENTS_DIR = path.join(ROOT_DIR, 'core', 'components');
+const CORE_INDEX_TYPES = path.join(ROOT_DIR, 'core', 'index.type.tsx');
+const TOKENS_RAW_FILE = path.join(ROOT_DIR, 'css', 'src', 'tokens', 'index.css');
+const TOKENS_VARIABLES_FILE = path.join(ROOT_DIR, 'css', 'src', 'variables', 'index.css');
+const CSS_UTILS_DIR = path.join(ROOT_DIR, 'css', 'src', 'utils');
+const A11Y_README_FILE = path.join(ROOT_DIR, 'a11y-context', 'README.md');
+const A11Y_WCAG_JSON_FILE = path.join(ROOT_DIR, 'a11y-context', 'wcag-as-json.json');
+
+function safeRead(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (_error) {
+    return '';
+  }
+}
+
+function walkDir(dirPath) {
+  const results = [];
+
+  if (!fs.existsSync(dirPath)) {
+    return results;
+  }
+
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+
+  entries.forEach((entry) => {
+    const fullPath = path.join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      results.push(...walkDir(fullPath));
+      return;
+    }
+
+    results.push(fullPath);
+  });
+
+  return results;
+}
+
+function parseCssVariables(cssContent) {
+  const matches = cssContent.match(/--[a-zA-Z0-9-_]+\s*:/g) || [];
+  return Array.from(new Set(matches.map((entry) => entry.replace(':', '').trim()))).sort();
+}
+
+function parseCssClasses(cssContent) {
+  const classMatches = cssContent.match(/\.([a-zA-Z][a-zA-Z0-9_-]*)/g) || [];
+  return Array.from(new Set(classMatches.map((item) => item.replace('.', '')))).sort();
+}
+
+function getComponentNameFromPath(filePath) {
+  const segments = filePath.split(path.sep);
+  const componentsIndex = segments.indexOf('components');
+
+  if (componentsIndex === -1 || componentsIndex + 2 >= segments.length) {
+    return '';
+  }
+
+  return segments[componentsIndex + 2];
+}
+
+function getComponentIndex() {
+  const files = walkDir(CORE_COMPONENTS_DIR);
+  const componentMap = new Map();
+
+  files.forEach((filePath) => {
+    const relativePath = path.relative(ROOT_DIR, filePath);
+    const componentName = getComponentNameFromPath(filePath);
+
+    if (!componentName) {
+      return;
+    }
+
+    if (!componentMap.has(componentName)) {
+      componentMap.set(componentName, {
+        name: componentName,
+        paths: [],
+        stories: [],
+        tests: [],
+        types: [],
+        implementations: [],
+      });
+    }
+
+    const record = componentMap.get(componentName);
+    record.paths.push(relativePath);
+
+    if (relativePath.includes('__stories__')) {
+      record.stories.push(relativePath);
+    }
+
+    if (relativePath.includes('__tests__')) {
+      record.tests.push(relativePath);
+    }
+
+    if (relativePath.endsWith('.type.tsx') || relativePath.endsWith('.types.tsx')) {
+      record.types.push(relativePath);
+    }
+
+    if (
+      relativePath.endsWith('.tsx')
+      && !relativePath.endsWith('index.tsx')
+      && !relativePath.endsWith('.test.tsx')
+      && !relativePath.includes('__stories__')
+    ) {
+      record.implementations.push(relativePath);
+    }
+  });
+
+  return Array.from(componentMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function resolveComponent(componentName) {
+  const components = getComponentIndex();
+  return components.find((component) => component.name.toLowerCase() === componentName.toLowerCase());
+}
+
+function getComponentContext(componentName) {
+  const component = resolveComponent(componentName);
+
+  if (!component) {
+    return {
+      found: false,
+      message: `Component \"${componentName}\" not found.`,
+      availableComponents: getComponentIndex().map((entry) => entry.name),
+    };
+  }
+
+  const fileContents = {};
+  const selectedFiles = [
+    ...component.implementations,
+    ...component.types,
+    ...component.stories,
+    ...component.tests,
+  ].slice(0, 30);
+
+  selectedFiles.forEach((relativePath) => {
+    fileContents[relativePath] = safeRead(path.join(ROOT_DIR, relativePath));
+  });
+
+  return {
+    found: true,
+    component,
+    exportedTypesIndex: safeRead(CORE_INDEX_TYPES),
+    files: fileContents,
+  };
+}
+
+function getTokensContext() {
+  const rawTokens = safeRead(TOKENS_RAW_FILE);
+  const variableTokens = safeRead(TOKENS_VARIABLES_FILE);
+
+  return {
+    rawTokensFile: path.relative(ROOT_DIR, TOKENS_RAW_FILE),
+    variableTokensFile: path.relative(ROOT_DIR, TOKENS_VARIABLES_FILE),
+    rawVariables: parseCssVariables(rawTokens),
+    semanticVariables: parseCssVariables(variableTokens),
+    rawTokens,
+    variableTokens,
+  };
+}
+
+function getCssHelpersContext() {
+  const utilFiles = walkDir(CSS_UTILS_DIR).filter((entry) => entry.endsWith('.css'));
+
+  const utilities = utilFiles.map((filePath) => {
+    const content = safeRead(filePath);
+    return {
+      file: path.relative(ROOT_DIR, filePath),
+      classes: parseCssClasses(content),
+      content,
+    };
+  });
+
+  return {
+    utilities,
+  };
+}
+
+function getA11yContext() {
+  const readme = safeRead(A11Y_README_FILE);
+  const wcagRaw = safeRead(A11Y_WCAG_JSON_FILE);
+
+  let wcag = [];
+  try {
+    wcag = JSON.parse(wcagRaw);
+  } catch (_error) {
+    wcag = [];
+  }
+
+  return {
+    readmeFile: path.relative(ROOT_DIR, A11Y_README_FILE),
+    wcagFile: path.relative(ROOT_DIR, A11Y_WCAG_JSON_FILE),
+    readme,
+    wcag,
+  };
+}
+
+function searchComponents(query) {
+  const normalized = query.toLowerCase().trim();
+  return getComponentIndex().filter((component) => {
+    if (component.name.toLowerCase().includes(normalized)) {
+      return true;
+    }
+
+    return component.paths.some((entry) => entry.toLowerCase().includes(normalized));
+  });
+}
+
+const SERVER_INFO = {
+  name: 'design-system-context-server',
+  version: '0.1.0',
+};
+
+function listResources() {
+  return [
+    {
+      uri: 'design-system://components/index',
+      name: 'Component Index',
+      description: 'All discoverable components with stories/tests/types paths',
+      mimeType: 'application/json',
+    },
+    {
+      uri: 'design-system://tokens/raw',
+      name: 'Raw Design Tokens',
+      description: 'Source raw token CSS definitions',
+      mimeType: 'text/css',
+    },
+    {
+      uri: 'design-system://tokens/variables',
+      name: 'Mapped Design Tokens',
+      description: 'Semantic token variable mappings used by components',
+      mimeType: 'text/css',
+    },
+    {
+      uri: 'design-system://css/helpers',
+      name: 'CSS Utility Helpers',
+      description: 'Utility class files and discovered helper classes',
+      mimeType: 'application/json',
+    },
+    {
+      uri: 'design-system://a11y/guide',
+      name: 'Accessibility Guide',
+      description: 'Accessibility guidance and WCAG mapping',
+      mimeType: 'application/json',
+    },
+  ];
+}
+
+function resourceByUri(uri) {
+  if (uri === 'design-system://components/index') {
+    return {
+      mimeType: 'application/json',
+      text: JSON.stringify(getComponentIndex(), null, 2),
+    };
+  }
+
+  if (uri === 'design-system://tokens/raw') {
+    return {
+      mimeType: 'text/css',
+      text: safeRead(TOKENS_RAW_FILE),
+    };
+  }
+
+  if (uri === 'design-system://tokens/variables') {
+    return {
+      mimeType: 'text/css',
+      text: safeRead(TOKENS_VARIABLES_FILE),
+    };
+  }
+
+  if (uri === 'design-system://css/helpers') {
+    return {
+      mimeType: 'application/json',
+      text: JSON.stringify(getCssHelpersContext(), null, 2),
+    };
+  }
+
+  if (uri === 'design-system://a11y/guide') {
+    return {
+      mimeType: 'application/json',
+      text: JSON.stringify(getA11yContext(), null, 2),
+    };
+  }
+
+  if (uri.startsWith('design-system://component/')) {
+    const componentName = uri.replace('design-system://component/', '');
+    return {
+      mimeType: 'application/json',
+      text: JSON.stringify(getComponentContext(componentName), null, 2),
+    };
+  }
+
+  return null;
+}
+
+function listTools() {
+  return [
+    {
+      name: 'search_components',
+      description: 'Search components by name or path.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string' },
+        },
+        required: ['query'],
+      },
+    },
+    {
+      name: 'get_component_context',
+      description:
+        'Get implementation, types, stories, tests, and export type index for a specific component.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          componentName: { type: 'string' },
+        },
+        required: ['componentName'],
+      },
+    },
+    {
+      name: 'get_tokens_context',
+      description: 'Get raw and semantic design token data and extracted CSS variables.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'get_css_helpers_context',
+      description: 'Get CSS utility files and discovered helper classes.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'get_accessibility_context',
+      description: 'Get accessibility guidance and WCAG mapping data.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  ];
+}
+
+function toolResponse(result) {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+  };
+}
+
+function makeError(id, code, message) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    error: {
+      code,
+      message,
+    },
+  };
+}
+
+function handleRequest(payload) {
+  const { id, method, params = {} } = payload;
+
+  if (method === 'initialize') {
+    return {
+      jsonrpc: '2.0',
+      id,
+      result: {
+        protocolVersion: '2024-11-05',
+        serverInfo: SERVER_INFO,
+        capabilities: {
+          resources: {
+            listChanged: false,
+          },
+          tools: {
+            listChanged: false,
+          },
+        },
+      },
+    };
+  }
+
+  if (method === 'notifications/initialized' || method === 'initialized') {
+    return null;
+  }
+
+  if (method === 'resources/list') {
+    return {
+      jsonrpc: '2.0',
+      id,
+      result: {
+        resources: listResources(),
+      },
+    };
+  }
+
+  if (method === 'resources/read') {
+    const resource = resourceByUri(params.uri || '');
+
+    if (!resource) {
+      return makeError(id, -32002, `Unknown resource URI: ${params.uri || '<empty>'}`);
+    }
+
+    return {
+      jsonrpc: '2.0',
+      id,
+      result: {
+        contents: [
+          {
+            uri: params.uri,
+            mimeType: resource.mimeType,
+            text: resource.text,
+          },
+        ],
+      },
+    };
+  }
+
+  if (method === 'tools/list') {
+    return {
+      jsonrpc: '2.0',
+      id,
+      result: {
+        tools: listTools(),
+      },
+    };
+  }
+
+  if (method === 'tools/call') {
+    const { name, arguments: args = {} } = params;
+
+    if (name === 'search_components') {
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: toolResponse(searchComponents(args.query || '')),
+      };
+    }
+
+    if (name === 'get_component_context') {
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: toolResponse(getComponentContext(args.componentName || '')),
+      };
+    }
+
+    if (name === 'get_tokens_context') {
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: toolResponse(getTokensContext()),
+      };
+    }
+
+    if (name === 'get_css_helpers_context') {
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: toolResponse(getCssHelpersContext()),
+      };
+    }
+
+    if (name === 'get_accessibility_context') {
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: toolResponse(getA11yContext()),
+      };
+    }
+
+    return makeError(id, -32003, `Unknown tool: ${name}`);
+  }
+
+  return makeError(id, -32601, `Method not found: ${method}`);
+}
+
+function startServer() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+
+  rl.on('line', (line) => {
+    const trimmed = line.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    let request;
+    try {
+      request = JSON.parse(trimmed);
+    } catch (_error) {
+      const response = makeError(null, -32700, 'Invalid JSON in request payload.');
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+      return;
+    }
+
+    const response = handleRequest(request);
+
+    if (response) {
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+  });
+}
+
+startServer();


### PR DESCRIPTION
### Motivation
- Provide a lightweight, repository-aware MCP server that exposes component implementations, stories, tests, types, tokens, accessibility guidance and CSS helpers to tooling and LLM-based clients. 
- Enable automated retrieval of source-of-truth UI information (props, examples, tokens, helper classes, a11y) without adding heavy dependencies. 

### Description
- Added a new MCP server at `tools/mcp/design-system-mcp-server.js` that communicates over stdio JSON-RPC and indexes `core/components`, token files, CSS utilities and a11y docs. 
- Exposed resource URIs including `design-system://components/index`, `design-system://component/<ComponentName>`, `design-system://tokens/raw`, `design-system://tokens/variables`, `design-system://css/helpers`, and `design-system://a11y/guide`. 
- Exposed tools for programmatic access: `search_components`, `get_component_context`, `get_tokens_context`, `get_css_helpers_context`, and `get_accessibility_context`. 
- Added `npm run mcp:server` script and usage documentation at `docs/MCP_SERVER.md`. 

### Testing
- Ran `npm run lint:check` which completed successfully. 
- Ran `npm run prettier:check` which failed with the repository Prettier invocation error: "No parser and no file path given, couldn't infer a parser." 
- Ran `npm run lint:types` which failed due to TypeScript type errors stemming from newer type definitions in `node_modules` versus the repo TypeScript version. 
- Started a smoke test against the MCP server (`node tools/mcp/design-system-mcp-server.js` with JSON-RPC initialize/resources calls) which returned expected capabilities and resource listings. 
- Initiated `npm test -- --runInBand` and observed many passing test suites before stopping due to runtime constraints; the test run produced numerous passing suites and some runtime warnings but was not run to completion in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a993ddcd68832f88dd30590d3578fc)