### PR TITLE
feat(calendarcolors): update colors and strokes for WCAG 2.2 AA compliance

### DIFF
--- a/core/components/organisms/calendar/Calendar.tsx
+++ b/core/components/organisms/calendar/Calendar.tsx
@@ -705,7 +705,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             [styles['Calendar-value--disabled']]: disabled,
             [styles['Calendar-yearValue']]: true,
             [styles[`Calendar-yearValue--${size}`]]: size,
-            [styles['Calendar-value--currDateMonthYear']]: isCurrentYear(),
+            [styles['Calendar-value--currDateMonthYear']]: isCurrentYear() && !active,
           });
 
           const textClass = classNames({
@@ -717,7 +717,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             inverse: !active && !isCurrentYear() && !disabled,
             white: active,
             'primary-lighter': isCurrentYear() && disabled,
-            primary: isCurrentYear(),
+            'primary-dark': isCurrentYear() && !active && !disabled,
             'inverse-lightest': disabled,
           }) as TextColor;
 
@@ -768,14 +768,14 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             [styles['Calendar-value--disabled']]: disabled,
             [styles['Calendar-monthValue']]: true,
             [styles[`Calendar-monthValue--${size}`]]: size,
-            [styles['Calendar-value--currDateMonthYear']]: isCurrentMonth(),
+            [styles['Calendar-value--currDateMonthYear']]: isCurrentMonth() && !active,
           });
 
           const getTextColor = classNames({
             inverse: !active && !isCurrentMonth() && !disabled,
             white: active,
             'primary-lighter': isCurrentMonth() && disabled,
-            primary: isCurrentMonth(),
+            'primary-dark': isCurrentMonth() && !active && !disabled,
             'inverse-lightest': disabled,
           }) as TextColor;
 
@@ -1079,14 +1079,14 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
               [styles['Calendar-value--disabled']]: disabled,
               [styles['Calendar-dateValue']]: true,
               [styles[`Calendar-dateValue--${size}`]]: size,
-              [styles['Calendar-value--currDateMonthYear']]: today(),
+              [styles['Calendar-value--currDateMonthYear']]: today() && !active && !activeDate,
               [styles['Calendar-value--currDate']]: today() && !active && !activeDate,
             });
 
             const getTextColor = classNames({
               inverse: !active && !today() && !disabled && !activeDate,
               white: active || activeDate,
-              primary: today(),
+              'primary-dark': today() && !active && !activeDate,
             }) as TextColor;
 
             return (
@@ -1111,7 +1111,13 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                 {((dummy && date > 0 && index === monthsInView - 1) || (dummy && date <= 0 && index === 0)) && (
                   <>
                     <Text
-                      appearance={active || activeDate ? 'white' : today() ? 'link' : 'subtle'}
+                      color={
+                        (active || activeDate
+                          ? 'inverse-light'
+                          : today()
+                          ? 'primary-dark'
+                          : 'inverse-lighter') as TextColor
+                      }
                       size={size === 'small' ? 'small' : 'regular'}
                       data-test="DesignSystem-Calendar--dateValue"
                       className={valueClass}

--- a/core/components/organisms/calendar/__tests__/Calendar.test.tsx
+++ b/core/components/organisms/calendar/__tests__/Calendar.test.tsx
@@ -278,9 +278,9 @@ describe('text color for different states', () => {
     expect(getAllByTestId('DesignSystem-Text')[3]).toHaveClass('color-inverse-lightest');
   });
 
-  it('should have the text color as primary for current date ', () => {
+  it('should have the text color as primary-dark for current date ', () => {
     const { getAllByTestId } = render(<Calendar />);
-    expect(getAllByTestId('DesignSystem-Calendar--dateValue')[24]).toHaveClass('color-primary');
+    expect(getAllByTestId('DesignSystem-Calendar--dateValue')[24]).toHaveClass('color-primary-dark');
   });
 
   it('should have the text color as primary-lighter when the state is disabled but with current year', () => {

--- a/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
+++ b/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
@@ -514,7 +514,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -525,7 +525,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -536,7 +536,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -547,7 +547,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -562,7 +562,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -573,7 +573,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -584,7 +584,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -595,7 +595,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -606,7 +606,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -617,7 +617,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -628,7 +628,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -1158,7 +1158,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -1169,7 +1169,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -1180,7 +1180,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -1191,7 +1191,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -1206,7 +1206,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -1217,7 +1217,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -1228,7 +1228,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -1239,7 +1239,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -1250,7 +1250,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -1261,7 +1261,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -1272,7 +1272,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -1802,7 +1802,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -1813,7 +1813,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -1824,7 +1824,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -1835,7 +1835,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -1850,7 +1850,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -1861,7 +1861,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -1872,7 +1872,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -1883,7 +1883,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -1894,7 +1894,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -1905,7 +1905,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -1916,7 +1916,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -2447,7 +2447,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -2458,7 +2458,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -2469,7 +2469,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -2480,7 +2480,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -2495,7 +2495,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -2506,7 +2506,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -2517,7 +2517,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -2528,7 +2528,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -2539,7 +2539,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -2550,7 +2550,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -2561,7 +2561,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -2733,7 +2733,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -2744,7 +2744,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -3112,7 +3112,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -3123,7 +3123,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -3138,7 +3138,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -3149,7 +3149,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -3160,7 +3160,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -3171,7 +3171,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -3182,7 +3182,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -3193,7 +3193,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -3204,7 +3204,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -3376,7 +3376,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   24
@@ -3387,7 +3387,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   25
@@ -3398,7 +3398,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   26
@@ -3409,7 +3409,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -3420,7 +3420,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -3431,7 +3431,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -3803,7 +3803,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -3814,7 +3814,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -3825,7 +3825,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -3836,7 +3836,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -3847,7 +3847,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -4019,7 +4019,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -4387,7 +4387,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -4398,7 +4398,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -4409,7 +4409,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -4424,7 +4424,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -4435,7 +4435,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -4446,7 +4446,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -4457,7 +4457,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -4468,7 +4468,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -4479,7 +4479,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -4490,7 +4490,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -5019,7 +5019,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -5030,7 +5030,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -5041,7 +5041,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -5052,7 +5052,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -5067,7 +5067,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -5078,7 +5078,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -5089,7 +5089,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -5100,7 +5100,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -5111,7 +5111,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -5122,7 +5122,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -5133,7 +5133,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -5305,7 +5305,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -5316,7 +5316,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -5327,7 +5327,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -5695,7 +5695,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -5710,7 +5710,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -5721,7 +5721,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -5732,7 +5732,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -5743,7 +5743,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -5754,7 +5754,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -5765,7 +5765,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -5776,7 +5776,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -5948,7 +5948,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   25
@@ -5959,7 +5959,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   26
@@ -5970,7 +5970,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -5981,7 +5981,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -5992,7 +5992,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -6364,7 +6364,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -6375,7 +6375,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -6386,7 +6386,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -6397,7 +6397,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -6408,7 +6408,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -6419,7 +6419,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -6591,7 +6591,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   26
@@ -6602,7 +6602,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -6613,7 +6613,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -6624,7 +6624,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -6996,7 +6996,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -7007,7 +7007,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -7018,7 +7018,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -7029,7 +7029,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -7040,7 +7040,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -7051,7 +7051,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -7062,7 +7062,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -7591,7 +7591,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -7602,7 +7602,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -7613,7 +7613,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -7624,7 +7624,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -7639,7 +7639,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -7650,7 +7650,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -7661,7 +7661,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -7672,7 +7672,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -7683,7 +7683,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -7694,7 +7694,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -7705,7 +7705,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -8715,7 +8715,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -8726,7 +8726,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -10232,7 +10232,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -10243,7 +10243,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -10254,7 +10254,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -10265,7 +10265,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -10276,7 +10276,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -10287,7 +10287,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -10816,7 +10816,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -10827,7 +10827,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -10838,7 +10838,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -10849,7 +10849,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -10864,7 +10864,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -10875,7 +10875,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -10886,7 +10886,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -10897,7 +10897,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -10908,7 +10908,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -10919,7 +10919,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -10930,7 +10930,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -11323,7 +11323,7 @@ exports[`Calendar component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
+                class="Text Text--regular color-primary-dark Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2021
@@ -11925,7 +11925,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -11936,7 +11936,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -11947,7 +11947,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -11958,7 +11958,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -11973,7 +11973,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -11984,7 +11984,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -11995,7 +11995,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -12006,7 +12006,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -12017,7 +12017,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -12028,7 +12028,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -12039,7 +12039,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -13049,7 +13049,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -13060,7 +13060,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -14566,7 +14566,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -14577,7 +14577,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -14588,7 +14588,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -14599,7 +14599,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -14610,7 +14610,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -14621,7 +14621,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -15150,7 +15150,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -15161,7 +15161,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -15172,7 +15172,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -15183,7 +15183,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -15198,7 +15198,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -15209,7 +15209,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -15220,7 +15220,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -15231,7 +15231,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -15242,7 +15242,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -15253,7 +15253,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -15264,7 +15264,7 @@ exports[`Calendar component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -15657,7 +15657,7 @@ exports[`Calendar component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--small color-primary Calendar-value--currDate Calendar-text"
+                class="Text Text--small color-primary-dark Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2021

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -518,7 +518,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -529,7 +529,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -540,7 +540,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -551,7 +551,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -566,7 +566,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -577,7 +577,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -588,7 +588,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -599,7 +599,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -610,7 +610,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -621,7 +621,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -632,7 +632,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11
@@ -1191,7 +1191,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -1202,7 +1202,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -1213,7 +1213,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -1224,7 +1224,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -1239,7 +1239,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -1250,7 +1250,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -1261,7 +1261,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -1272,7 +1272,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -1283,7 +1283,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -1294,7 +1294,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -1305,7 +1305,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11
@@ -1864,7 +1864,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -1875,7 +1875,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -1886,7 +1886,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -1897,7 +1897,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -1912,7 +1912,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -1923,7 +1923,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -1934,7 +1934,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -1945,7 +1945,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -1956,7 +1956,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -1967,7 +1967,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -1978,7 +1978,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11
@@ -2536,7 +2536,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -2547,7 +2547,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -2558,7 +2558,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -2569,7 +2569,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -2584,7 +2584,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -2595,7 +2595,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -2606,7 +2606,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -2617,7 +2617,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -2628,7 +2628,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -2639,7 +2639,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -2650,7 +2650,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11
@@ -3208,7 +3208,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -3219,7 +3219,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -3230,7 +3230,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -3241,7 +3241,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -3256,7 +3256,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -3267,7 +3267,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -3278,7 +3278,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -3289,7 +3289,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -3300,7 +3300,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -3311,7 +3311,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -3322,7 +3322,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11
@@ -3880,7 +3880,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -3891,7 +3891,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -3902,7 +3902,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -3913,7 +3913,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -3928,7 +3928,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -3939,7 +3939,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -3950,7 +3950,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -3961,7 +3961,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -3972,7 +3972,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -3983,7 +3983,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -3994,7 +3994,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11
@@ -4445,7 +4445,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   data-test="DesignSystem-Calendar--yearValue"
                 >
                   <span
-                    class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
+                    class="Text Text--regular color-primary-dark Calendar-value--currDate Calendar-text"
                     data-test="DesignSystem-Text"
                   >
                     2021
@@ -5076,7 +5076,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       1
@@ -5087,7 +5087,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       2
@@ -5098,7 +5098,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       3
@@ -5109,7 +5109,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       4
@@ -5124,7 +5124,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       5
@@ -5135,7 +5135,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       6
@@ -5146,7 +5146,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       7
@@ -5157,7 +5157,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       8
@@ -5168,7 +5168,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       9
@@ -5179,7 +5179,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       10
@@ -5190,7 +5190,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                     data-test="designSystem-Calendar-WrapperClass"
                   >
                     <span
-                      class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                      class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                       data-test="DesignSystem-Calendar--dateValue"
                     >
                       11

--- a/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -152,7 +152,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -509,7 +509,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -520,7 +520,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -531,7 +531,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -546,7 +546,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -557,7 +557,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -568,7 +568,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -579,7 +579,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -590,7 +590,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -601,7 +601,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -612,7 +612,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -768,7 +768,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -779,7 +779,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -1136,7 +1136,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -1147,7 +1147,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -1158,7 +1158,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -1173,7 +1173,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -1184,7 +1184,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -1195,7 +1195,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -1206,7 +1206,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -1217,7 +1217,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -1228,7 +1228,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -1239,7 +1239,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -1396,7 +1396,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -1407,7 +1407,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -1764,7 +1764,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -1775,7 +1775,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -1786,7 +1786,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -1801,7 +1801,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -1812,7 +1812,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -1823,7 +1823,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -1834,7 +1834,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -1845,7 +1845,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -1856,7 +1856,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -1867,7 +1867,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -2024,7 +2024,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -2035,7 +2035,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -2392,7 +2392,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -2403,7 +2403,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -2414,7 +2414,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -2429,7 +2429,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -2440,7 +2440,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -2451,7 +2451,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -2462,7 +2462,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -2473,7 +2473,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -2484,7 +2484,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -2495,7 +2495,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -2651,7 +2651,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -2662,7 +2662,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -2673,7 +2673,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -2684,7 +2684,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -3041,7 +3041,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -3056,7 +3056,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -3067,7 +3067,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -3078,7 +3078,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -3089,7 +3089,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -3100,7 +3100,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -3111,7 +3111,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -3122,7 +3122,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -3278,7 +3278,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -3635,7 +3635,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -3646,7 +3646,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -3657,7 +3657,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -3668,7 +3668,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -3683,7 +3683,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -3694,7 +3694,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -3705,7 +3705,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -3716,7 +3716,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -3727,7 +3727,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -3738,7 +3738,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -3749,7 +3749,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -3905,7 +3905,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -3916,7 +3916,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -3927,7 +3927,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -4284,7 +4284,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -4295,7 +4295,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -4310,7 +4310,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -4321,7 +4321,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -4332,7 +4332,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -4343,7 +4343,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -4354,7 +4354,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -4365,7 +4365,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -4376,7 +4376,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -4532,7 +4532,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -4543,7 +4543,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -4900,7 +4900,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -4911,7 +4911,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -4922,7 +4922,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -4937,7 +4937,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -4948,7 +4948,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -4959,7 +4959,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -4970,7 +4970,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -4981,7 +4981,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -4992,7 +4992,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -5003,7 +5003,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -5159,7 +5159,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -5170,7 +5170,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -5181,7 +5181,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -5192,7 +5192,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -5203,7 +5203,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -5564,7 +5564,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -5575,7 +5575,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -5586,7 +5586,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -5597,7 +5597,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -5608,7 +5608,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -5619,7 +5619,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -5630,7 +5630,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -6132,7 +6132,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -6143,7 +6143,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -6154,7 +6154,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -6165,7 +6165,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -6176,7 +6176,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -6191,7 +6191,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -6202,7 +6202,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -6213,7 +6213,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -6224,7 +6224,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -6235,7 +6235,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -6246,7 +6246,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -6257,7 +6257,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   12
@@ -6413,7 +6413,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   26
@@ -6424,7 +6424,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -6435,7 +6435,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -6446,7 +6446,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -6457,7 +6457,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -6468,7 +6468,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -6829,7 +6829,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -6840,7 +6840,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -6851,7 +6851,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -6862,7 +6862,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -6873,7 +6873,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -6884,7 +6884,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -7040,7 +7040,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -7051,7 +7051,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -7408,7 +7408,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -7419,7 +7419,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -7430,7 +7430,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -7445,7 +7445,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -7456,7 +7456,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -7467,7 +7467,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -7478,7 +7478,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -7489,7 +7489,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -7500,7 +7500,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -7511,7 +7511,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -7667,7 +7667,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -7678,7 +7678,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -8035,7 +8035,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -8046,7 +8046,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -8057,7 +8057,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -8072,7 +8072,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -8083,7 +8083,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -8094,7 +8094,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -8105,7 +8105,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -8116,7 +8116,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -8127,7 +8127,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -8138,7 +8138,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -8294,7 +8294,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -8305,7 +8305,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -8662,7 +8662,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -8673,7 +8673,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -8684,7 +8684,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -8699,7 +8699,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -8710,7 +8710,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -8721,7 +8721,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -8732,7 +8732,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -8743,7 +8743,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -8754,7 +8754,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -8765,7 +8765,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -8921,7 +8921,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -8932,7 +8932,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -9289,7 +9289,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -9300,7 +9300,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -9311,7 +9311,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -9326,7 +9326,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -9337,7 +9337,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -9348,7 +9348,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -9359,7 +9359,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -9370,7 +9370,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -9381,7 +9381,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -9392,7 +9392,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -9548,7 +9548,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -9559,7 +9559,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -9916,7 +9916,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -9927,7 +9927,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -9938,7 +9938,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -9953,7 +9953,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -9964,7 +9964,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -9975,7 +9975,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -9986,7 +9986,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -9997,7 +9997,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -10008,7 +10008,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -10019,7 +10019,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -10175,7 +10175,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -10186,7 +10186,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -10543,7 +10543,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -10554,7 +10554,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -10565,7 +10565,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -10580,7 +10580,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -10591,7 +10591,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -10602,7 +10602,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -10613,7 +10613,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -10624,7 +10624,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -10635,7 +10635,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -10646,7 +10646,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -10802,7 +10802,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -10813,7 +10813,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -11170,7 +11170,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -11181,7 +11181,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -11192,7 +11192,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -11207,7 +11207,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -11218,7 +11218,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -11229,7 +11229,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -11240,7 +11240,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -11251,7 +11251,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -11262,7 +11262,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -11273,7 +11273,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -11429,7 +11429,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -11440,7 +11440,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -11797,7 +11797,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -11808,7 +11808,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -11819,7 +11819,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -11834,7 +11834,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -11845,7 +11845,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -11856,7 +11856,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -11867,7 +11867,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -11878,7 +11878,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -11889,7 +11889,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -11900,7 +11900,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -12056,7 +12056,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -12067,7 +12067,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -12424,7 +12424,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -12435,7 +12435,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -12446,7 +12446,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -12461,7 +12461,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -12472,7 +12472,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -12483,7 +12483,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -12494,7 +12494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -12505,7 +12505,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -12516,7 +12516,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -12527,7 +12527,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -12683,7 +12683,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -12694,7 +12694,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -13051,7 +13051,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -13062,7 +13062,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -13073,7 +13073,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -13088,7 +13088,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -13099,7 +13099,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -13110,7 +13110,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -13121,7 +13121,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -13132,7 +13132,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -13143,7 +13143,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -13154,7 +13154,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -13310,7 +13310,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -13321,7 +13321,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -13678,7 +13678,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -13689,7 +13689,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -13700,7 +13700,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -13715,7 +13715,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -13726,7 +13726,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -13737,7 +13737,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -13748,7 +13748,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -13759,7 +13759,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -13770,7 +13770,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -13781,7 +13781,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -13937,7 +13937,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -13948,7 +13948,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -14305,7 +14305,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -14316,7 +14316,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -14327,7 +14327,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -14342,7 +14342,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -14353,7 +14353,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -14364,7 +14364,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -14375,7 +14375,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -14386,7 +14386,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -14397,7 +14397,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -14408,7 +14408,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -14564,7 +14564,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -14575,7 +14575,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -14932,7 +14932,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -14943,7 +14943,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -14954,7 +14954,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -14969,7 +14969,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -14980,7 +14980,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -14991,7 +14991,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -15002,7 +15002,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -15013,7 +15013,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -15024,7 +15024,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -15035,7 +15035,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -15191,7 +15191,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -15202,7 +15202,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -15559,7 +15559,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -15570,7 +15570,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -15581,7 +15581,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -15596,7 +15596,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -15607,7 +15607,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -15618,7 +15618,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -15629,7 +15629,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -15640,7 +15640,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -15651,7 +15651,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -15662,7 +15662,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -15818,7 +15818,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -15829,7 +15829,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -16186,7 +16186,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -16197,7 +16197,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -16208,7 +16208,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -16223,7 +16223,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -16234,7 +16234,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -16245,7 +16245,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -16256,7 +16256,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -16267,7 +16267,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -16278,7 +16278,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -16289,7 +16289,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -16445,7 +16445,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -16456,7 +16456,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -16813,7 +16813,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -16824,7 +16824,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -16835,7 +16835,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -16850,7 +16850,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -16861,7 +16861,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -16872,7 +16872,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -16883,7 +16883,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -16894,7 +16894,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -16905,7 +16905,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -16916,7 +16916,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -17072,7 +17072,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -17083,7 +17083,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -17440,7 +17440,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -17451,7 +17451,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -17462,7 +17462,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -17477,7 +17477,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -17488,7 +17488,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -17499,7 +17499,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -17510,7 +17510,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -17521,7 +17521,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -17532,7 +17532,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -17543,7 +17543,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -17699,7 +17699,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -17710,7 +17710,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -18067,7 +18067,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -18078,7 +18078,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -18089,7 +18089,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -18104,7 +18104,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -18115,7 +18115,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -18126,7 +18126,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -18137,7 +18137,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -18148,7 +18148,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -18159,7 +18159,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -18170,7 +18170,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -18326,7 +18326,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -18337,7 +18337,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -18694,7 +18694,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -18705,7 +18705,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -18716,7 +18716,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -18731,7 +18731,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -18742,7 +18742,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -18753,7 +18753,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -18764,7 +18764,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -18775,7 +18775,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -18786,7 +18786,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -18797,7 +18797,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -18953,7 +18953,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -18964,7 +18964,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -19321,7 +19321,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -19332,7 +19332,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -19343,7 +19343,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -19358,7 +19358,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -19369,7 +19369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -19380,7 +19380,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -19391,7 +19391,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -19402,7 +19402,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -19413,7 +19413,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -19424,7 +19424,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -19580,7 +19580,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -19591,7 +19591,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -19948,7 +19948,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -19959,7 +19959,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -19970,7 +19970,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -19985,7 +19985,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -19996,7 +19996,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -20007,7 +20007,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -20018,7 +20018,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -20029,7 +20029,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -20040,7 +20040,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -20051,7 +20051,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -20207,7 +20207,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -20218,7 +20218,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -20575,7 +20575,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -20586,7 +20586,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -20597,7 +20597,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -20612,7 +20612,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -20623,7 +20623,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -20634,7 +20634,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -20645,7 +20645,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -20656,7 +20656,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -20667,7 +20667,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -20678,7 +20678,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -20834,7 +20834,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -20845,7 +20845,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -21202,7 +21202,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -21213,7 +21213,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -21224,7 +21224,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -21239,7 +21239,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -21250,7 +21250,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -21261,7 +21261,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -21272,7 +21272,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -21283,7 +21283,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -21294,7 +21294,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -21305,7 +21305,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -21461,7 +21461,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -21472,7 +21472,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -21829,7 +21829,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -21840,7 +21840,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -21851,7 +21851,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -21866,7 +21866,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -21877,7 +21877,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -21888,7 +21888,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -21899,7 +21899,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -21910,7 +21910,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -21921,7 +21921,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -21932,7 +21932,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -22088,7 +22088,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -22099,7 +22099,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -22456,7 +22456,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -22467,7 +22467,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -22478,7 +22478,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -22493,7 +22493,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -22504,7 +22504,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -22515,7 +22515,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -22526,7 +22526,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -22537,7 +22537,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -22548,7 +22548,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -22559,7 +22559,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -22715,7 +22715,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -22726,7 +22726,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -23083,7 +23083,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -23094,7 +23094,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -23105,7 +23105,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -23120,7 +23120,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -23131,7 +23131,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -23142,7 +23142,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -23153,7 +23153,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -23164,7 +23164,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -23175,7 +23175,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -23186,7 +23186,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -23342,7 +23342,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -23353,7 +23353,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -23710,7 +23710,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -23721,7 +23721,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -23732,7 +23732,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -23747,7 +23747,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -23758,7 +23758,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -23769,7 +23769,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -23780,7 +23780,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -23791,7 +23791,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -23802,7 +23802,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -23813,7 +23813,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -23969,7 +23969,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -23980,7 +23980,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -24337,7 +24337,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -24348,7 +24348,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -24359,7 +24359,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -24374,7 +24374,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -24385,7 +24385,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -24396,7 +24396,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -24407,7 +24407,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -24418,7 +24418,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -24429,7 +24429,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -24440,7 +24440,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -24596,7 +24596,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -24607,7 +24607,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -24964,7 +24964,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -24975,7 +24975,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -24986,7 +24986,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -25001,7 +25001,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -25012,7 +25012,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -25023,7 +25023,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -25034,7 +25034,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -25045,7 +25045,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -25056,7 +25056,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -25067,7 +25067,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -25223,7 +25223,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -25234,7 +25234,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -25591,7 +25591,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -25602,7 +25602,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -25613,7 +25613,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -25628,7 +25628,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -25639,7 +25639,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -25650,7 +25650,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -25661,7 +25661,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -25672,7 +25672,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -25683,7 +25683,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -25694,7 +25694,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -25850,7 +25850,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -25861,7 +25861,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -26218,7 +26218,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -26229,7 +26229,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -26240,7 +26240,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -26255,7 +26255,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -26266,7 +26266,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -26277,7 +26277,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -26288,7 +26288,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -26299,7 +26299,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -26310,7 +26310,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -26321,7 +26321,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -26477,7 +26477,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -26488,7 +26488,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -26845,7 +26845,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -26856,7 +26856,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -26867,7 +26867,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -26882,7 +26882,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -26893,7 +26893,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -26904,7 +26904,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -26915,7 +26915,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -26926,7 +26926,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -26937,7 +26937,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -26948,7 +26948,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -27104,7 +27104,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -27115,7 +27115,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -27472,7 +27472,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -27483,7 +27483,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -27494,7 +27494,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -27509,7 +27509,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -27520,7 +27520,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -27531,7 +27531,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -27542,7 +27542,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -27553,7 +27553,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -27564,7 +27564,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -27575,7 +27575,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -27731,7 +27731,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -27742,7 +27742,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -28099,7 +28099,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -28110,7 +28110,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -28121,7 +28121,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -28136,7 +28136,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -28147,7 +28147,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -28158,7 +28158,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -28169,7 +28169,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -28180,7 +28180,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -28191,7 +28191,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -28202,7 +28202,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -28358,7 +28358,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -28369,7 +28369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -28726,7 +28726,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -28737,7 +28737,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -28748,7 +28748,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -28763,7 +28763,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -28774,7 +28774,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -28785,7 +28785,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -28796,7 +28796,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -28807,7 +28807,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -28818,7 +28818,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -28829,7 +28829,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -28985,7 +28985,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -28996,7 +28996,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -29353,7 +29353,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -29364,7 +29364,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -29375,7 +29375,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -29390,7 +29390,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -29401,7 +29401,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -29412,7 +29412,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -29423,7 +29423,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -29434,7 +29434,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -29445,7 +29445,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -29456,7 +29456,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -29612,7 +29612,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -29947,7 +29947,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -29958,7 +29958,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -29969,7 +29969,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -29980,7 +29980,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -29991,7 +29991,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -30002,7 +30002,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -30017,7 +30017,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -30028,7 +30028,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -30039,7 +30039,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -30050,7 +30050,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -30061,7 +30061,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -30072,7 +30072,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   12
@@ -30083,7 +30083,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   13
@@ -30219,7 +30219,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -31050,7 +31050,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -31061,7 +31061,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -31072,7 +31072,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -31208,7 +31208,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -32504,7 +32504,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -32660,7 +32660,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -33028,7 +33028,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -33039,7 +33039,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -33050,7 +33050,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -33065,7 +33065,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -33076,7 +33076,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -33087,7 +33087,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -33098,7 +33098,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -33109,7 +33109,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -33120,7 +33120,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -33131,7 +33131,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -33267,7 +33267,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -34120,7 +34120,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -34256,7 +34256,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -35589,7 +35589,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -35600,7 +35600,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -35611,7 +35611,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -35622,7 +35622,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -35633,7 +35633,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -35789,7 +35789,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -35800,7 +35800,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -35811,7 +35811,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -35822,7 +35822,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -36179,7 +36179,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -36194,7 +36194,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -36205,7 +36205,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -36216,7 +36216,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -36227,7 +36227,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -36238,7 +36238,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -36249,7 +36249,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -36260,7 +36260,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -36396,7 +36396,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -36407,7 +36407,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -36418,7 +36418,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -36429,7 +36429,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -37286,7 +37286,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -37297,7 +37297,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -37308,7 +37308,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -37319,7 +37319,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -37330,7 +37330,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -37466,7 +37466,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -37477,7 +37477,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -37488,7 +37488,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -37499,7 +37499,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -38821,7 +38821,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -38832,7 +38832,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -38843,7 +38843,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -38999,7 +38999,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -39010,7 +39010,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -39367,7 +39367,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -39378,7 +39378,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -39389,7 +39389,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -39404,7 +39404,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -39415,7 +39415,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -39426,7 +39426,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -39437,7 +39437,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -39448,7 +39448,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -39459,7 +39459,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -39470,7 +39470,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -39892,7 +39892,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
+                class="Text Text--regular color-primary-dark Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2024
@@ -40513,7 +40513,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -40524,7 +40524,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -40881,7 +40881,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -40892,7 +40892,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -40903,7 +40903,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -40918,7 +40918,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -40929,7 +40929,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -40940,7 +40940,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -40951,7 +40951,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -40962,7 +40962,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -40973,7 +40973,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -40984,7 +40984,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -41406,7 +41406,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--small color-primary Calendar-value--currDate Calendar-text"
+                class="Text Text--small color-primary-dark Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2024
@@ -42027,7 +42027,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -42038,7 +42038,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -42395,7 +42395,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -42406,7 +42406,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -42417,7 +42417,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -42432,7 +42432,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -42443,7 +42443,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -42454,7 +42454,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -42465,7 +42465,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -42476,7 +42476,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -42487,7 +42487,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -42498,7 +42498,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -42920,7 +42920,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--regular color-primary Calendar-value--currDate Calendar-text"
+                class="Text Text--regular color-primary-dark Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2024
@@ -43234,7 +43234,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -43245,7 +43245,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -44365,7 +44365,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -44376,7 +44376,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -45496,7 +45496,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -45507,7 +45507,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -46505,7 +46505,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -46516,7 +46516,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -46873,7 +46873,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -46884,7 +46884,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -46895,7 +46895,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -46910,7 +46910,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -46921,7 +46921,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -46932,7 +46932,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -46943,7 +46943,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -46954,7 +46954,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -46965,7 +46965,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -46976,7 +46976,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -47398,7 +47398,7 @@ exports[`DateRangePicker component
               data-test="DesignSystem-Calendar--yearValue"
             >
               <span
-                class="Text Text--small color-primary Calendar-value--currDate Calendar-text"
+                class="Text Text--small color-primary-dark Calendar-value--currDate Calendar-text"
                 data-test="DesignSystem-Text"
               >
                 2024
@@ -47712,7 +47712,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -47723,7 +47723,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -48843,7 +48843,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -48854,7 +48854,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -49974,7 +49974,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -49985,7 +49985,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--small Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
+                  class="Text Text--small color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -50983,7 +50983,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -50994,7 +50994,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -51351,7 +51351,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -51362,7 +51362,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -51373,7 +51373,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -51388,7 +51388,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -51399,7 +51399,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -51410,7 +51410,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -51421,7 +51421,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -51432,7 +51432,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -51443,7 +51443,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -51454,7 +51454,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -51610,7 +51610,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -51621,7 +51621,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -51978,7 +51978,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -51989,7 +51989,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -52000,7 +52000,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -52015,7 +52015,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -52026,7 +52026,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -52037,7 +52037,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -52048,7 +52048,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -52059,7 +52059,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -52070,7 +52070,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -52081,7 +52081,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -54802,7 +54802,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -54813,7 +54813,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -54824,7 +54824,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -54835,7 +54835,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -54850,7 +54850,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -54861,7 +54861,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -54872,7 +54872,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -54883,7 +54883,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -54894,7 +54894,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -54905,7 +54905,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -54916,7 +54916,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -55429,7 +55429,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -55440,7 +55440,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -55451,7 +55451,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -55462,7 +55462,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -55477,7 +55477,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -55488,7 +55488,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -55499,7 +55499,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -55510,7 +55510,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -55521,7 +55521,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -55532,7 +55532,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -55543,7 +55543,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -56056,7 +56056,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -56067,7 +56067,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -56078,7 +56078,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -56089,7 +56089,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -56104,7 +56104,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -56115,7 +56115,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -56126,7 +56126,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -56137,7 +56137,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -56148,7 +56148,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -56159,7 +56159,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -56170,7 +56170,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -56683,7 +56683,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -56694,7 +56694,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -56705,7 +56705,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -56716,7 +56716,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -56731,7 +56731,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -56742,7 +56742,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -56753,7 +56753,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -56764,7 +56764,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -56775,7 +56775,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -56786,7 +56786,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -56797,7 +56797,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -57310,7 +57310,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -57321,7 +57321,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -57332,7 +57332,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -57343,7 +57343,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -57358,7 +57358,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -57369,7 +57369,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -57380,7 +57380,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -57391,7 +57391,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -57402,7 +57402,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -57413,7 +57413,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -57424,7 +57424,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -57937,7 +57937,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -57948,7 +57948,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -57959,7 +57959,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -57970,7 +57970,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -57985,7 +57985,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -57996,7 +57996,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -58007,7 +58007,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -58018,7 +58018,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -58029,7 +58029,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -58040,7 +58040,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -58051,7 +58051,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -58564,7 +58564,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -58575,7 +58575,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -58586,7 +58586,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -58597,7 +58597,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -58612,7 +58612,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -58623,7 +58623,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -58634,7 +58634,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -58645,7 +58645,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -58656,7 +58656,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -58667,7 +58667,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -58678,7 +58678,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -59191,7 +59191,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -59202,7 +59202,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -59213,7 +59213,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -59224,7 +59224,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -59239,7 +59239,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -59250,7 +59250,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -59261,7 +59261,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -59272,7 +59272,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -59283,7 +59283,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -59294,7 +59294,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -59305,7 +59305,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -59818,7 +59818,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -59829,7 +59829,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -59840,7 +59840,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -59851,7 +59851,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -59866,7 +59866,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -59877,7 +59877,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -59888,7 +59888,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -59899,7 +59899,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -59910,7 +59910,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -59921,7 +59921,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -59932,7 +59932,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -60445,7 +60445,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -60456,7 +60456,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -60467,7 +60467,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -60478,7 +60478,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -60493,7 +60493,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -60504,7 +60504,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -60515,7 +60515,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -60526,7 +60526,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -60537,7 +60537,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -60548,7 +60548,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -60559,7 +60559,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -61072,7 +61072,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -61083,7 +61083,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -61094,7 +61094,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -61105,7 +61105,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -61120,7 +61120,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -61131,7 +61131,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -61142,7 +61142,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -61153,7 +61153,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -61164,7 +61164,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -61175,7 +61175,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -61186,7 +61186,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -61699,7 +61699,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -61710,7 +61710,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -61721,7 +61721,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -61732,7 +61732,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -61747,7 +61747,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -61758,7 +61758,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -61769,7 +61769,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -61780,7 +61780,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -61791,7 +61791,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -61802,7 +61802,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -61813,7 +61813,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -62326,7 +62326,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -62337,7 +62337,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -62348,7 +62348,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -62359,7 +62359,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -62374,7 +62374,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -62385,7 +62385,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -62396,7 +62396,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -62407,7 +62407,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -62418,7 +62418,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -62429,7 +62429,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -62440,7 +62440,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -62953,7 +62953,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -62964,7 +62964,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -62975,7 +62975,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -62986,7 +62986,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -63001,7 +63001,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -63012,7 +63012,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -63023,7 +63023,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -63034,7 +63034,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -63045,7 +63045,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -63056,7 +63056,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -63067,7 +63067,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -63580,7 +63580,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -63591,7 +63591,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -63602,7 +63602,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -63613,7 +63613,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -63628,7 +63628,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -63639,7 +63639,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -63650,7 +63650,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -63661,7 +63661,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -63672,7 +63672,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -63683,7 +63683,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -63694,7 +63694,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -64207,7 +64207,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -64218,7 +64218,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -64229,7 +64229,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -64240,7 +64240,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -64255,7 +64255,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -64266,7 +64266,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -64277,7 +64277,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -64288,7 +64288,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -64299,7 +64299,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -64310,7 +64310,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -64321,7 +64321,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -67042,7 +67042,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -67053,7 +67053,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -67064,7 +67064,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -67075,7 +67075,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -67090,7 +67090,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -67101,7 +67101,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -67112,7 +67112,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -67123,7 +67123,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -67134,7 +67134,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -67145,7 +67145,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -67156,7 +67156,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -67669,7 +67669,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -67680,7 +67680,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -67691,7 +67691,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -67702,7 +67702,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -67717,7 +67717,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -67728,7 +67728,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -67739,7 +67739,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -67750,7 +67750,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -67761,7 +67761,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -67772,7 +67772,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -67783,7 +67783,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -68296,7 +68296,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -68307,7 +68307,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -68318,7 +68318,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -68329,7 +68329,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -68344,7 +68344,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -68355,7 +68355,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -68366,7 +68366,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -68377,7 +68377,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -68388,7 +68388,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -68399,7 +68399,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -68410,7 +68410,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -68923,7 +68923,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -68934,7 +68934,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -68945,7 +68945,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -68956,7 +68956,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -68971,7 +68971,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -68982,7 +68982,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -68993,7 +68993,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -69004,7 +69004,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -69015,7 +69015,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -69026,7 +69026,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -69037,7 +69037,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -69550,7 +69550,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -69561,7 +69561,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -69572,7 +69572,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -69583,7 +69583,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -69598,7 +69598,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -69609,7 +69609,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -69620,7 +69620,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -69631,7 +69631,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -69642,7 +69642,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -69653,7 +69653,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -69664,7 +69664,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -70177,7 +70177,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -70188,7 +70188,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -70199,7 +70199,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -70210,7 +70210,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -70225,7 +70225,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -70236,7 +70236,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -70247,7 +70247,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -70258,7 +70258,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -70269,7 +70269,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -70280,7 +70280,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -70291,7 +70291,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -70804,7 +70804,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -70815,7 +70815,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -70826,7 +70826,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -70837,7 +70837,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -70852,7 +70852,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -70863,7 +70863,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -70874,7 +70874,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -70885,7 +70885,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -70896,7 +70896,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -70907,7 +70907,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -70918,7 +70918,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -71431,7 +71431,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -71442,7 +71442,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -71453,7 +71453,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -71464,7 +71464,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -71479,7 +71479,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -71490,7 +71490,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -71501,7 +71501,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -71512,7 +71512,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -71523,7 +71523,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -71534,7 +71534,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -71545,7 +71545,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -72058,7 +72058,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -72069,7 +72069,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -72080,7 +72080,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -72091,7 +72091,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -72106,7 +72106,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -72117,7 +72117,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -72128,7 +72128,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -72139,7 +72139,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -72150,7 +72150,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -72161,7 +72161,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -72172,7 +72172,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -72685,7 +72685,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -72696,7 +72696,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -72707,7 +72707,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -72718,7 +72718,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -72733,7 +72733,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -72744,7 +72744,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -72755,7 +72755,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -72766,7 +72766,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -72777,7 +72777,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -72788,7 +72788,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -72799,7 +72799,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -73312,7 +73312,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -73323,7 +73323,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -73334,7 +73334,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -73345,7 +73345,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -73360,7 +73360,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -73371,7 +73371,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -73382,7 +73382,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -73393,7 +73393,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -73404,7 +73404,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -73415,7 +73415,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -73426,7 +73426,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -73939,7 +73939,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -73950,7 +73950,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -73961,7 +73961,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -73972,7 +73972,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -73987,7 +73987,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -73998,7 +73998,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -74009,7 +74009,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -74020,7 +74020,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -74031,7 +74031,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -74042,7 +74042,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -74053,7 +74053,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -74566,7 +74566,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -74577,7 +74577,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -74588,7 +74588,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -74599,7 +74599,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -74614,7 +74614,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -74625,7 +74625,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -74636,7 +74636,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -74647,7 +74647,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -74658,7 +74658,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -74669,7 +74669,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -74680,7 +74680,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -75193,7 +75193,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -75204,7 +75204,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -75215,7 +75215,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -75226,7 +75226,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -75241,7 +75241,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -75252,7 +75252,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -75263,7 +75263,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -75274,7 +75274,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -75285,7 +75285,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -75296,7 +75296,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -75307,7 +75307,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -75820,7 +75820,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -75831,7 +75831,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -75842,7 +75842,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -75853,7 +75853,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -75868,7 +75868,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -75879,7 +75879,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -75890,7 +75890,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -75901,7 +75901,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -75912,7 +75912,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -75923,7 +75923,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -75934,7 +75934,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -76447,7 +76447,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -76458,7 +76458,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -76469,7 +76469,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -76480,7 +76480,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -76495,7 +76495,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -76506,7 +76506,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -76517,7 +76517,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -76528,7 +76528,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -76539,7 +76539,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -76550,7 +76550,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -76561,7 +76561,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -76717,7 +76717,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   26
@@ -76728,7 +76728,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   27
@@ -76739,7 +76739,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   28
@@ -76750,7 +76750,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   29
@@ -76761,7 +76761,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   30
@@ -76772,7 +76772,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -77133,7 +77133,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -77144,7 +77144,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -77155,7 +77155,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -77166,7 +77166,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -77177,7 +77177,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -77188,7 +77188,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -77690,7 +77690,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -77701,7 +77701,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -77712,7 +77712,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -77723,7 +77723,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -77734,7 +77734,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -77749,7 +77749,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -77760,7 +77760,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -77771,7 +77771,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -77782,7 +77782,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -77793,7 +77793,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -77804,7 +77804,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11
@@ -77815,7 +77815,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   12
@@ -77971,7 +77971,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   31
@@ -78328,7 +78328,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   1
@@ -78339,7 +78339,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   2
@@ -78350,7 +78350,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   3
@@ -78361,7 +78361,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   4
@@ -78376,7 +78376,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   5
@@ -78387,7 +78387,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   6
@@ -78398,7 +78398,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   7
@@ -78409,7 +78409,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   8
@@ -78420,7 +78420,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   9
@@ -78431,7 +78431,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   10
@@ -78442,7 +78442,7 @@ exports[`DateRangePicker component
                 data-test="designSystem-Calendar-WrapperClass"
               >
                 <span
-                  class="Text Text--subtle Text--regular Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
+                  class="Text Text--regular color-inverse-lighter Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-test="DesignSystem-Calendar--dateValue"
                 >
                   11

--- a/css/src/components/calendar.module.css
+++ b/css/src/components/calendar.module.css
@@ -118,10 +118,12 @@
 
 .Calendar-valueWrapper--inRange .Calendar-inRangeValue:hover {
   background: var(--primary-lighter);
+  box-shadow: none;
 }
 
 .Calendar-valueWrapper--inRange .Calendar-inRangeValue:active {
   background: var(--primary-light);
+  box-shadow: none;
 }
 
 .Calendar-valueWrapper--inRangeError {
@@ -172,63 +174,87 @@
 
 .Calendar-value:hover {
   background: var(--secondary-light);
+  box-shadow: inset 0 0 0 var(--border-width-2-5) var(--secondary-dark);
 }
 
 .Calendar-value:active {
   background: var(--secondary);
+  box-shadow: inset 0 0 0 var(--border-width-2-5) var(--secondary-dark);
 }
 
 .Calendar-value:active .Calendar-value--currDate {
-  color: var(--primary-dark);
+  color: var(--primary-darker);
 }
 
 .Calendar-value--start:hover,
 .Calendar-value--end:hover {
   background: var(--primary-lightest);
+  box-shadow: none;
+}
+
+.Calendar-value--start:active,
+.Calendar-value--end:active {
+  background: var(--primary-lightest);
+  box-shadow: none;
 }
 
 .Calendar-value--startError:hover,
 .Calendar-value--endError:hover {
   background: var(--alert-lightest);
+  box-shadow: none;
+}
+
+.Calendar-value--startError:active,
+.Calendar-value--endError:active {
+  background: var(--alert-lightest);
+  box-shadow: none;
 }
 
 .Calendar-value--start,
 .Calendar-value--end {
   background: var(--primary-lightest);
+  box-shadow: none;
 }
 
 .Calendar-value--startError,
 .Calendar-value--endError {
   background: var(--alert-lightest);
+  box-shadow: none;
 }
 
 .Calendar-value--currDateMonthYear {
-  background: var(--primary-lightest);
+  background: var(--primary-ultra-light);
+  box-shadow: inset 0 0 0 var(--border-width-2-5) var(--primary);
 }
 
 .Calendar-value--currDateMonthYear:hover {
-  background: var(--primary-lighter);
+  background: var(--primary-lightest);
+  box-shadow: inset 0 0 0 var(--border-width-2-5) var(--primary);
 }
 
 .Calendar-value--currDateMonthYear:active {
   background: var(--primary-lighter);
+  box-shadow: inset 0 0 0 var(--border-width-2-5) var(--primary-dark);
 }
 
 .Calendar-value--currDate:active {
-  color: var(--primary-dark);
+  color: var(--primary-darker);
 }
 
 .Calendar-value--active {
   background: var(--primary);
   font-weight: var(--font-weight-bold);
+  box-shadow: none;
 }
 
 .Calendar-value--active:hover {
   background: var(--primary-dark);
+  box-shadow: none;
 }
 
 .Calendar-value--active:active {
   background: var(--primary-darker);
+  box-shadow: none;
 }
 
 .Calendar-yearValue--small,
@@ -253,8 +279,46 @@
   width: var(--spacing-80);
 }
 
+.Calendar-valueWrapper--dummy .Calendar-value:hover {
+  background: var(--secondary-lightest);
+  box-shadow: none;
+}
+
+.Calendar-valueWrapper--dummy .Calendar-value:active {
+  background: var(--secondary-lighter);
+  box-shadow: none;
+  color: var(--inverse-light);
+}
+
+.Calendar-valueWrapper--dummy .Calendar-inRangeValue:hover {
+  background: var(--primary-lighter);
+  box-shadow: none;
+}
+
+.Calendar-valueWrapper--dummy .Calendar-inRangeValue:active {
+  background: var(--primary-light);
+  box-shadow: none;
+}
+
+.Calendar-valueWrapper--dummy .Calendar-value--active {
+  background: var(--primary-lighter);
+  box-shadow: none;
+}
+
+.Calendar-valueWrapper--dummy .Calendar-value--active:hover {
+  background: var(--primary-light);
+  box-shadow: none;
+  color: var(--inverse);
+}
+
+.Calendar-valueWrapper--dummy .Calendar-value--active:active {
+  background: var(--primary-dark);
+  box-shadow: none;
+  color: var(--white);
+}
+
 .Calendar-valueWrapper--dummy {
-  opacity: var(--opacity-20);
+  opacity: 1;
 }
 
 .Calendar-valueWrapper--disabled {
@@ -262,7 +326,24 @@
 }
 
 .Calendar-valueWrapper--active-dummy {
-  opacity: var(--opacity-16);
+  opacity: 1;
+}
+
+.Calendar-valueWrapper--active-dummy .Calendar-value--active {
+  background: var(--primary-lighter);
+  box-shadow: none;
+}
+
+.Calendar-valueWrapper--active-dummy .Calendar-value--active:hover {
+  background: var(--primary-light);
+  box-shadow: none;
+  color: var(--inverse);
+}
+
+.Calendar-valueWrapper--active-dummy .Calendar-value--active:active {
+  background: var(--primary-dark);
+  box-shadow: none;
+  color: var(--white);
 }
 
 .Calendar-value--disabled {
@@ -317,8 +398,10 @@
 
 .Calendar-valueWrapper--inEdgeRange .Calendar-inRangeValue:hover {
   background: var(--primary-lighter);
+  box-shadow: none;
 }
 
 .Calendar-valueWrapper--inEdgeRange .Calendar-inRangeValue:active {
   background: var(--primary-light);
+  box-shadow: none;
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Update calendar date cell colors, strokes, and text tokens to meet WCAG 4.5:1 contrast minimum. 

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
