### PR TITLE
feat(select): add optionTextWrap prop for customizable text wrapping behaviour

### DIFF
--- a/core/components/organisms/select/Select.tsx
+++ b/core/components/organisms/select/Select.tsx
@@ -130,6 +130,14 @@ export interface SelectProps extends BaseProps {
    */
 
   triggerOptions?: SelectTriggerProps;
+  /**
+   * Controls text wrapping behavior for option labels in the popover.
+   *
+   * - `undefined` (default): Text is truncated with ellipsis (current behavior).
+   * - `true`: Text wraps fully without any truncation.
+   * - `number` (e.g. `2`): Text wraps up to the specified number of lines, then truncates with ellipsis.
+   */
+  optionTextWrap?: boolean | number;
 }
 
 export interface SelectMethods {
@@ -165,6 +173,7 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
     onToggle,
     styleType = 'filled',
     error = false,
+    optionTextWrap,
   } = props;
 
   const [openPopover, setOpenPopover] = React.useState(false);
@@ -295,6 +304,7 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
     setHighlightLastItem,
     styleType,
     error,
+    optionTextWrap,
   };
 
   return (

--- a/core/components/organisms/select/SelectContext.tsx
+++ b/core/components/organisms/select/SelectContext.tsx
@@ -24,6 +24,7 @@ export type ContextProps = {
   size?: TListboxSize;
   styleType?: SelectStyleType;
   error?: boolean;
+  optionTextWrap?: boolean | number;
 };
 
 export const SelectContext = React.createContext<ContextProps>({});

--- a/core/components/organisms/select/SelectOption.tsx
+++ b/core/components/organisms/select/SelectOption.tsx
@@ -45,10 +45,28 @@ export interface SelectOptionProps extends BaseProps {
    * Aria label for the `SelectOption`
    */
   'aria-label'?: string;
+  /**
+   * Controls text wrapping behavior for this option's label.
+   * Overrides the `optionTextWrap` prop set on the parent `Select` component.
+   *
+   * - `undefined` (default): Inherits from parent `Select` or truncates with ellipsis.
+   * - `true`: Text wraps fully without any truncation.
+   * - `number` (e.g. `2`): Text wraps up to the specified number of lines, then truncates with ellipsis.
+   */
+  optionTextWrap?: boolean | number;
 }
 
 export const SelectOption = (props: SelectOptionProps) => {
-  const { children, option, checkedState, onClick, withCheckbox = true, disabled, ...rest } = props;
+  const {
+    children,
+    option,
+    checkedState,
+    onClick,
+    withCheckbox = true,
+    disabled,
+    optionTextWrap: optionTextWrapProp,
+    ...rest
+  } = props;
   const contextProp = React.useContext(SelectContext);
   const {
     onOptionClick,
@@ -65,7 +83,10 @@ export const SelectOption = (props: SelectOptionProps) => {
     setOpenPopover,
     triggerRef,
     size,
+    optionTextWrap: optionTextWrapContext,
   } = contextProp;
+
+  const optionTextWrap = optionTextWrapProp !== undefined ? optionTextWrapProp : optionTextWrapContext;
 
   const onClickHandler = () => {
     if (disabled) return;
@@ -90,11 +111,20 @@ export const SelectOption = (props: SelectOptionProps) => {
     [styles['Select-option']]: true,
   });
 
+  const isFullWrap = optionTextWrap === true;
+  const isLineClamp = typeof optionTextWrap === 'number' && optionTextWrap > 0;
+
   const textClass = classNames({
     [styles['Select-option--text']]: true,
     [styles['Select-option--textTight']]: size === 'tight',
+    [styles['Select-option--textWrap']]: isFullWrap,
+    [styles['Select-option--textLineClamp']]: isLineClamp,
     'pt-2': multiSelect,
   });
+
+  const textStyle: React.CSSProperties | undefined = isLineClamp
+    ? { WebkitLineClamp: optionTextWrap as number }
+    : undefined;
 
   const SelectOptionClass = classNames({
     [styles['Select-option--tight']]: size === 'tight',
@@ -137,7 +167,9 @@ export const SelectOption = (props: SelectOptionProps) => {
             indeterminate={indeterminate}
           />
         )}
-        <div className={textClass}>{children}</div>
+        <div className={textClass} style={textStyle}>
+          {children}
+        </div>
       </div>
     </Listbox.Item>
   );

--- a/core/components/organisms/select/__stories__/optionTextWrap.story.jsx
+++ b/core/components/organisms/select/__stories__/optionTextWrap.story.jsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { Select } from '@/index';
+import { action } from '@/utils/action';
+
+const longOptionList = [
+  { label: 'Aspirin', value: 'Aspirin' },
+  { label: 'Paracetamol with extended release formula for chronic pain management', value: 'Paracetamol' },
+  {
+    label: 'Lisinopril Anasthesia combined therapy for hypertension and cardiac rehabilitation program',
+    value: 'Lisinopril',
+  },
+  { label: 'Simvastatin', value: 'Simvastatin' },
+  {
+    label: 'Amoxicillin trihydrate dispersible tablets for pediatric bacterial infections and prophylaxis',
+    value: 'Amoxicillin',
+  },
+  { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+];
+
+const onSelectHandler = (selectedOption) => {
+  action('selectedOption', selectedOption)();
+};
+
+// Full wrap: text wraps completely without truncation
+export const fullWrap = () => {
+  return (
+    <Select onSelect={onSelectHandler} optionTextWrap triggerOptions={{ 'aria-label': 'Medication selector' }}>
+      <Select.List aria-label="Medication options list">
+        {longOptionList.map((item, key) => (
+          <Select.Option key={key} option={item} aria-label={`${item.label} option`}>
+            {item.label}
+          </Select.Option>
+        ))}
+      </Select.List>
+    </Select>
+  );
+};
+
+// Line clamp: text wraps up to 2 lines, then truncates with ellipsis
+export const lineClamp = () => {
+  return (
+    <Select onSelect={onSelectHandler} optionTextWrap={2} triggerOptions={{ 'aria-label': 'Medication selector' }}>
+      <Select.List aria-label="Medication options list">
+        {longOptionList.map((item, key) => (
+          <Select.Option key={key} option={item} aria-label={`${item.label} option`}>
+            {item.label}
+          </Select.Option>
+        ))}
+      </Select.List>
+    </Select>
+  );
+};
+
+// Per-option override: Select-level full wrap with a specific option clamped to 1 line
+export const perOptionOverride = () => {
+  return (
+    <Select onSelect={onSelectHandler} optionTextWrap triggerOptions={{ 'aria-label': 'Medication selector' }}>
+      <Select.List aria-label="Medication options list">
+        {longOptionList.map((item, key) => (
+          <Select.Option
+            key={key}
+            option={item}
+            aria-label={`${item.label} option`}
+            optionTextWrap={key === 2 ? 1 : undefined}
+          >
+            {item.label}
+          </Select.Option>
+        ))}
+      </Select.List>
+    </Select>
+  );
+};
+
+const customCode = `() => {
+  const longOptionList = [
+    { label: 'Aspirin', value: 'Aspirin' },
+    { label: 'Paracetamol with extended release formula for chronic pain management', value: 'Paracetamol' },
+    {
+      label: 'Lisinopril Anasthesia combined therapy for hypertension and cardiac rehabilitation program',
+      value: 'Lisinopril',
+    },
+    { label: 'Simvastatin', value: 'Simvastatin' },
+    {
+      label: 'Amoxicillin trihydrate dispersible tablets for pediatric bacterial infections and prophylaxis',
+      value: 'Amoxicillin',
+    },
+    { label: 'Ciprofloxacin', value: 'Ciprofloxacin' },
+  ];
+
+  const onSelectHandler = (selectedOption) => {
+    console.log('selectedOption', selectedOption);
+  };
+
+  return (
+    <Select onSelect={onSelectHandler} optionTextWrap={2} triggerOptions={{ 'aria-label': 'Medication selector' }}>
+      <Select.List aria-label="Medication options list">
+        {longOptionList.map((item, key) => (
+          <Select.Option key={key} option={item} aria-label={\`\${item.label} option\`}>
+            {item.label}
+          </Select.Option>
+        ))}
+      </Select.List>
+    </Select>
+  );
+}`;
+
+export default {
+  title: 'Components/Select/Option Text Wrap',
+  component: Select,
+  subcomponents: {
+    'Select.List': Select.List,
+    'Select.Option': Select.Option,
+  },
+  parameters: {
+    docs: {
+      docPage: {
+        title: 'Select',
+        customCode,
+      },
+    },
+  },
+};

--- a/css/src/components/select.module.css
+++ b/css/src/components/select.module.css
@@ -194,6 +194,22 @@
   font-weight: var(--font-weight-medium);
 }
 
+.Select-option--textWrap {
+  white-space: normal;
+  word-break: break-word;
+  overflow: visible;
+  text-overflow: initial;
+}
+
+.Select-option--textLineClamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+  word-break: break-word;
+  text-overflow: initial;
+}
+
 .Select-trigger--error {
   border: var(--border-width-2-5) solid var(--alert) !important;
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Adds a new optionTextWrap prop to Select and Select.Option to control option label text wrapping behavior in the popover dropdown.
By default, option text continues to truncate with ellipsis (no breaking changes).
Setting optionTextWrap={true} enables full text wrapping without truncation.
Setting optionTextWrap={N} (e.g. 2) wraps text up to N lines, then truncates with ellipsis using CSS line-clamp.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
