### PR TITLE
feat(focus): update focus states across multiple components

### DIFF
--- a/.cursor/rules/wcag-a11y-audit-report.mdc
+++ b/.cursor/rules/wcag-a11y-audit-report.mdc
@@ -1,7 +1,6 @@
 ---
 alwaysApply: true
 ---
-
 Use these sources as the primary references:
 - [a11y-context/wcag-as-json.json](mdc:a11y-context/wcag-as-json.json) for the full WCAG 2.2 success criteria set.
 - [wcag-audit-patterns.md](mdc:.cursor/rules/wcag-audit-patterns.md) for audit methodology.

--- a/css/src/components/actionCard.module.css
+++ b/css/src/components/actionCard.module.css
@@ -15,9 +15,8 @@
 
 .ActionCard--default:focus,
 .ActionCard--default:focus-visible {
-  outline: none;
-  border: var(--border-width-2-5) solid var(--secondary-dark);
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .ActionCard--default:active {

--- a/css/src/components/breadcrumbs.module.css
+++ b/css/src/components/breadcrumbs.module.css
@@ -37,5 +37,6 @@
 }
 
 .Breadcrumbs-Button:focus {
-  background: var(--secondary) !important;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }

--- a/css/src/components/segmentedControl.module.css
+++ b/css/src/components/segmentedControl.module.css
@@ -98,9 +98,9 @@
 }
 
 .SegmentedControl-segment:focus-visible:not(.SegmentedControl-segment--selected) {
-  border-color: var(--primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
   border-radius: var(--border-radius-10);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
   z-index: 100;
   position: relative;
 }

--- a/css/src/components/selectionCard.module.css
+++ b/css/src/components/selectionCard.module.css
@@ -16,8 +16,9 @@
 
 .Selection-card--default:focus,
 .Selection-card--default:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-spread) var(--secondary-shadow), inset 0 0 0 var(--spacing-2-5) var(--secondary-dark);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  box-shadow: inset 0 0 0 var(--spacing-2-5) var(--secondary-dark);
 }
 
 .Selection-card--default:active {
@@ -46,8 +47,9 @@
 
 .Selection-card--selected:focus,
 .Selection-card--selected:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-spread) var(--primary-shadow), inset 0 0 0 var(--spacing-05) var(--primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
+  box-shadow: inset 0 0 0 var(--spacing-05) var(--primary);
 }
 
 .Selection-card--selected:active {

--- a/css/src/components/slider.module.css
+++ b/css/src/components/slider.module.css
@@ -98,8 +98,8 @@
 }
 
 .Slider-handle:focus {
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
-  outline: none;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Slider-handle--disabled {
@@ -109,5 +109,6 @@
 }
 
 .Slider-handle--disabled:focus {
+  outline: none;
   box-shadow: none;
 }

--- a/css/src/components/stepper.module.css
+++ b/css/src/components/stepper.module.css
@@ -23,8 +23,8 @@
 
 .Step:focus,
 .Step:focus-visible {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
-  outline: none;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 /* Completed State */
@@ -43,8 +43,8 @@
 
 .Step--completed:focus,
 .Step--completed:focus-visible {
-  box-shadow: var(--shadow-spread) var(--secondary-shadow);
-  outline: none;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 /* Active State */
@@ -62,8 +62,8 @@
 .Step--active:focus,
 .Step--active:focus-visible {
   background-color: var(--primary-lightest);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
-  outline: none;
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .Step--active:active {


### PR DESCRIPTION


### What does this implement/fix? Explain your changes.

- SelectionCard — replaced halo with outline; kept inset box-shadow border at default-state values for both default and selected states
- ActionCard — replaced outline: none + halo with outline; border stays at default --secondary-dark
- Stepper — all 3 states (default, completed, active) updated from halo to outline
- Slider handle — replaced halo with outline; added explicit outline: none on disabled state
- SegmentedControl — removed border-color change + halo; border stays transparent (default); outline with --spacing-05 offset matching Button pattern
- Breadcrumbs overflow button — replaced background-only focus with proper outline

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
