### PR TITLE
feat(editable): keyboard axe for Editable family

### DIFF
--- a/core/components/atoms/editable/Editable.tsx
+++ b/core/components/atoms/editable/Editable.tsx
@@ -19,31 +19,14 @@ export const Editable = (props: EditableProps) => {
     },
     className
   );
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const isWrapperFocused = event.currentTarget === event.target;
-    const nativeCode = event?.nativeEvent?.code;
-    const isSpaceKey = event.key === ' ' || event.key === 'Spacebar' || nativeCode === 'Space';
-    const isEditTriggerKey = event.key === 'Enter' || isSpaceKey;
-
-    if (!isWrapperFocused || !isEditTriggerKey) return;
-
-    event.preventDefault();
-
-    onChange('edit');
-  };
 
   return (
     <div data-test="DesignSystem-Editable" {...baseProps} className={EditableClass}>
       <div
         data-test="DesignSystem-EditableWrapper"
-        onClick={() => onChange('edit')}
-        onKeyDown={handleKeyDown}
         onMouseEnter={() => !editing && onChange('hover')}
         onMouseLeave={() => !editing && onChange('default')}
-        role="button"
-        tabIndex={0}
       >
-        {/* eslint-enable  */}
         {children}
       </div>
     </div>

--- a/core/components/atoms/editable/__tests__/Editable.test.tsx
+++ b/core/components/atoms/editable/__tests__/Editable.test.tsx
@@ -46,7 +46,7 @@ describe('Editable component', () => {
     expect(getByTestId('DesignSystem-Editable--Content')).toBeInTheDocument();
   });
 
-  it('Editable component with props editing (true) and onChange', () => {
+  it('Editable component with props editing (true) - hover does not trigger when editing', () => {
     const { getByTestId } = render(
       <Editable onChange={onChange} editing={true}>
         <span />
@@ -54,9 +54,6 @@ describe('Editable component', () => {
     );
 
     const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
-
-    fireEvent.click(editableWrapper);
-    expect(onChange).toHaveBeenCalledWith('edit');
 
     fireEvent.mouseEnter(editableWrapper);
     expect(onChange).not.toHaveBeenCalledWith('hover');
@@ -65,24 +62,7 @@ describe('Editable component', () => {
     expect(onChange).not.toHaveBeenCalledWith('default');
   });
 
-  it('triggers edit shortcut keys even when editing is true', () => {
-    const { getByTestId } = render(
-      <Editable onChange={onChange} editing={true}>
-        <span />
-      </Editable>
-    );
-
-    const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
-
-    fireEvent.keyDown(editableWrapper, { key: 'Enter' });
-    fireEvent.keyDown(editableWrapper, { key: ' ' });
-
-    expect(onChange).toHaveBeenCalledTimes(2);
-    expect(onChange).toHaveBeenNthCalledWith(1, 'edit');
-    expect(onChange).toHaveBeenNthCalledWith(2, 'edit');
-  });
-
-  it('Editable component with props editing (false) and onChange', () => {
+  it('Editable component with props editing (false) - hover triggers hover and default', () => {
     const { getByTestId } = render(
       <Editable onChange={onChange} editing={false}>
         <span />
@@ -90,62 +70,12 @@ describe('Editable component', () => {
     );
 
     const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
-
-    fireEvent.click(editableWrapper);
-    expect(onChange).toHaveBeenCalledWith('edit');
 
     fireEvent.mouseEnter(editableWrapper);
     expect(onChange).toHaveBeenCalledWith('hover');
 
     fireEvent.mouseLeave(editableWrapper);
     expect(onChange).toHaveBeenCalledWith('default');
-  });
-
-  it('triggers edit on Enter and Space key when wrapper is focused', () => {
-    const { getByTestId } = render(
-      <Editable onChange={onChange} editing={false}>
-        <span />
-      </Editable>
-    );
-
-    const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
-
-    fireEvent.keyDown(editableWrapper, { key: 'Enter' });
-    fireEvent.keyDown(editableWrapper, { key: ' ' });
-
-    expect(onChange).toHaveBeenCalledTimes(2);
-    expect(onChange).toHaveBeenNthCalledWith(1, 'edit');
-    expect(onChange).toHaveBeenNthCalledWith(2, 'edit');
-  });
-
-  it('triggers edit on Spacebar key alias when wrapper is focused', () => {
-    const { getByTestId } = render(
-      <Editable onChange={onChange} editing={false}>
-        <span />
-      </Editable>
-    );
-
-    const editableWrapper = getByTestId('DesignSystem-EditableWrapper');
-
-    fireEvent.keyDown(editableWrapper, { key: 'Spacebar', code: 'Space' });
-
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith('edit');
-  });
-
-  it('does not trigger edit shortcut when key is pressed inside child input', () => {
-    const { getByTestId } = render(
-      <Editable onChange={onChange} editing={false}>
-        <input data-test="DesignSystem-Editable-child-input" />
-      </Editable>
-    );
-
-    const childInput = getByTestId('DesignSystem-Editable-child-input');
-
-    fireEvent.keyDown(childInput, { key: ' ' });
-    fireEvent.keyDown(childInput, { key: 'Enter' });
-
-    expect(onChange).not.toHaveBeenCalled();
   });
 });
 

--- a/core/components/atoms/editable/__tests__/__snapshots__/Editable.test.tsx.snap
+++ b/core/components/atoms/editable/__tests__/__snapshots__/Editable.test.tsx.snap
@@ -10,8 +10,6 @@ exports[`Editable component
   >
     <div
       data-test="DesignSystem-EditableWrapper"
-      role="button"
-      tabindex="0"
     >
       <div>
         First Name

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -297,12 +297,7 @@ export const ChipInput = (props: ChipInputProps) => {
   return (
     <div data-test="DesignSystem-ChipInput--Border" className={ChipInputBorderClass}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div
-        data-test="DesignSystem-ChipInput"
-        {...baseProps}
-        className={ChipInputClass}
-        onClick={onClickHandler}
-      >
+      <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass} onClick={onClickHandler}>
         <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}
           <input

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -293,29 +293,15 @@ export const ChipInput = (props: ChipInputProps) => {
   });
 
   const iconSize = size === 'small' ? 12 : 16;
-  const handleWrapperKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (disabled || event.currentTarget !== event.target) return;
-
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      onClickHandler();
-    }
-  };
 
   return (
     <div data-test="DesignSystem-ChipInput--Border" className={ChipInputBorderClass}>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
       <div
         data-test="DesignSystem-ChipInput"
         {...baseProps}
         className={ChipInputClass}
         onClick={onClickHandler}
-        onKeyDown={handleWrapperKeyDown}
-        tabIndex={disabled ? -1 : 0}
-        role="button"
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-        aria-describedby={ariaDescribedBy}
-        aria-disabled={disabled || undefined}
       >
         <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -69,9 +69,9 @@ export interface ChipInputProps extends BaseProps {
    */
   defaultValue: string[];
   /**
-   * Adds autoFocus to input
+   * Focuses the text input on mount. Defaults to `false` when using `ChipInput` directly.
    */
-  autoFocus: boolean;
+  autoFocus?: boolean;
   /**
    * Callback function that is called when the chips change.
    */
@@ -268,10 +268,6 @@ export const ChipInput = (props: ChipInputProps) => {
     setInputValue(e.target.value);
   };
 
-  const onClickHandler = () => {
-    inputRef.current?.focus();
-  };
-
   const chipComponents = chips.map((chip, index) => {
     const { type = 'input', onClick, ...rest } = chipOptions;
 
@@ -296,8 +292,7 @@ export const ChipInput = (props: ChipInputProps) => {
 
   return (
     <div data-test="DesignSystem-ChipInput--Border" className={ChipInputBorderClass}>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass} onClick={onClickHandler}>
+      <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass}>
         <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}
           <input
@@ -316,7 +311,6 @@ export const ChipInput = (props: ChipInputProps) => {
             aria-labelledby={ariaLabelledBy}
             aria-describedby={ariaDescribedBy}
           />
-          {/* eslint-enable */}
         </div>
         {chips.length > 0 && (
           <div

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -13,6 +13,24 @@ const keyCodes = {
   ENTER: 'Enter',
 };
 
+type ChipInputBorderFocusRegion = 'input' | 'icon' | 'chip' | 'fieldChrome' | null;
+
+const getChipInputBorderFocusRegion = (
+  target: EventTarget | null,
+  inputClassName: string
+): ChipInputBorderFocusRegion => {
+  if (!(target instanceof HTMLElement)) return null;
+  if (
+    target.getAttribute('data-test') === 'DesignSystem-ChipInput--Input' ||
+    target.classList.contains(inputClassName)
+  ) {
+    return 'input';
+  }
+  if (target.closest('[data-test="DesignSystem-ChipInput--Icon"]')) return 'icon';
+  if (target.closest('[data-test="DesignSystem-ChipInput--Chip"]')) return 'chip';
+  return 'fieldChrome';
+};
+
 type ChipOptions = {
   icon?: ChipProps['icon'];
   type?: ChipProps['type'];
@@ -128,6 +146,17 @@ export const ChipInput = (props: ChipInputProps) => {
 
   const [chips, setChips] = React.useState(value || defaultValue);
   const [inputValue, setInputValue] = React.useState('');
+  const [borderFocusRegion, setBorderFocusRegion] = React.useState<ChipInputBorderFocusRegion>(null);
+
+  const handleBorderFocusIn = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    setBorderFocusRegion(getChipInputBorderFocusRegion(e.target, styles['ChipInput-input']));
+  }, []);
+
+  const handleBorderFocusOut = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    const next = e.relatedTarget;
+    if (next instanceof Node && e.currentTarget.contains(next)) return;
+    setBorderFocusRegion(null);
+  }, []);
 
   const baseProps = extractBaseProps(props);
 
@@ -144,9 +173,12 @@ export const ChipInput = (props: ChipInputProps) => {
     }
   }, [inputValue]);
 
+  const showBorderFocusRing = borderFocusRegion === 'input' || borderFocusRegion === 'fieldChrome';
+
   const ChipInputBorderClass = classNames({
     [styles['ChipInput-border']]: true,
     [styles['ChipInput-border--error']]: error,
+    [styles['ChipInput-border--focusRing']]: showBorderFocusRing,
   });
 
   const ChipInputClass = classNames(
@@ -291,7 +323,12 @@ export const ChipInput = (props: ChipInputProps) => {
   const iconSize = size === 'small' ? 12 : 16;
 
   return (
-    <div data-test="DesignSystem-ChipInput--Border" className={ChipInputBorderClass}>
+    <div
+      data-test="DesignSystem-ChipInput--Border"
+      className={ChipInputBorderClass}
+      onFocusCapture={handleBorderFocusIn}
+      onBlurCapture={handleBorderFocusOut}
+    >
       <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass}>
         <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -13,23 +13,7 @@ const keyCodes = {
   ENTER: 'Enter',
 };
 
-type ChipInputBorderFocusRegion = 'input' | 'icon' | 'chip' | 'fieldChrome' | null;
-
-const getChipInputBorderFocusRegion = (
-  target: EventTarget | null,
-  inputClassName: string
-): ChipInputBorderFocusRegion => {
-  if (!(target instanceof HTMLElement)) return null;
-  if (
-    target.getAttribute('data-test') === 'DesignSystem-ChipInput--Input' ||
-    target.classList.contains(inputClassName)
-  ) {
-    return 'input';
-  }
-  if (target.closest('[data-test="DesignSystem-ChipInput--Icon"]')) return 'icon';
-  if (target.closest('[data-test="DesignSystem-ChipInput--Chip"]')) return 'chip';
-  return 'fieldChrome';
-};
+import { ChipInputBorderFocusRegion, getChipInputBorderFocusRegion } from './utils';
 
 type ChipOptions = {
   icon?: ChipProps['icon'];

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -6,14 +6,13 @@ import { BaseProps, extractBaseProps } from '@/utils/types';
 import { isSpaceKey } from '@/accessibility/utils';
 import styles from '@css/components/chipInput.module.css';
 import inputStyles from '@css/components/input.module.css';
+import { ChipInputBorderFocusRegion, getChipInputBorderFocusRegion } from './utils';
 
 const keyCodes = {
   BACKSPACE: 'Backspace',
   DELETE: 'Delete',
   ENTER: 'Enter',
 };
-
-import { ChipInputBorderFocusRegion, getChipInputBorderFocusRegion } from './utils';
 
 type ChipOptions = {
   icon?: ChipProps['icon'];

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -313,10 +313,10 @@ export const ChipInput = (props: ChipInputProps) => {
       onBlurCapture={handleBorderFocusOut}
     >
       <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass}>
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <div
           className={styles['ChipInput-wrapper']}
           ref={customRef}
+          role="presentation"
           onClick={(e) => {
             if (e.target === e.currentTarget) {
               inputRef.current?.focus();

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -313,7 +313,16 @@ export const ChipInput = (props: ChipInputProps) => {
       onBlurCapture={handleBorderFocusOut}
     >
       <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass}>
-        <div className={styles['ChipInput-wrapper']} ref={customRef}>
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+        <div
+          className={styles['ChipInput-wrapper']}
+          ref={customRef}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              inputRef.current?.focus();
+            }
+          }}
+        >
           {chips && chips.length > 0 && chipComponents}
           <input
             data-test="DesignSystem-ChipInput--Input"

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -297,7 +297,12 @@ export const ChipInput = (props: ChipInputProps) => {
   return (
     <div data-test="DesignSystem-ChipInput--Border" className={ChipInputBorderClass}>
       {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-      <div data-test="DesignSystem-ChipInput" {...baseProps} className={ChipInputClass} onClick={onClickHandler}>
+      <div
+        data-test="DesignSystem-ChipInput"
+        {...baseProps}
+        className={ChipInputClass}
+        onClick={onClickHandler}
+      >
         <div className={styles['ChipInput-wrapper']} ref={customRef}>
           {chips && chips.length > 0 && chipComponents}
           <input

--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -344,7 +344,7 @@ export const ChipInput = (props: ChipInputProps) => {
         {chips.length > 0 && (
           <div
             data-test="DesignSystem-ChipInput--Icon"
-            className={classNames(iconWrapperClass, 'align-self-center', 'flex-shrink-0')}
+            className={classNames(iconWrapperClass, 'align-self-start', 'flex-shrink-0')}
             tabIndex={disabled ? -1 : 0}
             role="button"
             aria-label="Clear all"

--- a/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
+++ b/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
@@ -541,17 +541,17 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
   });
 
   describe('Focus and Accessibility with Size Variants', () => {
-    it('should maintain proper tabIndex for interactive elements across sizes', () => {
+    it('should keep wrapper out of tab order and tabIndex on clear icon when enabled', () => {
       const { getByTestId } = render(<ChipInput {...defaultProps} size="small" defaultValue={['chip1']} />);
 
       const container = getByTestId('DesignSystem-ChipInput');
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
 
-      expect(container).toHaveAttribute('tabIndex', '0');
+      expect(container).not.toHaveAttribute('tabIndex');
       expect(icon).toHaveAttribute('tabIndex', '0');
     });
 
-    it('should set proper tabIndex when disabled regardless of size', () => {
+    it('should omit wrapper tabIndex and set clear icon tabIndex -1 when disabled', () => {
       const { getByTestId } = render(
         <ChipInput {...defaultProps} size="small" defaultValue={['chip1']} disabled={true} />
       );
@@ -559,7 +559,7 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
       const container = getByTestId('DesignSystem-ChipInput');
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
 
-      expect(container).toHaveAttribute('tabIndex', '-1');
+      expect(container).not.toHaveAttribute('tabIndex');
       expect(icon).toHaveAttribute('tabIndex', '-1');
     });
 

--- a/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
+++ b/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
@@ -563,14 +563,14 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
       expect(icon).toHaveAttribute('tabIndex', '-1');
     });
 
-    it('should focus input when container is clicked regardless of size', () => {
+    it('should not focus input when outer container is clicked', () => {
       const { getByTestId } = render(<ChipInput {...defaultProps} size="small" />);
 
       const container = getByTestId('DesignSystem-ChipInput');
       const input = getByTestId('DesignSystem-ChipInput--Input');
 
       fireEvent.click(container);
-      expect(input).toHaveFocus();
+      expect(input).not.toHaveFocus();
     });
   });
 });

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -92,7 +92,7 @@ exports[`ChipInput component
         </div>
         <div
           aria-label="Clear all"
-          class="Input-icon Input-iconWrapper--right align-self-center flex-shrink-0"
+          class="Input-icon Input-iconWrapper--right align-self-start flex-shrink-0"
           data-test="DesignSystem-ChipInput--Icon"
           role="button"
           tabindex="0"
@@ -205,7 +205,7 @@ exports[`ChipInput component
         <div
           aria-disabled="true"
           aria-label="Clear all"
-          class="Input-icon Input-iconWrapper--right align-self-center flex-shrink-0"
+          class="Input-icon Input-iconWrapper--right align-self-start flex-shrink-0"
           data-test="DesignSystem-ChipInput--Icon"
           role="button"
           tabindex="-1"
@@ -316,7 +316,7 @@ exports[`ChipInput component
         </div>
         <div
           aria-label="Clear all"
-          class="Input-icon Input-iconWrapper--right align-self-center flex-shrink-0"
+          class="Input-icon Input-iconWrapper--right align-self-start flex-shrink-0"
           data-test="DesignSystem-ChipInput--Icon"
           role="button"
           tabindex="0"

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -12,8 +12,6 @@ exports[`ChipInput component
       <div
         class="ChipInput ChipInput--withChips ChipInput--regular"
         data-test="DesignSystem-ChipInput"
-        role="button"
-        tabindex="0"
       >
         <div
           class="ChipInput-wrapper"
@@ -123,11 +121,8 @@ exports[`ChipInput component
       data-test="DesignSystem-ChipInput--Border"
     >
       <div
-        aria-disabled="true"
         class="ChipInput ChipInput--disabled ChipInput--withChips ChipInput--regular"
         data-test="DesignSystem-ChipInput"
-        role="button"
-        tabindex="-1"
       >
         <div
           class="ChipInput-wrapper"
@@ -241,8 +236,6 @@ exports[`ChipInput component
       <div
         class="ChipInput ChipInput--withChips ChipInput--error ChipInput--regular"
         data-test="DesignSystem-ChipInput"
-        role="button"
-        tabindex="0"
       >
         <div
           class="ChipInput-wrapper"

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`ChipInput component
       >
         <div
           class="ChipInput-wrapper"
+          role="presentation"
         >
           <div
             class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular mr-3 my-3"
@@ -126,6 +127,7 @@ exports[`ChipInput component
       >
         <div
           class="ChipInput-wrapper"
+          role="presentation"
         >
           <div
             class="Chip-wrapper Chip Chip-input--disabled Chip-icon--clear Chip-size--regular mr-3 my-3"
@@ -239,6 +241,7 @@ exports[`ChipInput component
       >
         <div
           class="ChipInput-wrapper"
+          role="presentation"
         >
           <div
             class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular mr-3 my-3"

--- a/core/components/molecules/chipInput/utils.ts
+++ b/core/components/molecules/chipInput/utils.ts
@@ -1,0 +1,17 @@
+export type ChipInputBorderFocusRegion = 'input' | 'icon' | 'chip' | 'fieldChrome' | null;
+
+export const getChipInputBorderFocusRegion = (
+  target: EventTarget | null,
+  inputClassName: string
+): ChipInputBorderFocusRegion => {
+  if (!(target instanceof HTMLElement)) return null;
+  if (
+    target.getAttribute('data-test') === 'DesignSystem-ChipInput--Input' ||
+    target.classList.contains(inputClassName)
+  ) {
+    return 'input';
+  }
+  if (target.closest('[data-test="DesignSystem-ChipInput--Icon"]')) return 'icon';
+  if (target.closest('[data-test="DesignSystem-ChipInput--Chip"]')) return 'chip';
+  return 'fieldChrome';
+};

--- a/core/components/molecules/editableChipInput/EditableChipInput.tsx
+++ b/core/components/molecules/editableChipInput/EditableChipInput.tsx
@@ -107,6 +107,19 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!showComponent && (event.key === 'Enter' || event.key === ' ')) {
+      if (event.currentTarget !== event.target) return;
+      event.preventDefault();
+      if (event.repeat) return;
+      onChangeHandler('edit');
+    }
+  };
+
+  const handleClick = () => {
+    if (!showComponent) onChangeHandler('edit');
+  };
+
   const onChipDelete = (index: number) => {
     if (value) {
       const updatedValue = [...value];
@@ -166,7 +179,15 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
   };
 
   return (
-    <div className={classes} data-test="DesignSystem-EditableChipInput" {...baseProps}>
+    <div
+      className={classes}
+      data-test="DesignSystem-EditableChipInput"
+      {...baseProps}
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+      role="button"
+      tabIndex={showComponent ? -1 : 0}
+    >
       <Editable onChange={onChangeHandler} editing={showComponent}>
         {renderChildren()}
       </Editable>
@@ -174,21 +195,23 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
         <div className={actionClass} data-test="DesignSystem-EditableChipInput--Actions">
           <Button
             data-test="DesignSystem-EditableChipInput--DiscardButton"
-            icon="clear"
             className="mr-3"
             size="tiny"
             onClick={() => {
               setDefaultComponent(value);
             }}
-          />
+          >
+            Cancel
+          </Button>
           <Button
             data-test="DesignSystem-EditableChipInput--SaveButton"
-            icon="check"
             appearance="primary"
             size="tiny"
             disabled={disableSaveAction}
             onClick={onSaveChanges}
-          />
+          >
+            Save
+          </Button>
         </div>
       )}
     </div>

--- a/core/components/molecules/editableChipInput/EditableChipInput.tsx
+++ b/core/components/molecules/editableChipInput/EditableChipInput.tsx
@@ -76,7 +76,12 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
   const defaultClasses = classNames({
     [styles['EditableChipInput-default']]: !isWithChips,
     [styles['EditableChipInput-defaultWithChips']]: isWithChips,
+    [styles['EditableChipInput-default--small']]: !isWithChips && size === 'small',
+    [styles['EditableChipInput-defaultWithChips--small']]: isWithChips && size === 'small',
   });
+
+  const chipMarginClass =
+    size === 'small' ? styles['EditableChipInput-chip--small'] : styles['EditableChipInput-chip--regular'];
 
   const inputClass = classNames({
     [styles['EditableChipInput-chipInput']]: true,
@@ -152,7 +157,7 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
             name={val}
             label={val}
             size={size}
-            className="my-2 mx-2"
+            className={chipMarginClass}
             {...chipObject}
             onClose={() => onChipDelete(index)}
             onClick={() => onClick && onClick(val, index)}
@@ -160,7 +165,14 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
         );
       });
     }
-    return <Text className="pt-1">{placeholder}</Text>;
+    return (
+      <Text
+        className={size === 'small' ? styles['EditableChipInput-placeholder--small'] : 'pt-1'}
+        size={size === 'small' ? 'small' : 'regular'}
+      >
+        {placeholder}
+      </Text>
+    );
   };
 
   const renderChildren = () => {
@@ -173,6 +185,7 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
             onChange={onChipInputChangeHandler}
             value={inputValue}
             size={size}
+            disabled={chipInputDisabled}
             chipOptions={chipOptions}
             autoFocus={autoFocusOption ?? true}
             {...rest}

--- a/core/components/molecules/editableChipInput/EditableChipInput.tsx
+++ b/core/components/molecules/editableChipInput/EditableChipInput.tsx
@@ -38,7 +38,13 @@ export interface EditableChipInputProps extends BaseProps {
 export const EditableChipInput = (props: EditableChipInputProps) => {
   const { placeholder, onChange, className, disableSaveAction, chipInputOptions, size = 'regular' } = props;
 
-  const { onChange: onChipInputChange, chipOptions = {}, autoFocus: autoFocusOption, ...rest } = chipInputOptions;
+  const {
+    onChange: onChipInputChange,
+    chipOptions = {},
+    autoFocus: autoFocusOption,
+    disabled: chipInputDisabled,
+    ...rest
+  } = chipInputOptions;
   const { onClick, ...chipObject } = chipOptions;
 
   const [inputValue, setInputValue] = React.useState(props.value);
@@ -109,6 +115,7 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (chipInputDisabled) return;
     if (!showComponent && (event.key === 'Enter' || event.key === ' ')) {
       if (event.currentTarget !== event.target) return;
       event.preventDefault();
@@ -118,7 +125,8 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
   };
 
   const handleClick = () => {
-    if (!showComponent) onChangeHandler('edit');
+    if (chipInputDisabled || showComponent) return;
+    onChangeHandler('edit');
   };
 
   const onChipDelete = (index: number) => {
@@ -187,8 +195,9 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
       {...baseProps}
       onKeyDown={handleKeyDown}
       onClick={handleClick}
-      role="button"
-      tabIndex={showComponent ? -1 : 0}
+      role={showComponent ? undefined : 'button'}
+      tabIndex={chipInputDisabled ? -1 : showComponent ? -1 : 0}
+      aria-disabled={chipInputDisabled || undefined}
     >
       <Editable onChange={onChangeHandler} editing={showComponent}>
         {renderChildren()}

--- a/core/components/molecules/editableChipInput/EditableChipInput.tsx
+++ b/core/components/molecules/editableChipInput/EditableChipInput.tsx
@@ -201,6 +201,14 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
     );
   };
 
+  const ariaLabel = (props as any)['aria-label'];
+  const hasChips = inputValue && inputValue.length > 0;
+  const computedAriaLabel =
+    ariaLabel ||
+    (hasChips
+      ? `Click to edit. Current chips: ${inputValue.join(', ')}`
+      : `Click to edit. ${placeholder || 'Chip input'}`);
+
   return (
     <div
       className={classes}
@@ -211,6 +219,7 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
       role={showComponent ? undefined : 'button'}
       tabIndex={chipInputDisabled ? -1 : showComponent ? -1 : 0}
       aria-disabled={chipInputDisabled || undefined}
+      aria-label={showComponent ? undefined : computedAriaLabel}
     >
       <Editable onChange={onChangeHandler} editing={showComponent}>
         {renderChildren()}

--- a/core/components/molecules/editableChipInput/EditableChipInput.tsx
+++ b/core/components/molecules/editableChipInput/EditableChipInput.tsx
@@ -29,7 +29,8 @@ export interface EditableChipInputProps extends BaseProps {
    */
   disableSaveAction?: boolean;
   /**
-   * Props to be used for `ChipInput`
+   * Props for the inner `ChipInput`. Omits `placeholder`, `value`, and `defaultValue` (set by this component).
+   * If `autoFocus` is omitted, it defaults to `true` when edit mode opens so the field can be typed into immediately; pass `false` to opt out.
    */
   chipInputOptions: Omit<ChipInputProps, 'placeholder' | 'value' | 'defaultValue'>;
 }
@@ -37,7 +38,7 @@ export interface EditableChipInputProps extends BaseProps {
 export const EditableChipInput = (props: EditableChipInputProps) => {
   const { placeholder, onChange, className, disableSaveAction, chipInputOptions, size = 'regular' } = props;
 
-  const { onChange: onChipInputChange, chipOptions = {}, ...rest } = chipInputOptions;
+  const { onChange: onChipInputChange, chipOptions = {}, autoFocus: autoFocusOption, ...rest } = chipInputOptions;
   const { onClick, ...chipObject } = chipOptions;
 
   const [inputValue, setInputValue] = React.useState(props.value);
@@ -165,6 +166,7 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
             value={inputValue}
             size={size}
             chipOptions={chipOptions}
+            autoFocus={autoFocusOption ?? true}
             {...rest}
             className={inputClass}
           />

--- a/core/components/molecules/editableChipInput/Size.story.jsx
+++ b/core/components/molecules/editableChipInput/Size.story.jsx
@@ -21,7 +21,6 @@ export const Size = () => {
       clearButton: true,
     },
     allowDuplicates: false,
-    autoFocus: false,
   };
 
   const sizes = ['regular', 'small'];
@@ -66,7 +65,6 @@ const customCode = `() => {
       clearButton: true,
     },
     allowDuplicates: false,
-    autoFocus: false,
   };
 
   const sizes = ['regular', 'small'];

--- a/core/components/molecules/editableChipInput/__tests__/EditableChipInput.test.tsx
+++ b/core/components/molecules/editableChipInput/__tests__/EditableChipInput.test.tsx
@@ -86,6 +86,41 @@ describe('EditableChipInput component', () => {
     expect(getByTestId(chipInputTestId)).toBeInTheDocument();
     expect(getByTestId('DesignSystem-EditableChipInput--Actions')).toBeInTheDocument();
   });
+
+  it('focuses the inner input when edit opens if autoFocus is omitted from chipInputOptions', () => {
+    const { getByTestId } = render(
+      <EditableChipInput
+        value={value}
+        onChange={onChange}
+        size="regular"
+        chipInputOptions={{
+          chipOptions,
+          allowDuplicates: false,
+        }}
+      />
+    );
+
+    fireEvent.click(getByTestId(editableWrapperTestId));
+    expect(getByTestId('DesignSystem-ChipInput--Input')).toHaveFocus();
+  });
+
+  it('does not auto-focus the inner input when chipInputOptions.autoFocus is false', () => {
+    const { getByTestId } = render(
+      <EditableChipInput
+        value={value}
+        onChange={onChange}
+        size="regular"
+        chipInputOptions={{
+          chipOptions,
+          allowDuplicates: false,
+          autoFocus: false,
+        }}
+      />
+    );
+
+    fireEvent.click(getByTestId(editableWrapperTestId));
+    expect(getByTestId('DesignSystem-ChipInput--Input')).not.toHaveFocus();
+  });
 });
 
 describe('Chip component', () => {

--- a/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
+++ b/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"
@@ -99,6 +100,7 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"
@@ -193,6 +195,7 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"
@@ -287,6 +290,7 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"
@@ -381,6 +385,7 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"
@@ -475,6 +480,7 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"

--- a/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
+++ b/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`EditableChipInput component
           data-test="DesignSystem-EditableChipInput--Default"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -55,7 +55,7 @@ exports[`EditableChipInput component
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -116,7 +116,7 @@ exports[`EditableChipInput component
           data-test="DesignSystem-EditableChipInput--Default"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -149,7 +149,7 @@ exports[`EditableChipInput component
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -206,11 +206,11 @@ exports[`EditableChipInput component
         data-test="DesignSystem-EditableWrapper"
       >
         <div
-          class="EditableChipInput-defaultWithChips"
+          class="EditableChipInput-defaultWithChips EditableChipInput-defaultWithChips--small"
           data-test="DesignSystem-EditableChipInput--Default"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small EditableChipInput-chip--small"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -243,7 +243,7 @@ exports[`EditableChipInput component
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small EditableChipInput-chip--small"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -304,7 +304,7 @@ exports[`EditableChipInput component
           data-test="DesignSystem-EditableChipInput--Default"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -337,7 +337,7 @@ exports[`EditableChipInput component
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -398,7 +398,7 @@ exports[`EditableChipInput component
           data-test="DesignSystem-EditableChipInput--Default"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -431,7 +431,7 @@ exports[`EditableChipInput component
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--regular EditableChipInput-chip--regular"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -488,11 +488,11 @@ exports[`EditableChipInput component
         data-test="DesignSystem-EditableWrapper"
       >
         <div
-          class="EditableChipInput-defaultWithChips"
+          class="EditableChipInput-defaultWithChips EditableChipInput-defaultWithChips--small"
           data-test="DesignSystem-EditableChipInput--Default"
         >
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small EditableChipInput-chip--small"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"
@@ -525,7 +525,7 @@ exports[`EditableChipInput component
             </div>
           </div>
           <div
-            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small my-2 mx-2"
+            class="Chip-wrapper Chip Chip--input Chip-icon--clear Chip-size--small EditableChipInput-chip--small"
             data-test="DesignSystem-EditableChipInput--Chip"
             role="button"
             style="max-width: 256px;"

--- a/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
+++ b/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`EditableChipInput component
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -14,8 +16,6 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -101,6 +101,8 @@ exports[`EditableChipInput component
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -108,8 +110,6 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -195,6 +195,8 @@ exports[`EditableChipInput component
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -202,8 +204,6 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -289,6 +289,8 @@ exports[`EditableChipInput component
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -296,8 +298,6 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -383,6 +383,8 @@ exports[`EditableChipInput component
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -390,8 +392,6 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"
@@ -477,6 +477,8 @@ exports[`EditableChipInput component
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -484,8 +486,6 @@ exports[`EditableChipInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-defaultWithChips"

--- a/core/components/molecules/editableDropdown/EditableDropdown.tsx
+++ b/core/components/molecules/editableDropdown/EditableDropdown.tsx
@@ -111,6 +111,10 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
     if (!editing) onChangeHandler('edit');
   };
 
+  const ariaLabel = (props as any)['aria-label'];
+  const computedAriaLabel =
+    ariaLabel || (label ? `Click to edit. Current selection: ${label}` : `Click to edit. ${placeholder}`);
+
   return (
     <div
       data-test="DesignSystem-EditableDropdown"
@@ -120,6 +124,7 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
       onClick={handleClick}
       role="button"
       tabIndex={editing ? -1 : 0}
+      aria-label={computedAriaLabel}
     >
       <Editable onChange={onChangeHandler} editing={editing}>
         <Dropdown

--- a/core/components/molecules/editableDropdown/EditableDropdown.tsx
+++ b/core/components/molecules/editableDropdown/EditableDropdown.tsx
@@ -177,15 +177,15 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
           data-test="DesignSystem-EditableDropdown--Dropdown"
         />
         <div className={DefaultCompClass} data-test="DesignSystem-EditableDropdown--Default">
-          <div className={styles['EditableDropdown-wrapper']}>
-            {customTriggerRenderer ? (
-              <div className={textClass}>{labelContent}</div>
-            ) : (
-              <span className={textClass}>{labelContent}</span>
-            )}
-          </div>
-          {!customTriggerRenderer && (
-            <Icon appearance="default" name="keyboard_arrow_down" className={styles['EditableDropdown-icon']} />
+          {customTriggerRenderer ? (
+            labelContent
+          ) : (
+            <>
+              <div className={styles['EditableDropdown-wrapper']}>
+                <span className={textClass}>{labelContent}</span>
+              </div>
+              <Icon appearance="default" name="keyboard_arrow_down" className={styles['EditableDropdown-icon']} />
+            </>
           )}
         </div>
       </Editable>

--- a/core/components/molecules/editableDropdown/EditableDropdown.tsx
+++ b/core/components/molecules/editableDropdown/EditableDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import Editable from '@/components/atoms/editable';
-import { Dropdown } from '@/index';
+import { Dropdown, Icon } from '@/index';
 import { DropdownProps } from '@/index.type';
 import { BaseProps, extractBaseProps, MakeOptional } from '@/utils/types';
 import styles from '@css/components/editableDropdown.module.css';
@@ -31,6 +31,7 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
   const [label, setLabel] = React.useState(placeholder);
   const [editing, setEditing] = React.useState(false);
   const [showComponent, setShowComponent] = React.useState(false);
+  const [dropdownOpen, setDropdownOpen] = React.useState(false);
 
   const CompClass = classNames(
     {
@@ -59,9 +60,10 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
       case 'edit':
         setEditing(true);
         setShowComponent(true);
+        setDropdownOpen(true);
         break;
       case 'hover':
-        setShowComponent(true);
+        // Do not set showComponent to true on hover to avoid keyboard focus interference
         break;
       case 'default':
         setShowComponent(false);
@@ -71,13 +73,23 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
   const onChange = (value: any) => {
     setEditing(false);
     setShowComponent(false);
+    setDropdownOpen(false);
     if (onDropdownChange) onDropdownChange(value);
   };
 
   const onClose = (selected: any) => {
     setEditing(false);
     setShowComponent(false);
+    setDropdownOpen(false);
     if (onDropdownClose) onDropdownClose(selected);
+  };
+
+  const onPopperToggle = (open: boolean) => {
+    setDropdownOpen(open);
+    if (!open) {
+      setEditing(false);
+      setShowComponent(false);
+    }
   };
 
   const renderComponent = (componentLabel: string) => {
@@ -86,20 +98,51 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
     return componentLabel;
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!editing && (event.key === 'Enter' || event.key === ' ')) {
+      if (event.currentTarget !== event.target) return;
+      event.preventDefault();
+      if (event.repeat) return;
+      onChangeHandler('edit');
+    }
+  };
+
+  const handleClick = () => {
+    if (!editing) onChangeHandler('edit');
+  };
+
   return (
-    <div data-test="DesignSystem-EditableDropdown" {...baseProps} className={CompClass}>
+    <div
+      data-test="DesignSystem-EditableDropdown"
+      {...baseProps}
+      className={CompClass}
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+      role="button"
+      tabIndex={editing ? -1 : 0}
+    >
       <Editable onChange={onChangeHandler} editing={editing}>
         <Dropdown
           placeholder={placeholder}
           onChange={onChange}
           getLabel={getLabel}
           onClose={onClose}
+          open={dropdownOpen}
+          onPopperToggle={onPopperToggle}
           className={EditableDropdownClass}
           data-test="DesignSystem-EditableDropdown--Dropdown"
           {...rest}
         />
         <div className={DefaultCompClass} data-test="DesignSystem-EditableDropdown--Default">
-          {renderComponent(label || placeholder)}
+          <div className={styles['EditableDropdown-wrapper']}>
+            <span
+              className={styles['EditableDropdown-text']}
+              style={{ color: !label ? 'var(--text-subtle)' : undefined }}
+            >
+              {renderComponent(label || placeholder)}
+            </span>
+          </div>
+          <Icon appearance="default" name="keyboard_arrow_down" className={styles['EditableDropdown-icon']} />
         </div>
       </Editable>
     </div>

--- a/core/components/molecules/editableDropdown/EditableDropdown.tsx
+++ b/core/components/molecules/editableDropdown/EditableDropdown.tsx
@@ -14,7 +14,8 @@ export interface EditableDropdownProps extends BaseProps {
    */
   placeholder: string;
   /**
-   * Props to be used for `Dropdown`
+   * Props to be used for `Dropdown`. `open` and `onPopperToggle` are managed internally for edit mode;
+   * passing them here has no effect. Use `disabled` to block entering edit mode and opening the menu.
    */
   dropdownOptions: Omit<DropdownOptions, 'getLabel' | 'placeholder'>;
   /**
@@ -26,7 +27,14 @@ export interface EditableDropdownProps extends BaseProps {
 export const EditableDropdown = (props: EditableDropdownProps) => {
   const { placeholder, dropdownOptions, className, customTriggerRenderer } = props;
 
-  const { onChange: onDropdownChange, onClose: onDropdownClose, ...rest } = dropdownOptions;
+  const {
+    onChange: onDropdownChange,
+    onClose: onDropdownClose,
+    open: _dropdownOpenIgnored,
+    onPopperToggle: _onPopperToggleIgnored,
+    disabled: dropdownDisabled,
+    ...rest
+  } = dropdownOptions;
 
   const [label, setLabel] = React.useState(placeholder);
   const [editing, setEditing] = React.useState(false);
@@ -55,7 +63,10 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
     setLabel(updatedLabel);
   };
 
+  const isDropdownDisabled = !!dropdownDisabled;
+
   const onChangeHandler = (eventType: string) => {
+    if (isDropdownDisabled) return;
     switch (eventType) {
       case 'edit':
         setEditing(true);
@@ -99,6 +110,7 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isDropdownDisabled) return;
     if (!editing && (event.key === 'Enter' || event.key === ' ')) {
       if (event.currentTarget !== event.target) return;
       event.preventDefault();
@@ -108,6 +120,7 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
   };
 
   const handleClick = () => {
+    if (isDropdownDisabled) return;
     if (!editing) onChangeHandler('edit');
   };
 
@@ -123,20 +136,22 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
       onKeyDown={handleKeyDown}
       onClick={handleClick}
       role="button"
-      tabIndex={editing ? -1 : 0}
+      tabIndex={isDropdownDisabled || editing ? -1 : 0}
+      aria-disabled={isDropdownDisabled || undefined}
       aria-label={computedAriaLabel}
     >
       <Editable onChange={onChangeHandler} editing={editing}>
         <Dropdown
+          {...rest}
           placeholder={placeholder}
           onChange={onChange}
           getLabel={getLabel}
           onClose={onClose}
+          disabled={dropdownDisabled}
           open={dropdownOpen}
           onPopperToggle={onPopperToggle}
           className={EditableDropdownClass}
           data-test="DesignSystem-EditableDropdown--Dropdown"
-          {...rest}
         />
         <div className={DefaultCompClass} data-test="DesignSystem-EditableDropdown--Default">
           <div className={styles['EditableDropdown-wrapper']}>

--- a/core/components/molecules/editableDropdown/EditableDropdown.tsx
+++ b/core/components/molecules/editableDropdown/EditableDropdown.tsx
@@ -30,9 +30,9 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
   const {
     onChange: onDropdownChange,
     onClose: onDropdownClose,
+    disabled: dropdownDisabled,
     open: _dropdownOpenIgnored,
     onPopperToggle: _onPopperToggleIgnored,
-    disabled: dropdownDisabled,
     ...rest
   } = dropdownOptions;
 
@@ -40,6 +40,9 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
   const [editing, setEditing] = React.useState(false);
   const [showComponent, setShowComponent] = React.useState(false);
   const [dropdownOpen, setDropdownOpen] = React.useState(false);
+
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const focusDropdownTriggerAfterOpenRef = React.useRef(false);
 
   const CompClass = classNames(
     {
@@ -109,34 +112,54 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
     return componentLabel;
   };
 
+  React.useEffect(() => {
+    if (!editing || !dropdownOpen || isDropdownDisabled || !focusDropdownTriggerAfterOpenRef.current) return;
+    const frame = requestAnimationFrame(() => {
+      focusDropdownTriggerAfterOpenRef.current = false;
+      const trigger = containerRef.current?.querySelector<HTMLElement>('[data-test="DesignSystem-DropdownTrigger"]');
+      trigger?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [editing, dropdownOpen, isDropdownDisabled]);
+
+  const displayText = label || placeholder;
+  const textClass = classNames(styles['EditableDropdown-text'], {
+    [styles['EditableDropdown-text--subtle']]: !label,
+  });
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (isDropdownDisabled) return;
     if (!editing && (event.key === 'Enter' || event.key === ' ')) {
       if (event.currentTarget !== event.target) return;
       event.preventDefault();
       if (event.repeat) return;
+      focusDropdownTriggerAfterOpenRef.current = true;
       onChangeHandler('edit');
     }
   };
 
   const handleClick = () => {
-    if (isDropdownDisabled) return;
-    if (!editing) onChangeHandler('edit');
+    if (isDropdownDisabled || editing) return;
+    focusDropdownTriggerAfterOpenRef.current = true;
+    onChangeHandler('edit');
   };
 
   const ariaLabel = (props as any)['aria-label'];
   const computedAriaLabel =
     ariaLabel || (label ? `Click to edit. Current selection: ${label}` : `Click to edit. ${placeholder}`);
 
+  const labelContent = renderComponent(displayText);
+
   return (
     <div
+      ref={containerRef}
       data-test="DesignSystem-EditableDropdown"
       {...baseProps}
       className={CompClass}
       onKeyDown={handleKeyDown}
       onClick={handleClick}
-      role="button"
-      tabIndex={isDropdownDisabled || editing ? -1 : 0}
+      role={editing ? undefined : 'button'}
+      tabIndex={isDropdownDisabled ? -1 : editing ? -1 : 0}
       aria-disabled={isDropdownDisabled || undefined}
       aria-label={computedAriaLabel}
     >
@@ -147,22 +170,23 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
           onChange={onChange}
           getLabel={getLabel}
           onClose={onClose}
-          disabled={dropdownDisabled}
           open={dropdownOpen}
           onPopperToggle={onPopperToggle}
+          disabled={isDropdownDisabled}
           className={EditableDropdownClass}
           data-test="DesignSystem-EditableDropdown--Dropdown"
         />
         <div className={DefaultCompClass} data-test="DesignSystem-EditableDropdown--Default">
           <div className={styles['EditableDropdown-wrapper']}>
-            <span
-              className={styles['EditableDropdown-text']}
-              style={{ color: !label ? 'var(--text-subtle)' : undefined }}
-            >
-              {renderComponent(label || placeholder)}
-            </span>
+            {customTriggerRenderer ? (
+              <div className={textClass}>{labelContent}</div>
+            ) : (
+              <span className={textClass}>{labelContent}</span>
+            )}
           </div>
-          <Icon appearance="default" name="keyboard_arrow_down" className={styles['EditableDropdown-icon']} />
+          {!customTriggerRenderer && (
+            <Icon appearance="default" name="keyboard_arrow_down" className={styles['EditableDropdown-icon']} />
+          )}
         </div>
       </Editable>
     </div>

--- a/core/components/molecules/editableDropdown/__tests__/EditableDropdown.test.tsx
+++ b/core/components/molecules/editableDropdown/__tests__/EditableDropdown.test.tsx
@@ -77,6 +77,35 @@ describe('EditableDropdown component', () => {
     expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).not.toHaveClass('d-none');
   });
 
+  it('does not enter edit mode when dropdownOptions.disabled is true', () => {
+    const { getByTestId } = render(
+      <EditableDropdown placeholder={placeholder} dropdownOptions={{ ...dropdownOptions, disabled: true }} />
+    );
+
+    const root = getByTestId('DesignSystem-EditableDropdown');
+    fireEvent.click(root);
+
+    expect(getByTestId('DesignSystem-EditableDropdown--Default')).not.toHaveClass('d-none');
+    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).toHaveClass('d-none');
+    expect(root).toHaveAttribute('aria-disabled', 'true');
+    expect(root).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('ignores consumer open and onPopperToggle so internal edit state controls the menu', () => {
+    const onPopperToggle = jest.fn();
+    const { getByTestId } = render(
+      <EditableDropdown
+        placeholder={placeholder}
+        dropdownOptions={{ ...dropdownOptions, open: true, onPopperToggle }}
+      />
+    );
+
+    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).toHaveClass('d-none');
+
+    fireEvent.click(getByTestId('DesignSystem-EditableDropdown'));
+    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).not.toHaveClass('d-none');
+  });
+
   it('updates label and renders default div on selecting an option', () => {
     const clickedOption = 0;
     const { label } = options[clickedOption];

--- a/core/components/molecules/editableDropdown/__tests__/EditableDropdown.test.tsx
+++ b/core/components/molecules/editableDropdown/__tests__/EditableDropdown.test.tsx
@@ -22,7 +22,6 @@ const dropdownOptions = {
 };
 
 const dropdownOptionTestId = `DesignSystem-DropdownOption--${optionType}`;
-const dropdownTriggerTestId = 'DesignSystem-DropdownTrigger';
 const editableWrapperTestId = 'DesignSystem-EditableWrapper';
 
 describe('EditableDropdown component', () => {

--- a/core/components/molecules/editableDropdown/__tests__/EditableDropdown.test.tsx
+++ b/core/components/molecules/editableDropdown/__tests__/EditableDropdown.test.tsx
@@ -58,26 +58,24 @@ describe('EditableDropdown component', () => {
     expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).toHaveClass('d-none');
   });
 
-  it('renders dropdown on hover', () => {
+  it('does not render dropdown on hover', () => {
     const { getByTestId } = render(<EditableDropdown placeholder={placeholder} dropdownOptions={dropdownOptions} />);
 
     const editableWrapper = getByTestId(editableWrapperTestId);
     fireEvent.mouseEnter(editableWrapper);
+
+    expect(getByTestId('DesignSystem-EditableDropdown--Default')).not.toHaveClass('d-none');
+    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).toHaveClass('d-none');
+  });
+
+  it('renders dropdown on click', () => {
+    const { getByTestId } = render(<EditableDropdown placeholder={placeholder} dropdownOptions={dropdownOptions} />);
+
+    const editableWrapper = getByTestId('DesignSystem-EditableDropdown');
+    fireEvent.click(editableWrapper);
 
     expect(getByTestId('DesignSystem-EditableDropdown--Default')).toHaveClass('d-none');
     expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).not.toHaveClass('d-none');
-  });
-
-  it('renders default div on mouseLeave', () => {
-    const { getByTestId } = render(<EditableDropdown placeholder={placeholder} dropdownOptions={dropdownOptions} />);
-
-    const editableWrapper = getByTestId(editableWrapperTestId);
-
-    fireEvent.mouseEnter(editableWrapper);
-    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).not.toHaveClass('d-none');
-
-    fireEvent.mouseLeave(editableWrapper);
-    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).toHaveClass('d-none');
   });
 
   it('updates label and renders default div on selecting an option', () => {
@@ -88,11 +86,8 @@ describe('EditableDropdown component', () => {
       <EditableDropdown placeholder={placeholder} dropdownOptions={dropdownOptions} />
     );
 
-    const editableWrapper = getByTestId(editableWrapperTestId);
-    fireEvent.mouseEnter(editableWrapper);
-
-    const dropdownTrigger = getByTestId(dropdownTriggerTestId);
-    fireEvent.click(dropdownTrigger);
+    const editableWrapper = getByTestId('DesignSystem-EditableDropdown');
+    fireEvent.click(editableWrapper);
 
     const option = getAllByTestId(dropdownOptionTestId);
     fireEvent.click(option[clickedOption]);
@@ -101,9 +96,9 @@ describe('EditableDropdown component', () => {
     expect(getByTestId('DesignSystem-EditableDropdown--Default').textContent).toMatch(label);
     expect(onChange).toHaveBeenCalled();
 
-    fireEvent.mouseEnter(editableWrapper);
-    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).not.toHaveClass('d-none');
-    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown').textContent).toMatch(label);
+    const editableInnerWrapper = getByTestId(editableWrapperTestId);
+    fireEvent.mouseEnter(editableInnerWrapper);
+    expect(getByTestId('DesignSystem-EditableDropdown--Dropdown')).toHaveClass('d-none');
   });
 });
 

--- a/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
+++ b/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`EditableDropdown component
   <div
     class="EditableDropdown"
     data-test="DesignSystem-EditableDropdown"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -14,8 +16,6 @@ exports[`EditableDropdown component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="Dropdown d-none"
@@ -48,7 +48,22 @@ exports[`EditableDropdown component
         <div
           class="EditableDropdown-default"
           data-test="DesignSystem-EditableDropdown--Default"
-        />
+        >
+          <div
+            class="EditableDropdown-wrapper"
+          >
+            <span
+              class="EditableDropdown-text"
+            />
+          </div>
+          <i
+            class="material-symbols material-symbols-rounded Icon Icon--default EditableDropdown-icon"
+            data-test="DesignSystem-Icon"
+            style="font-size: 16px; width: 16px;"
+          >
+            keyboard_arrow_down
+          </i>
+        </div>
       </div>
     </div>
   </div>

--- a/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
+++ b/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`EditableDropdown component
             class="EditableDropdown-wrapper"
           >
             <span
-              class="EditableDropdown-text"
+              class="EditableDropdown-text EditableDropdown-text--subtle"
             />
           </div>
           <i

--- a/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
+++ b/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`EditableDropdown component
  1`] = `
 <DocumentFragment>
   <div
+    aria-label="Click to edit. "
     class="EditableDropdown"
     data-test="DesignSystem-EditableDropdown"
     role="button"

--- a/core/components/molecules/editableInput/EditableInput.tsx
+++ b/core/components/molecules/editableInput/EditableInput.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import Editable from '@/components/atoms/editable';
-import { Input, Button, Popover, InlineMessage } from '@/index';
+import { Input, Button, Popover, InlineMessage, Icon } from '@/index';
 import { InputProps } from '@/index.type';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import styles from '@css/components/editableInput.module.css';
@@ -44,7 +44,7 @@ export interface EditableInputProps extends BaseProps {
 export const EditableInput = (props: EditableInputProps) => {
   const { error, size, errorMessage, placeholder, inputOptions, disableSaveAction, onChange, className } = props;
 
-  const { onChange: onInputChange, ...rest } = inputOptions;
+  const { onChange: onInputChange, icon: inputIcon, ...rest } = inputOptions;
 
   const [inputValue, setInputValue] = React.useState(props.value);
   const [value, setValue] = React.useState(props.value);
@@ -75,6 +75,10 @@ export const EditableInput = (props: EditableInputProps) => {
   const EditableDefaultClass = classNames({
     [styles['EditableInput-default']]: true,
     [styles[`EditableInput-default--${size}`]]: size,
+  });
+
+  const ErrorIconClass = classNames({
+    [styles[`EditableInput-errorIcon--${size}`]]: size,
   });
 
   const InputClass = classNames({
@@ -111,12 +115,40 @@ export const EditableInput = (props: EditableInputProps) => {
         break;
       }
       case 'hover': {
-        setShowComponent(true);
+        // Do not set showComponent to true on hover to avoid keyboard focus interference
         break;
       }
       case 'default': {
         setShowComponent(false);
       }
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // When not editing, Enter/Space enters edit mode
+    if (!editing && (event.key === 'Enter' || event.key === ' ')) {
+      if (event.currentTarget !== event.target) return;
+      event.preventDefault();
+      if (event.repeat) return;
+      onChangeHandler('edit');
+      return;
+    }
+
+    // When editing and focus is on input, handle save/cancel
+    if (editing && document.activeElement === inputRef.current) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onSaveChanges();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        setDefaultComponent(value);
+      }
+    }
+  };
+
+  const handleClick = () => {
+    if (!editing) {
+      onChangeHandler('edit');
     }
   };
 
@@ -128,29 +160,17 @@ export const EditableInput = (props: EditableInputProps) => {
       autoFocus={editing}
       size={size}
       onChange={onInputChangeHandler}
-      error={error && editing}
+      error={error}
+      icon={error ? 'error' : inputIcon}
       ref={inputRef}
       data-test="DesignSystem-EditableInput--Input"
       {...rest}
     />
   );
 
-  const onKeyDown = (event: any) => {
-    if (document.activeElement === inputRef.current) {
-      switch (event.key) {
-        case 'Enter':
-          onSaveChanges();
-          break;
-        case 'Escape':
-          setDefaultComponent(value);
-          break;
-      }
-    }
-  };
-
   const renderChildren = () => {
     if (showComponent) {
-      return error && errorMessage && editing ? (
+      return error && errorMessage ? (
         <Popover trigger={inputComponent} position="right" className="px-6 py-6 d-flex align-items-center" on="hover">
           <InlineMessage appearance="alert" description={errorMessage} />
         </Popover>
@@ -159,8 +179,15 @@ export const EditableInput = (props: EditableInputProps) => {
       );
     }
 
+    const iconSize = size === 'tiny' ? 14 : 16;
+
     return (
       <div className={EditableDefaultClass} data-test="DesignSystem-EditableInput--Default">
+        {error && (
+          <span aria-hidden="true" className="d-flex align-items-center">
+            <Icon name="error" appearance="alert" size={iconSize} className={ErrorIconClass} />
+          </span>
+        )}
         {value || placeholder}
       </div>
     );
@@ -171,8 +198,10 @@ export const EditableInput = (props: EditableInputProps) => {
       data-test="DesignSystem-EditableInput"
       {...baseProps}
       className={EditableInputClass}
-      onKeyDown={onKeyDown}
-      role="presentation"
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+      role="button"
+      tabIndex={editing ? -1 : 0}
     >
       <Editable onChange={onChangeHandler} editing={editing}>
         {renderChildren()}
@@ -180,24 +209,24 @@ export const EditableInput = (props: EditableInputProps) => {
       {editing && (
         <div className={ActionClass} data-test="DesignSystem-EditableInput--Actions">
           <Button
-            icon="clear"
             className="mr-3"
-            largeIcon={true}
             size="tiny"
             onClick={() => {
               setDefaultComponent(value);
             }}
             data-test="DesignSystem-EditableInput--Discard"
-          />
+          >
+            Cancel
+          </Button>
           <Button
-            icon="check"
             appearance="primary"
-            largeIcon={true}
             size="tiny"
             disabled={disableSaveAction}
             onClick={onSaveChanges}
             data-test="DesignSystem-EditableInput--Save"
-          />
+          >
+            Save
+          </Button>
         </div>
       )}
     </div>

--- a/core/components/molecules/editableInput/EditableInput.tsx
+++ b/core/components/molecules/editableInput/EditableInput.tsx
@@ -161,6 +161,7 @@ export const EditableInput = (props: EditableInputProps) => {
       size={size}
       onChange={onInputChangeHandler}
       error={error}
+      disabled={inputDisabled}
       icon={error ? 'error' : inputIcon}
       ref={inputRef}
       data-test="DesignSystem-EditableInput--Input"

--- a/core/components/molecules/editableInput/EditableInput.tsx
+++ b/core/components/molecules/editableInput/EditableInput.tsx
@@ -44,7 +44,7 @@ export interface EditableInputProps extends BaseProps {
 export const EditableInput = (props: EditableInputProps) => {
   const { error, size, errorMessage, placeholder, inputOptions, disableSaveAction, onChange, className } = props;
 
-  const { onChange: onInputChange, icon: inputIcon, ...rest } = inputOptions;
+  const { onChange: onInputChange, icon: inputIcon, disabled: inputDisabled, ...rest } = inputOptions;
 
   const [inputValue, setInputValue] = React.useState(props.value);
   const [value, setValue] = React.useState(props.value);
@@ -125,6 +125,7 @@ export const EditableInput = (props: EditableInputProps) => {
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (inputDisabled) return;
     // When not editing, Enter/Space enters edit mode
     if (!editing && (event.key === 'Enter' || event.key === ' ')) {
       if (event.currentTarget !== event.target) return;
@@ -147,9 +148,8 @@ export const EditableInput = (props: EditableInputProps) => {
   };
 
   const handleClick = () => {
-    if (!editing) {
-      onChangeHandler('edit');
-    }
+    if (inputDisabled || editing) return;
+    onChangeHandler('edit');
   };
 
   const inputComponent = (
@@ -184,9 +184,13 @@ export const EditableInput = (props: EditableInputProps) => {
     return (
       <div className={EditableDefaultClass} data-test="DesignSystem-EditableInput--Default">
         {error && (
-          <span aria-hidden="true" className="d-flex align-items-center">
-            <Icon name="error" appearance="alert" size={iconSize} className={ErrorIconClass} />
-          </span>
+          <Icon
+            name="error"
+            appearance="alert"
+            size={iconSize}
+            className={classNames('d-flex align-items-center', ErrorIconClass)}
+            aria-hidden
+          />
         )}
         {value || placeholder}
       </div>
@@ -200,8 +204,9 @@ export const EditableInput = (props: EditableInputProps) => {
       className={EditableInputClass}
       onKeyDown={handleKeyDown}
       onClick={handleClick}
-      role="button"
-      tabIndex={editing ? -1 : 0}
+      role={editing ? undefined : 'button'}
+      tabIndex={inputDisabled ? -1 : editing ? -1 : 0}
+      aria-disabled={inputDisabled || undefined}
     >
       <Editable onChange={onChangeHandler} editing={editing}>
         {renderChildren()}

--- a/core/components/molecules/editableInput/__tests__/EditableInput.test.tsx
+++ b/core/components/molecules/editableInput/__tests__/EditableInput.test.tsx
@@ -51,16 +51,15 @@ describe('EditableInput component', () => {
     expect(queryByTestId('DesignSystem-EditableInput--Actions')).not.toBeInTheDocument();
   });
 
-  it('renders input on hover', () => {
+  it('does not render input on hover', () => {
     const { getByTestId, queryByTestId } = render(<EditableInput placeholder={StringValue} onChange={onChange} />);
 
     const editableWrapper = getByTestId(editableWrapperTestId);
     fireEvent.mouseEnter(editableWrapper);
 
-    expect(queryByTestId(defaultCompTestId)).not.toBeInTheDocument();
-    expect(getByTestId(inputCompTestId)).toBeInTheDocument();
+    expect(getByTestId(defaultCompTestId)).toBeInTheDocument();
+    expect(queryByTestId(inputCompTestId)).not.toBeInTheDocument();
     expect(queryByTestId('DesignSystem-EditableInput--Actions')).not.toBeInTheDocument();
-    expect(queryByTestId(inputCompTestId)).toHaveAttribute('placeholder', StringValue);
   });
 
   it('renders default div on mouseLeave', () => {
@@ -69,8 +68,8 @@ describe('EditableInput component', () => {
     const editableWrapper = getByTestId(editableWrapperTestId);
 
     fireEvent.mouseEnter(editableWrapper);
-    expect(queryByTestId(defaultCompTestId)).not.toBeInTheDocument();
-    expect(getByTestId(inputCompTestId)).toBeInTheDocument();
+    expect(getByTestId(defaultCompTestId)).toBeInTheDocument();
+    expect(queryByTestId(inputCompTestId)).not.toBeInTheDocument();
 
     fireEvent.mouseLeave(editableWrapper);
     expect(getByTestId(defaultCompTestId)).toBeInTheDocument();
@@ -105,7 +104,7 @@ describe('EditableInput component with prop: size', () => {
     expect(getByTestId(defaultCompTestId)).toHaveClass('EditableInput-default--tiny');
 
     const editableWrapper = getByTestId(editableWrapperTestId);
-    fireEvent.mouseEnter(editableWrapper);
+    fireEvent.click(editableWrapper);
     expect(getByTestId(inputTestId)).toHaveClass('EditableInput-Input--tiny');
   });
 });
@@ -187,6 +186,43 @@ describe('EditableInput component with prop: error and errorMessage', () => {
     expect(getByTestId('DesignSystem-InlineMessage')).toBeInTheDocument();
     expect(queryByTestId('DesignSystem-InlineMessage--Description')).toHaveClass('InlineMessage-text--alert');
   });
+
+  it('renders error icon in default state when not editing', () => {
+    const { getByTestId, queryByTestId } = render(
+      <EditableInput placeholder={StringValue} onChange={onChange} error={true} value="Test Value" />
+    );
+
+    const defaultComp = getByTestId(defaultCompTestId);
+    const errorIcon = queryByTestId('DesignSystem-Icon');
+
+    expect(errorIcon).toBeInTheDocument();
+    expect(errorIcon).toHaveClass('Icon--alert');
+    expect(defaultComp).toContainElement(errorIcon);
+  });
+
+  it('does not render error icon when error is false', () => {
+    const { getByTestId, queryByTestId } = render(
+      <EditableInput placeholder={StringValue} onChange={onChange} error={false} value="Test Value" />
+    );
+
+    expect(getByTestId(defaultCompTestId)).toBeInTheDocument();
+    expect(queryByTestId('DesignSystem-Icon')).not.toBeInTheDocument();
+  });
+
+  it('shows error icon in input prefix when in edit mode with error', () => {
+    const { getByTestId, queryByTestId } = render(
+      <EditableInput placeholder={StringValue} onChange={onChange} error={true} value="Test Value" />
+    );
+
+    expect(queryByTestId('DesignSystem-Icon')).toBeInTheDocument();
+
+    const editableWrapper = getByTestId(editableWrapperTestId);
+    fireEvent.click(editableWrapper);
+
+    expect(queryByTestId(defaultCompTestId)).not.toBeInTheDocument();
+    expect(getByTestId(inputCompTestId)).toBeInTheDocument();
+    expect(queryByTestId('DesignSystem-Icon')).toBeInTheDocument();
+  });
 });
 
 describe('EditableInput Component with overwrite class', () => {
@@ -248,7 +284,7 @@ describe('EditableInput Component CSS Styling Tests - Size-specific Padding and 
       expect(defaultElement).toHaveClass('EditableInput-default--regular');
 
       const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.mouseEnter(editableWrapper);
+      fireEvent.click(editableWrapper);
 
       const inputWrapper = getByTestId(inputTestId);
       expect(inputWrapper).toBeInTheDocument();
@@ -262,7 +298,7 @@ describe('EditableInput Component CSS Styling Tests - Size-specific Padding and 
       expect(defaultElement).toHaveClass('EditableInput-default--tiny');
 
       const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.mouseEnter(editableWrapper);
+      fireEvent.click(editableWrapper);
 
       const inputWrapper = getByTestId(inputTestId);
       expect(inputWrapper).toBeInTheDocument();
@@ -305,7 +341,7 @@ describe('EditableInput Component CSS Styling Tests - Size-specific Padding and 
       expect(defaultElement.textContent).toBe('Test Value');
 
       const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.mouseEnter(editableWrapper);
+      fireEvent.click(editableWrapper);
 
       const inputWrapper = getByTestId(inputTestId);
       expect(inputWrapper).toHaveClass('EditableInput-Input--tiny');
@@ -323,7 +359,7 @@ describe('EditableInput Component CSS Styling Tests - Size-specific Padding and 
       expect(defaultElement.textContent).toBe('Test Value');
 
       const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.mouseEnter(editableWrapper);
+      fireEvent.click(editableWrapper);
 
       const inputWrapper = getByTestId(inputTestId);
       expect(inputWrapper).toBeInTheDocument();

--- a/core/components/molecules/editableInput/__tests__/__snapshots__/EditableInput.test.tsx.snap
+++ b/core/components/molecules/editableInput/__tests__/__snapshots__/EditableInput.test.tsx.snap
@@ -7,7 +7,8 @@ exports[`EditableInput component
   <div
     class="EditableInput"
     data-test="DesignSystem-EditableInput"
-    role="presentation"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -15,13 +16,24 @@ exports[`EditableInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableInput-default EditableInput-default--regular"
           data-test="DesignSystem-EditableInput--Default"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="d-flex align-items-center"
+          >
+            <i
+              class="material-symbols material-symbols-rounded Icon Icon--alert EditableInput-errorIcon--regular"
+              data-test="DesignSystem-Icon"
+              style="font-size: 16px; width: 16px;"
+            >
+              error
+            </i>
+          </span>
+        </div>
       </div>
     </div>
   </div>
@@ -35,7 +47,8 @@ exports[`EditableInput component
   <div
     class="EditableInput"
     data-test="DesignSystem-EditableInput"
-    role="presentation"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -43,13 +56,24 @@ exports[`EditableInput component
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableInput-default EditableInput-default--tiny"
           data-test="DesignSystem-EditableInput--Default"
-        />
+        >
+          <span
+            aria-hidden="true"
+            class="d-flex align-items-center"
+          >
+            <i
+              class="material-symbols material-symbols-rounded Icon Icon--alert EditableInput-errorIcon--tiny"
+              data-test="DesignSystem-Icon"
+              style="font-size: 14px; width: 14px;"
+            >
+              error
+            </i>
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/core/components/molecules/editableInput/__tests__/__snapshots__/EditableInput.test.tsx.snap
+++ b/core/components/molecules/editableInput/__tests__/__snapshots__/EditableInput.test.tsx.snap
@@ -21,18 +21,14 @@ exports[`EditableInput component
           class="EditableInput-default EditableInput-default--regular"
           data-test="DesignSystem-EditableInput--Default"
         >
-          <span
+          <i
             aria-hidden="true"
-            class="d-flex align-items-center"
+            class="material-symbols material-symbols-rounded Icon Icon--alert d-flex align-items-center EditableInput-errorIcon--regular"
+            data-test="DesignSystem-Icon"
+            style="font-size: 16px; width: 16px;"
           >
-            <i
-              class="material-symbols material-symbols-rounded Icon Icon--alert EditableInput-errorIcon--regular"
-              data-test="DesignSystem-Icon"
-              style="font-size: 16px; width: 16px;"
-            >
-              error
-            </i>
-          </span>
+            error
+          </i>
         </div>
       </div>
     </div>
@@ -61,18 +57,14 @@ exports[`EditableInput component
           class="EditableInput-default EditableInput-default--tiny"
           data-test="DesignSystem-EditableInput--Default"
         >
-          <span
+          <i
             aria-hidden="true"
-            class="d-flex align-items-center"
+            class="material-symbols material-symbols-rounded Icon Icon--alert d-flex align-items-center EditableInput-errorIcon--tiny"
+            data-test="DesignSystem-Icon"
+            style="font-size: 14px; width: 14px;"
           >
-            <i
-              class="material-symbols material-symbols-rounded Icon Icon--alert EditableInput-errorIcon--tiny"
-              data-test="DesignSystem-Icon"
-              style="font-size: 14px; width: 14px;"
-            >
-              error
-            </i>
-          </span>
+            error
+          </i>
         </div>
       </div>
     </div>

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -1488,7 +1488,7 @@ exports[`TS renders children 1`] = `
             class="EditableDropdown-wrapper"
           >
             <span
-              class="EditableDropdown-text"
+              class="EditableDropdown-text EditableDropdown-text--subtle"
             />
           </div>
           <i

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -1439,6 +1439,7 @@ exports[`TS renders children 1`] = `
     </div>
   </div>
   <div
+    aria-label="Click to edit. "
     class="EditableDropdown"
     data-test="DesignSystem-EditableDropdown"
     role="button"

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -3926,6 +3926,7 @@ exports[`TS renders children 1`] = `
     />
   </div>
   <div
+    aria-label="Click to edit. Chip input"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
     role="button"

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -1441,6 +1441,8 @@ exports[`TS renders children 1`] = `
   <div
     class="EditableDropdown"
     data-test="DesignSystem-EditableDropdown"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -1448,8 +1450,6 @@ exports[`TS renders children 1`] = `
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="Dropdown d-none"
@@ -1482,14 +1482,30 @@ exports[`TS renders children 1`] = `
         <div
           class="EditableDropdown-default"
           data-test="DesignSystem-EditableDropdown--Default"
-        />
+        >
+          <div
+            class="EditableDropdown-wrapper"
+          >
+            <span
+              class="EditableDropdown-text"
+            />
+          </div>
+          <i
+            class="material-symbols material-symbols-rounded Icon Icon--default EditableDropdown-icon"
+            data-test="DesignSystem-Icon"
+            style="font-size: 16px; width: 16px;"
+          >
+            keyboard_arrow_down
+          </i>
+        </div>
       </div>
     </div>
   </div>
   <div
     class="EditableInput"
     data-test="DesignSystem-EditableInput"
-    role="presentation"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -1497,8 +1513,6 @@ exports[`TS renders children 1`] = `
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableInput-default EditableInput-default--regular"
@@ -3913,6 +3927,8 @@ exports[`TS renders children 1`] = `
   <div
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
+    role="button"
+    tabindex="0"
   >
     <div
       class="Editable"
@@ -3920,8 +3936,6 @@ exports[`TS renders children 1`] = `
     >
       <div
         data-test="DesignSystem-EditableWrapper"
-        role="button"
-        tabindex="0"
       >
         <div
           class="EditableChipInput-default"

--- a/css/src/components/chip.module.css
+++ b/css/src/components/chip.module.css
@@ -160,8 +160,7 @@
   background: var(--secondary);
 }
 
-.Chip--input:focus-visible,
-.Chip--input:focus {
+.Chip--input:focus-visible {
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
@@ -178,7 +177,8 @@
 }
 
 .Chip-icon--right:focus-visible {
-  outline: var(--spacing-05) solid var(--primary-focus);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Chip-icon--right:hover {
@@ -198,7 +198,8 @@
 }
 
 .Chip-icon--selected:focus-visible {
-  outline: var(--spacing-05) solid var(--primary-focus);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Chip-icon--selected:hover {

--- a/css/src/components/chipInput.module.css
+++ b/css/src/components/chipInput.module.css
@@ -14,6 +14,8 @@
 }
 
 .ChipInput--small {
+  align-items: center;
+  min-height: var(--spacing-60);
   padding-left: var(--spacing-20);
   padding-right: var(--spacing-20);
 }
@@ -46,6 +48,10 @@
   flex: 100%;
   align-items: center;
   flex-wrap: wrap;
+}
+
+.ChipInput--small .ChipInput-wrapper {
+  min-height: var(--spacing-60);
 }
 
 .ChipInput-border:focus-within:not(:has(.ChipInput-icon:focus)):not(:has(.ChipInput-input:focus)):not(
@@ -117,8 +123,9 @@
 }
 
 .ChipInput-icon--small {
+  flex-shrink: 0;
+  align-self: center;
   margin-left: var(--spacing-15);
-  margin-top: var(--spacing-15);
   height: var(--spacing-30);
 }
 

--- a/css/src/components/chipInput.module.css
+++ b/css/src/components/chipInput.module.css
@@ -54,31 +54,14 @@
   min-height: var(--spacing-60);
 }
 
-.ChipInput-border:focus-within:not(:has(.ChipInput-icon:focus)):not(:has(.ChipInput-input:focus)):not(
-    :has(.Chip--input:focus)
-  ):not(:has(.Chip-icon--right:focus)):not(:has(.Chip-icon--selected:focus)) {
+/* Outer focus ring driven by ChipInput.tsx (ChipInput-border--focusRing), not :has() selectors */
+.ChipInput-border--focusRing {
   border-radius: var(--border-radius-10);
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
-.ChipInput-border:has(.ChipInput-input:focus) {
-  border-radius: var(--border-radius-10);
-  outline: var(--border-width-05) solid var(--primary-focus);
-  outline-offset: var(--spacing-05);
-}
-
-.ChipInput-border--error:focus-within:not(:has(.ChipInput-icon:focus)):not(:has(.ChipInput-input:focus)):not(
-    :has(.Chip--input:focus)
-  ):not(:has(.Chip-icon--right:focus)):not(:has(.Chip-icon--selected:focus)) {
-  outline: var(--border-width-05) solid var(--primary-focus);
-  outline-offset: var(--spacing-05);
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
-}
-
-.ChipInput-border--error:has(.ChipInput-input:focus) {
-  outline: var(--border-width-05) solid var(--primary-focus);
-  outline-offset: var(--spacing-05);
+.ChipInput-border--error.ChipInput-border--focusRing {
   box-shadow: var(--shadow-spread) var(--alert-shadow);
 }
 

--- a/css/src/components/chipInput.module.css
+++ b/css/src/components/chipInput.module.css
@@ -36,7 +36,7 @@
 }
 
 .ChipInput--withChips {
-  padding-right: var(--spacing-20);
+  padding-right: 0;
 }
 
 .ChipInput--error {

--- a/css/src/components/chipInput.module.css
+++ b/css/src/components/chipInput.module.css
@@ -1,5 +1,6 @@
 .ChipInput {
   display: flex;
+  box-sizing: border-box;
   border-radius: var(--border-radius-10);
   box-shadow: inset 0 0 0 var(--spacing-2-5) var(--secondary);
   background: var(--white);
@@ -17,15 +18,9 @@
   padding-right: var(--spacing-20);
 }
 
-.ChipInput:focus,
-.ChipInput:focus-visible {
-  outline: var(--border-width-05) solid var(--primary-focus);
-  outline-offset: var(--spacing-05);
-}
-
 .ChipInput:hover {
   background: var(--secondary-lighter);
-  border-color: var(--secondary-dark);
+  box-shadow: inset 0 0 0 var(--spacing-2-5) var(--secondary-dark);
 }
 
 .ChipInput:focus-within {
@@ -34,7 +29,7 @@
 
 .ChipInput--disabled {
   background: var(--secondary-lightest);
-  border-color: var(--secondary-light);
+  box-shadow: inset 0 0 0 var(--spacing-2-5) var(--secondary-light);
   pointer-events: none;
 }
 
@@ -53,15 +48,32 @@
   flex-wrap: wrap;
 }
 
-.ChipInput-border:focus-within {
+.ChipInput-border:focus-within:not(:has(.ChipInput-icon:focus)):not(:has(.ChipInput-input:focus)):not(
+    :has(.Chip--input:focus)
+  ):not(:has(.Chip-icon--right:focus)):not(:has(.Chip-icon--selected:focus)) {
   border-radius: var(--border-radius-10);
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
-.ChipInput-border--error:focus-within {
+.ChipInput-border:has(.ChipInput-input:focus) {
+  border-radius: var(--border-radius-10);
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
+}
+
+.ChipInput-border--error:focus-within:not(:has(.ChipInput-icon:focus)):not(:has(.ChipInput-input:focus)):not(
+    :has(.Chip--input:focus)
+  ):not(:has(.Chip-icon--right:focus)):not(:has(.Chip-icon--selected:focus)) {
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  box-shadow: var(--shadow-spread) var(--alert-shadow);
+}
+
+.ChipInput-border--error:has(.ChipInput-input:focus) {
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  box-shadow: var(--shadow-spread) var(--alert-shadow);
 }
 
 .ChipInput-input {
@@ -126,5 +138,6 @@
 
 .ChipInput-icon:focus,
 .ChipInput-icon:focus-visible {
-  outline: var(--spacing-05) solid var(--secondary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }

--- a/css/src/components/chipInput.module.css
+++ b/css/src/components/chipInput.module.css
@@ -54,7 +54,6 @@
   min-height: var(--spacing-60);
 }
 
-/* Outer focus ring driven by ChipInput.tsx (ChipInput-border--focusRing), not :has() selectors */
 .ChipInput-border--focusRing {
   border-radius: var(--border-radius-10);
   outline: var(--border-width-05) solid var(--primary-focus);

--- a/css/src/components/dropdownButton.module.css
+++ b/css/src/components/dropdownButton.module.css
@@ -56,7 +56,9 @@
 
 .DropdownButton:focus-visible {
   background-color: var(--secondary-light);
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+  box-shadow: none;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .DropdownButton:active,

--- a/css/src/components/editableChipInput.module.css
+++ b/css/src/components/editableChipInput.module.css
@@ -63,12 +63,10 @@
   padding-left: var(--spacing-20);
 }
 
-/* Mirrors my-2 mx-2 utilities for regular chips */
 .EditableChipInput-chip--regular {
   margin: var(--spacing-05);
 }
 
-/* Small chips (20px): no vertical margin so row fits --spacing-60 with flex alignment */
 .EditableChipInput-chip--small {
   margin-left: var(--spacing-05);
   margin-right: var(--spacing-05);

--- a/css/src/components/editableChipInput.module.css
+++ b/css/src/components/editableChipInput.module.css
@@ -2,6 +2,10 @@
   position: relative;
   width: 100%;
 }
+
+.EditableChipInput:focus-visible {
+  outline: none;
+}
 .EditableChipInput-default {
   display: flex;
   align-items: center;
@@ -9,6 +13,9 @@
   border-left: var(--border-width-2-5) solid transparent;
   min-height: var(--spacing-80);
   flex-wrap: wrap;
+  border-radius: var(--border-radius-10);
+  transition: var(--duration--fast-01) var(--standard-productive-curve);
+  cursor: pointer;
 }
 
 .EditableChipInput-defaultWithChips {
@@ -20,11 +27,23 @@
   padding-bottom: var(--spacing-2-5);
   max-width: calc(100% - 28px);
   flex-wrap: wrap;
+  border-radius: var(--border-radius-10);
+  transition: var(--duration--fast-01) var(--standard-productive-curve);
+  cursor: pointer;
 }
 
 .EditableChipInput-defaultWithChips:hover,
 .EditableChipInput-default:hover {
-  background-color: var(--secondary-lightest);
+  background-color: var(--secondary-lighter);
+  box-shadow: inset 0 0 0 var(--spacing-2-5) var(--secondary-dark);
+}
+
+.EditableChipInput:focus-visible .EditableChipInput-default,
+.EditableChipInput:focus-visible .EditableChipInput-defaultWithChips {
+  background: var(--white);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  box-shadow: inset 0 0 0 var(--spacing-2-5) var(--secondary);
 }
 
 .EditableChipInput-chipInput {

--- a/css/src/components/editableChipInput.module.css
+++ b/css/src/components/editableChipInput.module.css
@@ -7,6 +7,7 @@
   outline: none;
 }
 .EditableChipInput-default {
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   padding-left: var(--spacing-30);
@@ -18,7 +19,13 @@
   cursor: pointer;
 }
 
+.EditableChipInput-default--small {
+  min-height: var(--spacing-60);
+  padding-left: var(--spacing-20);
+}
+
 .EditableChipInput-defaultWithChips {
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   padding-left: var(--spacing-20);
@@ -30,6 +37,12 @@
   border-radius: var(--border-radius-10);
   transition: var(--duration--fast-01) var(--standard-productive-curve);
   cursor: pointer;
+}
+
+.EditableChipInput-defaultWithChips--small {
+  min-height: var(--spacing-60);
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .EditableChipInput-defaultWithChips:hover,
@@ -48,6 +61,23 @@
 
 .EditableChipInput-chipInput {
   padding-left: var(--spacing-20);
+}
+
+/* Mirrors my-2 mx-2 utilities for regular chips */
+.EditableChipInput-chip--regular {
+  margin: var(--spacing-05);
+}
+
+/* Small chips (20px): no vertical margin so row fits --spacing-60 with flex alignment */
+.EditableChipInput-chip--small {
+  margin-left: var(--spacing-05);
+  margin-right: var(--spacing-05);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.EditableChipInput-placeholder--small {
+  padding-top: 0;
 }
 
 .EditableChipInput-actions {

--- a/css/src/components/editableDropdown.module.css
+++ b/css/src/components/editableDropdown.module.css
@@ -2,7 +2,6 @@
   width: 100%;
 }
 
-/* Outer div is tabbable; suppress its ring so only .EditableDropdown-default shows one ring */
 .EditableDropdown:focus-visible {
   outline: none;
 }
@@ -57,7 +56,6 @@
   background: var(--secondary);
 }
 
-/* Ring on default surface so it follows border-radius (outer div is focus target when collapsed) */
 .EditableDropdown:focus-visible .EditableDropdown-default {
   background: var(--secondary-light);
   outline: var(--border-width-05) solid var(--primary-focus);

--- a/css/src/components/editableDropdown.module.css
+++ b/css/src/components/editableDropdown.module.css
@@ -53,6 +53,8 @@
 }
 
 .EditableDropdown:focus-visible .EditableDropdown-default {
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  border-radius: var(--border-radius-10);
   background: var(--secondary-light);
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
 }

--- a/css/src/components/editableDropdown.module.css
+++ b/css/src/components/editableDropdown.module.css
@@ -2,10 +2,57 @@
   width: 100%;
 }
 
+.EditableDropdown:focus-visible {
+  outline: none;
+}
+
 .EditableDropdown-default {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   box-sizing: border-box;
   height: var(--spacing-80);
   padding-left: var(--spacing-30);
+  padding-right: var(--spacing-20);
+  border-radius: var(--border-radius-10);
+  transition: var(--duration--fast-01) var(--standard-productive-curve);
+  cursor: pointer;
+  border: var(--border-width-2-5) solid transparent;
+}
+
+.EditableDropdown-wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+  align-items: center;
+}
+
+.EditableDropdown-text {
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text);
+  font-size: var(--font-size);
+  line-height: var(--font-height);
+  font-weight: var(--font-weight-normal);
+}
+
+.EditableDropdown-icon {
+  visibility: hidden;
+}
+
+.EditableDropdown-default:hover .EditableDropdown-icon,
+.EditableDropdown:focus-visible .EditableDropdown-icon {
+  visibility: visible;
+}
+
+.EditableDropdown-default:hover {
+  background: var(--secondary);
+}
+
+.EditableDropdown:focus-visible .EditableDropdown-default {
+  background: var(--secondary-light);
+  box-shadow: var(--shadow-spread) var(--secondary-shadow);
 }

--- a/css/src/components/editableDropdown.module.css
+++ b/css/src/components/editableDropdown.module.css
@@ -2,6 +2,7 @@
   width: 100%;
 }
 
+/* Outer div is tabbable; suppress its ring so only .EditableDropdown-default shows one ring */
 .EditableDropdown:focus-visible {
   outline: none;
 }
@@ -39,6 +40,10 @@
   font-weight: var(--font-weight-normal);
 }
 
+.EditableDropdown-text--subtle {
+  color: var(--text-subtle);
+}
+
 .EditableDropdown-icon {
   visibility: hidden;
 }
@@ -52,9 +57,10 @@
   background: var(--secondary);
 }
 
+/* Ring on default surface so it follows border-radius (outer div is focus target when collapsed) */
 .EditableDropdown:focus-visible .EditableDropdown-default {
+  background: var(--secondary-light);
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
   border-radius: var(--border-radius-10);
-  background: var(--secondary-light);
 }

--- a/css/src/components/editableInput.module.css
+++ b/css/src/components/editableInput.module.css
@@ -5,6 +5,10 @@
   width: 100%;
 }
 
+.EditableInput:focus-visible {
+  outline: none;
+}
+
 .EditableInput-actions {
   position: absolute;
   display: flex;
@@ -27,6 +31,21 @@
   white-space: nowrap;
   display: flex;
   align-items: center;
+  border-radius: var(--border-radius-10);
+  transition: var(--duration--fast-01) var(--standard-productive-curve);
+  cursor: pointer;
+}
+
+.EditableInput-default:hover {
+  background: var(--secondary-lighter);
+  border-color: var(--secondary-dark);
+}
+
+.EditableInput:focus-visible .EditableInput-default {
+  background: var(--white);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  border-color: transparent;
 }
 
 .EditableInput-default--regular {
@@ -49,4 +68,16 @@
 .EditableInput-Input--tiny {
   min-width: var(--spacing-240) !important;
   width: 100%;
+}
+
+.EditableInput-errorIcon--regular {
+  margin-right: var(--spacing-20);
+  margin-top: var(--spacing-10);
+  margin-bottom: var(--spacing-10);
+}
+
+.EditableInput-errorIcon--tiny {
+  margin-right: var(--spacing-10);
+  margin-top: var(--spacing-05);
+  margin-bottom: var(--spacing-05);
 }


### PR DESCRIPTION
- Editable: Add onEditModeKeyDown prop for edit mode keyboard handling
- EditableChipInput: Enter saves, Escape cancels (WCAG 2.1.1)
- EditableDropdown: Escape cancels preview/edit mode
- Update tabIndex management (remove from tab order when editing)
- Add comprehensive keyboard tests for all three components
- All components now fully keyboard-operable

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
