### PR TITLE
fix(icons): prevent role/tabIndex to non-interactive icons to avoid nested controls

### DIFF
--- a/core/accessibility/utils/__tests__/useAccessibilityProps.test.tsx
+++ b/core/accessibility/utils/__tests__/useAccessibilityProps.test.tsx
@@ -57,7 +57,14 @@ describe('useAccessibilityProps', () => {
     const element = container.firstChild as HTMLElement;
     expect(element).not.toHaveAttribute('role');
     expect(element).not.toHaveAttribute('tabindex');
-    expect(element).not.toHaveAttribute('aria-label');
+  });
+
+  test('preserves non-interactive ARIA props when onClick is not provided', () => {
+    const { container } = render(<TestComponent aria-label="Message sent" aria-labelledby="id" aria-hidden={true} />);
+    const element = container.firstChild as HTMLElement;
+    expect(element).toHaveAttribute('aria-label', 'Message sent');
+    expect(element).toHaveAttribute('aria-labelledby', 'id');
+    expect(element).toHaveAttribute('aria-hidden', 'true');
   });
 
   test('No trigger for callback on event of not allowed aria roles', () => {

--- a/core/accessibility/utils/__tests__/useAccessibilityProps.test.tsx
+++ b/core/accessibility/utils/__tests__/useAccessibilityProps.test.tsx
@@ -42,11 +42,22 @@ describe('useAccessibilityProps', () => {
     }
   });
 
-  test('role, tabIndex and aria-label are set correctly', () => {
-    const { getByRole } = render(<TestComponent role="button" tabIndex={-1} aria-label="test label" />);
+  test('role, tabIndex and aria-label are set correctly when onClick is provided', () => {
+    const onClick = jest.fn();
+    const { getByRole } = render(
+      <TestComponent onClick={onClick} role="button" tabIndex={-1} aria-label="test label" />
+    );
     const element = getByRole('button');
     expect(element).toHaveAttribute('tabIndex', '-1');
     expect(element).toHaveAttribute('aria-label', 'test label');
+  });
+
+  test('does not add interactive props when onClick is not provided (avoids nested button/link)', () => {
+    const { container } = render(<TestComponent role="button" tabIndex={-1} aria-label="test label" />);
+    const element = container.firstChild as HTMLElement;
+    expect(element).not.toHaveAttribute('role');
+    expect(element).not.toHaveAttribute('tabindex');
+    expect(element).not.toHaveAttribute('aria-label');
   });
 
   test('No trigger for callback on event of not allowed aria roles', () => {

--- a/core/accessibility/utils/useAccessibilityProps.ts
+++ b/core/accessibility/utils/useAccessibilityProps.ts
@@ -9,6 +9,9 @@ interface IProps {
   role?: AriaRoleType;
   tabIndex?: number;
   'aria-label'?: React.AriaAttributes['aria-label'];
+  'aria-labelledby'?: React.AriaAttributes['aria-labelledby'];
+  'aria-describedby'?: React.AriaAttributes['aria-describedby'];
+  'aria-hidden'?: React.AriaAttributes['aria-hidden'];
 }
 
 const allowed: Record<string, Set<KeyboardEventKeyType>> = {
@@ -30,11 +33,20 @@ const isKeyboardInteractionAllowed = (role: AriaRoleType, key: KeyboardEventKeyT
 };
 
 const useAccessibilityProps = ({ onClick, onKeyDown, role = 'button', tabIndex, ...rest }: IProps) => {
-  // Only add interactive props when onClick is provided. Adding role="button" or tabIndex
-  // to non-interactive elements (e.g. decorative icons inside buttons/links) creates
-  // invalid nesting and causes dual role announcement + extra tab stops (WCAG 4.1.2).
+  // Only add interactive props when onClick is provided.
   if (!onClick) {
-    return {};
+    const {
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+      'aria-hidden': ariaHidden,
+    } = rest;
+    return {
+      ...(ariaLabel != null && { 'aria-label': ariaLabel }),
+      ...(ariaLabelledBy != null && { 'aria-labelledby': ariaLabelledBy }),
+      ...(ariaDescribedBy != null && { 'aria-describedby': ariaDescribedBy }),
+      ...(ariaHidden != null && { 'aria-hidden': ariaHidden }),
+    };
   }
   return {
     onClick: onClick,

--- a/core/accessibility/utils/useAccessibilityProps.ts
+++ b/core/accessibility/utils/useAccessibilityProps.ts
@@ -30,28 +30,28 @@ const isKeyboardInteractionAllowed = (role: AriaRoleType, key: KeyboardEventKeyT
 };
 
 const useAccessibilityProps = ({ onClick, onKeyDown, role = 'button', tabIndex, ...rest }: IProps) => {
+  // Only add interactive props when onClick is provided. Adding role="button" or tabIndex
+  // to non-interactive elements (e.g. decorative icons inside buttons/links) creates
+  // invalid nesting and causes dual role announcement + extra tab stops (WCAG 4.1.2).
+  if (!onClick) {
+    return {};
+  }
   return {
-    ...(onClick
-      ? {
-          onClick: onClick,
-          role: role,
-          tabIndex: tabIndex || 0,
-          'aria-label': rest['aria-label'],
-          onKeyDown: (e: React.SyntheticEvent<HTMLElement>) => {
-            if (onKeyDown) {
-              onKeyDown(e as React.KeyboardEvent<HTMLElement>);
-              return;
-            }
-            const key = (e as React.KeyboardEvent<HTMLElement>).key;
-            if (isKeyboardInteractionAllowed(role, key)) {
-              if (onClick) {
-                e.preventDefault();
-                onClick(e as React.MouseEvent<HTMLElement>);
-              }
-            }
-          },
-        }
-      : { role, tabIndex, 'aria-label': rest['aria-label'] }),
+    onClick: onClick,
+    role: role,
+    tabIndex: tabIndex ?? 0,
+    'aria-label': rest['aria-label'],
+    onKeyDown: (e: React.SyntheticEvent<HTMLElement>) => {
+      if (onKeyDown) {
+        onKeyDown(e as React.KeyboardEvent<HTMLElement>);
+        return;
+      }
+      const key = (e as React.KeyboardEvent<HTMLElement>).key;
+      if (isKeyboardInteractionAllowed(role, key)) {
+        e.preventDefault();
+        onClick(e as React.MouseEvent<HTMLElement>);
+      }
+    },
   };
 };
 

--- a/core/components/atoms/_chip/__tests__/__snapshots__/_chip.test.tsx.snap
+++ b/core/components/atoms/_chip/__tests__/__snapshots__/_chip.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -50,7 +49,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--primaryDark Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -85,7 +83,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -120,7 +117,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--primaryDark Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -155,7 +151,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -180,7 +175,6 @@ exports[`Chip component
         <i
           class="material-symbols material-symbols-rounded Icon Icon--subtle"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           clear
@@ -206,7 +200,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--primaryDark Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -231,7 +224,6 @@ exports[`Chip component
         <i
           class="material-symbols material-symbols-rounded Icon Icon--primaryDark"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           clear
@@ -257,7 +249,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -282,7 +273,6 @@ exports[`Chip component
         <i
           class="material-symbols material-symbols-rounded Icon Icon--subtle"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           clear
@@ -308,7 +298,6 @@ exports[`Chip component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--primaryDark Chip-icon Chip-icon--left"
         data-test="DesignSystem-GenericChip--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -333,7 +322,6 @@ exports[`Chip component
         <i
           class="material-symbols material-symbols-rounded Icon Icon--primaryDark"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           clear

--- a/core/components/atoms/avatar/avatarIcon/__tests__/__snapshots__/AvatarIcon.test.tsx.snap
+++ b/core/components/atoms/avatar/avatarIcon/__tests__/__snapshots__/AvatarIcon.test.tsx.snap
@@ -24,7 +24,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -52,7 +51,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -139,7 +137,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent2Darker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -167,7 +164,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent2Darker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -254,7 +250,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent3Darker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -282,7 +277,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent3Darker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -369,7 +363,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent4Darker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -397,7 +390,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent4Darker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -484,7 +476,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -512,7 +503,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -599,7 +589,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--primaryDarker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -627,7 +616,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--primaryDarker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -714,7 +702,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--inverse Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -742,7 +729,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--inverse Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -829,7 +815,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--successDarker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -857,7 +842,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--successDarker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -944,7 +928,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--warningDarker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 20px; width: 20px;"
             >
               events
@@ -972,7 +955,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--warningDarker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             events
@@ -1059,7 +1041,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1087,7 +1068,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1174,7 +1154,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent2Darker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1202,7 +1181,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent2Darker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1289,7 +1267,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent3Darker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1317,7 +1294,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent3Darker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1404,7 +1380,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--accent4Darker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1432,7 +1407,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--accent4Darker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1519,7 +1493,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1547,7 +1520,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1634,7 +1606,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--primaryDarker"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1662,7 +1633,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--primaryDarker"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1749,7 +1719,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--inverse Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1777,7 +1746,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--inverse Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1864,7 +1832,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--successDarker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -1892,7 +1859,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--successDarker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -1979,7 +1945,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--warningDarker Avatar-content"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -2007,7 +1972,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--warningDarker Avatar-content"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events

--- a/core/components/atoms/avatarGroup/__tests__/__snapshots__/AvatarGroup.test.tsx.snap
+++ b/core/components/atoms/avatarGroup/__tests__/__snapshots__/AvatarGroup.test.tsx.snap
@@ -37,7 +37,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 20px; width: 20px;"
                   >
                     places
@@ -73,7 +72,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 20px; width: 20px;"
                   >
                     smart_toy
@@ -117,7 +115,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 20px; width: 20px;"
                 >
                   places
@@ -153,7 +150,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 20px; width: 20px;"
                 >
                   smart_toy
@@ -256,7 +252,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 20px; width: 20px;"
                   >
                     places
@@ -292,7 +287,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 20px; width: 20px;"
                   >
                     smart_toy
@@ -336,7 +330,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 20px; width: 20px;"
                 >
                   places
@@ -372,7 +365,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 20px; width: 20px;"
                 >
                   smart_toy
@@ -475,7 +467,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     places
@@ -511,7 +502,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     smart_toy
@@ -555,7 +545,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   places
@@ -591,7 +580,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   smart_toy
@@ -694,7 +682,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     places
@@ -730,7 +717,6 @@ Object {
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     smart_toy
@@ -774,7 +760,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--accent1Darker Avatar-content"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   places
@@ -810,7 +795,6 @@ Object {
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--alertDarker"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   smart_toy

--- a/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -525,7 +525,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 20px; width: 20px;"
         >
           events
@@ -558,7 +557,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 20px; width: 20px;"
         >
           events
@@ -591,7 +589,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 20px; width: 20px;"
         >
           events
@@ -644,7 +641,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -677,7 +673,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -710,7 +705,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -763,7 +757,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 14px; width: 14px;"
         >
           events
@@ -796,7 +789,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 14px; width: 14px;"
         >
           events
@@ -829,7 +821,6 @@ exports[`Button component
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Button--Icon"
-          role="button"
           style="font-size: 14px; width: 14px;"
         >
           events

--- a/core/components/atoms/chipGroup/__tests__/__snapshots__/chipGroup.test.tsx.snap
+++ b/core/components/atoms/chipGroup/__tests__/__snapshots__/chipGroup.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`ChipGroup component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
             data-test="DesignSystem-GenericChip--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assessment
@@ -52,7 +51,6 @@ exports[`ChipGroup component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
             data-test="DesignSystem-GenericChip--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assessment
@@ -77,7 +75,6 @@ exports[`ChipGroup component
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               clear
@@ -99,7 +96,6 @@ exports[`ChipGroup component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--primaryDark Chip-icon Chip-icon--left"
             data-test="DesignSystem-GenericChip--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assessment
@@ -124,7 +120,6 @@ exports[`ChipGroup component
             <i
               class="material-symbols material-symbols-rounded Icon Icon--primaryDark"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               clear
@@ -146,7 +141,6 @@ exports[`ChipGroup component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--inverse Chip-icon Chip-icon--left"
             data-test="DesignSystem-GenericChip--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assessment
@@ -171,7 +165,6 @@ exports[`ChipGroup component
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               clear

--- a/core/components/atoms/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
+++ b/core/components/atoms/collapsible/__tests__/__snapshots__/Collapsible.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`Collapsible component
           <i
             class="material-symbols material-symbols-rounded Icon px-6 py-4 my-2 cursor-pointer"
             data-test="DesignSystem-Collapsible--FooterIcon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_right
@@ -76,7 +75,6 @@ exports[`Collapsible component
           <i
             class="material-symbols material-symbols-rounded Icon px-6 py-4 my-2 cursor-pointer"
             data-test="DesignSystem-Collapsible--FooterIcon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_right
@@ -121,7 +119,6 @@ exports[`Collapsible component
           <i
             class="material-symbols material-symbols-rounded Icon px-6 py-4 my-2 cursor-pointer"
             data-test="DesignSystem-Collapsible--FooterIcon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_left
@@ -166,7 +163,6 @@ exports[`Collapsible component
           <i
             class="material-symbols material-symbols-rounded Icon px-6 py-4 my-2 cursor-pointer"
             data-test="DesignSystem-Collapsible--FooterIcon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_left

--- a/core/components/atoms/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/core/components/atoms/dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -76,7 +75,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -120,7 +118,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -164,7 +161,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -202,7 +198,6 @@ exports[`Dropdown component
             <i
               class="material-symbols material-symbols-rounded Icon Icon--default d-flex align-items-center mr-4"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -216,7 +211,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -266,7 +260,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -310,7 +303,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -349,7 +341,6 @@ exports[`Dropdown component
             <i
               class="material-symbols material-symbols-rounded Icon Icon--disabled d-flex align-items-center mr-4"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -363,7 +354,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--disabled"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -414,7 +404,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--disabled"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -459,7 +448,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--disabled"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -503,7 +491,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -547,7 +534,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -591,7 +577,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -635,7 +620,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -679,7 +663,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -714,7 +697,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             more_horiz
@@ -758,7 +740,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -802,7 +783,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -846,7 +826,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -890,7 +869,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -934,7 +912,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -978,7 +955,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1022,7 +998,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1066,7 +1041,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1110,7 +1084,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1154,7 +1127,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1198,7 +1170,6 @@ exports[`Dropdown component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down

--- a/core/components/atoms/helpText/__tests__/__snapshots__/HelpText.test.tsx.snap
+++ b/core/components/atoms/helpText/__tests__/__snapshots__/HelpText.test.tsx.snap
@@ -31,7 +31,6 @@ exports[`HelpText component snapshot
       <i
         class="material-symbols material-symbols-rounded Icon Icon--alert InlineMessage-icon--small"
         data-test="DesignSystem-InlineMessage--Icon"
-        role="button"
         style="font-size: 14px; width: 14px;"
       >
         error

--- a/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
+++ b/core/components/atoms/input/__tests__/__snapshots__/Input.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`Input Component - Disabled State with Icon Snapshot Tests
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -104,7 +103,6 @@ exports[`Input Component - Disabled State without Change Handler Snapshot Tests
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -164,7 +162,6 @@ exports[`Input Component - Error State with Icon Snapshot Tests
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -223,7 +220,6 @@ exports[`Input Component - Icon and Placeholder Variants Snapshot Tests
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -283,7 +279,6 @@ exports[`Input Component - Icon and Placeholder Variants Snapshot Tests
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -508,7 +503,6 @@ exports[`Input Component - ReadOnly State with Icon Snapshot Tests
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events

--- a/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -102,7 +102,6 @@ exports[`Label component - info prop tests
             aria-label="long information text"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             info
@@ -136,7 +135,6 @@ exports[`Label component - info prop tests
             aria-label="sample info"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             info
@@ -170,7 +168,6 @@ exports[`Label component - info prop tests
             aria-label="tooltip text"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             info
@@ -261,7 +258,6 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
             aria-label="Small label info"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             info

--- a/core/components/atoms/linkButton/__tests__/__snapshots__/LinkButton.test.tsx.snap
+++ b/core/components/atoms/linkButton/__tests__/__snapshots__/LinkButton.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -44,7 +43,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -72,7 +70,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -100,7 +97,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -128,7 +124,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -156,7 +151,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -185,7 +179,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -214,7 +207,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -243,7 +235,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -272,7 +263,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -301,7 +291,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -330,7 +319,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -358,7 +346,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -386,7 +373,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -414,7 +400,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -442,7 +427,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -470,7 +454,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -498,7 +481,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -527,7 +509,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -556,7 +537,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -585,7 +565,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -614,7 +593,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -643,7 +621,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -672,7 +649,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -700,7 +676,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -728,7 +703,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -756,7 +730,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -784,7 +757,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -812,7 +784,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -840,7 +811,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -869,7 +839,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -898,7 +867,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -927,7 +895,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -956,7 +923,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -985,7 +951,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1014,7 +979,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1042,7 +1006,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1070,7 +1033,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1098,7 +1060,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1126,7 +1087,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1154,7 +1114,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1182,7 +1141,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1211,7 +1169,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1240,7 +1197,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1269,7 +1225,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1298,7 +1253,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1327,7 +1281,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1356,7 +1309,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1384,7 +1336,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1412,7 +1363,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1440,7 +1390,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1468,7 +1417,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1496,7 +1444,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1524,7 +1471,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1553,7 +1499,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1582,7 +1527,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1611,7 +1555,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1640,7 +1583,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1669,7 +1611,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1698,7 +1639,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events
@@ -1726,7 +1666,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1754,7 +1693,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1782,7 +1720,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1810,7 +1747,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1838,7 +1774,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1866,7 +1801,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1895,7 +1829,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1924,7 +1857,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1953,7 +1885,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -1982,7 +1913,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -2011,7 +1941,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events
@@ -2040,7 +1969,6 @@ exports[`Link Button component snapshots
         <i
           class="material-symbols material-symbols-rounded Icon"
           data-test="DesignSystem-LinkButton--Icon"
-          role="button"
           style="font-size: 12px; width: 12px;"
         >
           events

--- a/core/components/atoms/message/__tests__/__snapshots__/Message.test.tsx.snap
+++ b/core/components/atoms/message/__tests__/__snapshots__/Message.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`Message component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--alert Message-icon--alert Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         error
@@ -65,9 +65,9 @@ exports[`Message component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--alert Message-icon--alert Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         error
@@ -119,9 +119,9 @@ exports[`Message component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--alert Message-icon--alert Message-icon--small Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 14px; width: 14px;"
       >
         error
@@ -173,9 +173,9 @@ exports[`Message component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         info
@@ -227,9 +227,9 @@ exports[`Message component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         info
@@ -281,9 +281,9 @@ exports[`Message component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--small Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 14px; width: 14px;"
       >
         info
@@ -335,9 +335,9 @@ exports[`Message component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--success Message-icon--success Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -389,9 +389,9 @@ exports[`Message component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--success Message-icon--success Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -443,9 +443,9 @@ exports[`Message component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--success Message-icon--success Message-icon--small Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 14px; width: 14px;"
       >
         check_circle
@@ -497,9 +497,9 @@ exports[`Message component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--warning Message-icon--warning Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         warning
@@ -551,9 +551,9 @@ exports[`Message component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--warning Message-icon--warning Message-icon--regular Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         warning
@@ -605,9 +605,9 @@ exports[`Message component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Icon--warning Message-icon--warning Message-icon--small Message-icon--withTitle"
         data-test="DesignSystem-Message--Icon"
-        role="button"
         style="font-size: 14px; width: 14px;"
       >
         warning

--- a/core/components/atoms/metaList/__tests__/__snapshots__/MetaList.test.tsx.snap
+++ b/core/components/atoms/metaList/__tests__/__snapshots__/MetaList.test.tsx.snap
@@ -21,7 +21,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
               data-test="DesignSystem-MetaList--MetaIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               assessment
@@ -52,7 +51,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
             data-test="DesignSystem-MetaList--MetaIcon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assessment
@@ -142,7 +140,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
               data-test="DesignSystem-MetaList--MetaIcon"
-              role="button"
               style="font-size: 12px; width: 12px;"
             >
               assessment
@@ -173,7 +170,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
             data-test="DesignSystem-MetaList--MetaIcon"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             assessment
@@ -256,7 +252,6 @@ Object {
         <i
           class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator MetaList-seperator--left"
           data-test="DesignSystem-MetaList--Seperator"
-          role="button"
           style="font-size: 8px; width: 8px;"
         >
           fiber_manual_record
@@ -271,7 +266,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
               data-test="DesignSystem-MetaList--MetaIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               assessment
@@ -295,7 +289,6 @@ Object {
       <i
         class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator MetaList-seperator--left"
         data-test="DesignSystem-MetaList--Seperator"
-        role="button"
         style="font-size: 8px; width: 8px;"
       >
         fiber_manual_record
@@ -310,7 +303,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
             data-test="DesignSystem-MetaList--MetaIcon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assessment
@@ -393,7 +385,6 @@ Object {
         <i
           class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator MetaList-seperator--left"
           data-test="DesignSystem-MetaList--Seperator"
-          role="button"
           style="font-size: 8px; width: 8px;"
         >
           fiber_manual_record
@@ -408,7 +399,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
               data-test="DesignSystem-MetaList--MetaIcon"
-              role="button"
               style="font-size: 12px; width: 12px;"
             >
               assessment
@@ -432,7 +422,6 @@ Object {
       <i
         class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator MetaList-seperator--left"
         data-test="DesignSystem-MetaList--Seperator"
-        role="button"
         style="font-size: 8px; width: 8px;"
       >
         fiber_manual_record
@@ -447,7 +436,6 @@ Object {
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle Meta-icon"
             data-test="DesignSystem-MetaList--MetaIcon"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             assessment

--- a/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
+++ b/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`MetricInput component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--subtle MetricInput-icon MetricInput-icon--regular"
         data-test="DesignSystem-MetricInput--icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -36,7 +35,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             keyboard_arrow_up
@@ -51,7 +49,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             keyboard_arrow_down
@@ -76,7 +73,6 @@ exports[`MetricInput component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--subtle MetricInput-icon MetricInput-icon--regular"
         data-test="DesignSystem-MetricInput--icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         events
@@ -99,7 +95,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             keyboard_arrow_up
@@ -114,7 +109,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             keyboard_arrow_down
@@ -167,7 +161,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_up
@@ -182,7 +175,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -235,7 +227,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             keyboard_arrow_up
@@ -250,7 +241,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             keyboard_arrow_down
@@ -303,7 +293,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             keyboard_arrow_up
@@ -318,7 +307,6 @@ exports[`MetricInput component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 12px; width: 12px;"
           >
             keyboard_arrow_down

--- a/core/components/atoms/segmentedControl/__tests__/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/core/components/atoms/segmentedControl/__tests__/__snapshots__/SegmentedControl.test.tsx.snap
@@ -370,7 +370,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             home
@@ -397,7 +396,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             settings
@@ -424,7 +422,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             person
@@ -465,7 +462,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             home
@@ -492,7 +488,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             settings
@@ -519,7 +514,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             person
@@ -560,7 +554,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             home
@@ -587,7 +580,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             settings
@@ -614,7 +606,6 @@ exports[`SegmentedControl Component - Icon + Label Snapshot Tests matches snapsh
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             person
@@ -655,7 +646,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             home
@@ -677,7 +667,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             settings
@@ -699,7 +688,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             person
@@ -735,7 +723,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             home
@@ -757,7 +744,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             settings
@@ -779,7 +765,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             person
@@ -815,7 +800,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             home
@@ -837,7 +821,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             settings
@@ -859,7 +842,6 @@ exports[`SegmentedControl Component - Icon Only Snapshot Tests matches snapshot 
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 14px; width: 14px;"
           >
             person

--- a/core/components/atoms/toast/__tests__/__snapshots__/Toast.test.tsx.snap
+++ b/core/components/atoms/toast/__tests__/__snapshots__/Toast.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`Toast component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--alert"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         error
@@ -58,9 +58,9 @@ exports[`Toast component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         info
@@ -105,9 +105,9 @@ exports[`Toast component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--success"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -152,9 +152,9 @@ exports[`Toast component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--warning"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         warning
@@ -199,9 +199,9 @@ exports[`Toast component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--alert"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         error
@@ -252,9 +252,9 @@ exports[`Toast component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--alert"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         error
@@ -319,9 +319,9 @@ exports[`Toast component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         info
@@ -372,9 +372,9 @@ exports[`Toast component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         info
@@ -439,9 +439,9 @@ exports[`Toast component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--success"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -492,9 +492,9 @@ exports[`Toast component
       role="status"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--success"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -559,9 +559,9 @@ exports[`Toast component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--warning"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         warning
@@ -612,9 +612,9 @@ exports[`Toast component
       role="alert"
     >
       <i
+        aria-hidden="true"
         class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--warning"
         data-test="DesignSystem-Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         warning

--- a/core/components/molecules/chat/chatBubble/__tests__/__snapshots__/ChatBubble.test.tsx.snap
+++ b/core/components/molecules/chat/chatBubble/__tests__/__snapshots__/ChatBubble.test.tsx.snap
@@ -343,7 +343,6 @@ Object {
             aria-label="Message sent successfully"
             class="material-symbols material-symbols-rounded Icon Icon--success ml-3"
             data-test="DesignSystem-OutgoingChatBubble-Status"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             check_circle
@@ -426,7 +425,6 @@ Object {
           aria-label="Message sent successfully"
           class="material-symbols material-symbols-rounded Icon Icon--success ml-3"
           data-test="DesignSystem-OutgoingChatBubble-Status"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           check_circle

--- a/core/components/molecules/chat/chatInput/__tests__/__snapshots__/ChatInput.test.tsx.snap
+++ b/core/components/molecules/chat/chatInput/__tests__/__snapshots__/ChatInput.test.tsx.snap
@@ -33,7 +33,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               arrow_upward_alt
@@ -79,7 +78,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               stop
@@ -126,7 +124,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               arrow_upward_alt
@@ -173,7 +170,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               stop
@@ -221,7 +217,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               arrow_upward_alt
@@ -269,7 +264,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               stop
@@ -318,7 +312,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               arrow_upward_alt
@@ -367,7 +360,6 @@ exports[`ChatInput component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               stop

--- a/core/components/molecules/chat/unreadMessage/__tests__/__snapshots__/UnreadMessage.test.tsx.snap
+++ b/core/components/molecules/chat/unreadMessage/__tests__/__snapshots__/UnreadMessage.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`Chat Unread Message component snapshot
           <i
             class="material-symbols material-symbols-rounded Icon Icon--white mr-3"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             arrow_Downward

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -45,7 +45,6 @@ exports[`ChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -79,7 +78,6 @@ exports[`ChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -155,7 +153,6 @@ exports[`ChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -189,7 +186,6 @@ exports[`ChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -265,7 +261,6 @@ exports[`ChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -299,7 +294,6 @@ exports[`ChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear

--- a/core/components/molecules/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
+++ b/core/components/molecules/dialog/__tests__/__snapshots__/Dialog.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -211,7 +210,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -353,7 +351,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -496,7 +493,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -639,7 +635,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -782,7 +777,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -925,7 +919,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1068,7 +1061,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1211,7 +1203,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1354,7 +1345,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1497,7 +1487,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1640,7 +1629,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1783,7 +1771,6 @@ exports[`Dialog component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close

--- a/core/components/molecules/dropzone/__tests__/__snapshots__/Dropzone.test.tsx.snap
+++ b/core/components/molecules/dropzone/__tests__/__snapshots__/Dropzone.test.tsx.snap
@@ -215,7 +215,6 @@ exports[`Dropzone component snapshot
           aria-label="Drag your files here or click to select files"
           class="Text Text--disabled Text--strong Text--large ml-2 cursor-pointer"
           data-test="DesignSystem-Text"
-          role="button"
           tabindex="-1"
         >
           browse files
@@ -279,7 +278,6 @@ exports[`Dropzone component snapshot
           aria-label="Drag your files here or click to select files"
           class="Text Text--disabled Text--strong Text--large ml-2 cursor-pointer"
           data-test="DesignSystem-Text"
-          role="button"
           tabindex="-1"
         >
           browse files
@@ -332,7 +330,6 @@ exports[`Dropzone component snapshot
           aria-label="Drag your files here or click to select files"
           class="Text Text--disabled Text--strong Text--large ml-2 cursor-pointer"
           data-test="DesignSystem-Text"
-          role="button"
           tabindex="-1"
         >
           browse files

--- a/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
+++ b/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -82,7 +81,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -144,7 +142,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -178,7 +175,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -240,7 +236,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 12px; width: 12px;"
               >
                 clear
@@ -274,7 +269,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 12px; width: 12px;"
               >
                 clear
@@ -336,7 +330,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -370,7 +363,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -432,7 +424,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -466,7 +457,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 clear
@@ -528,7 +518,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 12px; width: 12px;"
               >
                 clear
@@ -562,7 +551,6 @@ exports[`EditableChipInput component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--subtle"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 12px; width: 12px;"
               >
                 clear

--- a/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
+++ b/core/components/molecules/editableDropdown/__tests__/__snapshots__/EditableDropdown.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`EditableDropdown component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--default"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down

--- a/core/components/molecules/emptyState/_tests_/__snapshots__/EmptyState.test.tsx.snap
+++ b/core/components/molecules/emptyState/_tests_/__snapshots__/EmptyState.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`EmptyState component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 32px; width: 32px;"
           >
             events
@@ -156,7 +155,6 @@ exports[`EmptyState component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 32px; width: 32px;"
           >
             events
@@ -216,7 +214,6 @@ exports[`EmptyState component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 32px; width: 32px;"
           >
             events

--- a/core/components/molecules/fileList/__tests__/__snapshots__/FileList.test.tsx.snap
+++ b/core/components/molecules/fileList/__tests__/__snapshots__/FileList.test.tsx.snap
@@ -80,7 +80,6 @@ exports[`FileList component
           <i
             class="material-symbols material-symbols-rounded Icon FileIcon FileIcon--animate FileIcon--video"
             data-test="DesignSystem-FileListItem--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             movie
@@ -119,7 +118,6 @@ exports[`FileList component
           <i
             class="material-symbols material-symbols-rounded Icon FileIcon FileIcon--image"
             data-test="DesignSystem-FileListItem--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             image
@@ -149,7 +147,6 @@ exports[`FileList component
         <i
           class="material-symbols material-symbols-rounded Icon Icon--alert InlineMessage-icon--small"
           data-test="DesignSystem-InlineMessage--Icon"
-          role="button"
           style="font-size: 14px; width: 14px;"
         >
           error
@@ -177,7 +174,6 @@ exports[`FileList component
           <i
             class="material-symbols material-symbols-rounded Icon FileIcon FileIcon--animate FileIcon--application"
             data-test="DesignSystem-FileListItem--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             insert_drive_file
@@ -216,7 +212,6 @@ exports[`FileList component
           <i
             class="material-symbols material-symbols-rounded Icon FileIcon FileIcon--animate FileIcon--others"
             data-test="DesignSystem-FileListItem--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             text_snippet

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`FileUploader component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             backup
@@ -101,7 +100,6 @@ exports[`FileUploader component prop:accept snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             backup
@@ -161,7 +159,6 @@ exports[`FileUploader component prop:disabled snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             backup
@@ -221,7 +218,6 @@ exports[`FileUploader component prop:disabled snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             backup
@@ -281,7 +277,6 @@ exports[`FileUploader component prop:multiple snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             backup
@@ -340,7 +335,6 @@ exports[`FileUploader component prop:multiple snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             backup

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploaderList.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploaderList.test.tsx.snap
@@ -64,7 +64,6 @@ exports[`FileUploaderList component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 close
@@ -104,7 +103,6 @@ exports[`FileUploaderList component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 close
@@ -144,7 +142,6 @@ exports[`FileUploaderList component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 refresh
@@ -163,7 +160,6 @@ exports[`FileUploaderList component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 close
@@ -179,7 +175,6 @@ exports[`FileUploaderList component
         <i
           class="material-symbols material-symbols-rounded Icon Icon--alert InlineMessage-icon--small"
           data-test="DesignSystem-InlineMessage--Icon"
-          role="button"
           style="font-size: 14px; width: 14px;"
         >
           error

--- a/core/components/molecules/fullscreenModal/__tests__/__snapshots__/Fullscreen.test.tsx.snap
+++ b/core/components/molecules/fullscreenModal/__tests__/__snapshots__/Fullscreen.test.tsx.snap
@@ -63,7 +63,6 @@ exports[`FullscreenModal component
                       <i
                         class="material-symbols material-symbols-rounded Icon"
                         data-test="DesignSystem-Button--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         close
@@ -149,7 +148,6 @@ exports[`FullscreenModal component
                       <i
                         class="material-symbols material-symbols-rounded Icon"
                         data-test="DesignSystem-Button--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         close
@@ -279,7 +277,6 @@ exports[`FullscreenModal component
                       <i
                         class="material-symbols material-symbols-rounded Icon"
                         data-test="DesignSystem-Button--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         close
@@ -372,7 +369,6 @@ exports[`FullscreenModal component
                       <i
                         class="material-symbols material-symbols-rounded Icon"
                         data-test="DesignSystem-Button--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         close
@@ -457,7 +453,6 @@ exports[`FullscreenModal component
                       <i
                         class="material-symbols material-symbols-rounded Icon"
                         data-test="DesignSystem-Button--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         close
@@ -587,7 +582,6 @@ exports[`FullscreenModal component
                       <i
                         class="material-symbols material-symbols-rounded Icon"
                         data-test="DesignSystem-Button--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         close

--- a/core/components/molecules/modal/__tests__/__snapshots__/Modal.test.tsx.snap
+++ b/core/components/molecules/modal/__tests__/__snapshots__/Modal.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`Modal component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   close
@@ -160,7 +159,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -240,7 +238,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -299,7 +296,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -409,7 +405,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -468,7 +463,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -593,7 +587,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -652,7 +645,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -756,7 +748,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -815,7 +806,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -911,7 +901,6 @@ exports[`Modal component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   close
@@ -1004,7 +993,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1084,7 +1072,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1143,7 +1130,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1253,7 +1239,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -1312,7 +1297,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -1437,7 +1421,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1496,7 +1479,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1600,7 +1582,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -1659,7 +1640,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -1756,7 +1736,6 @@ exports[`Modal component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   close
@@ -1848,7 +1827,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1928,7 +1906,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -1987,7 +1964,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -2097,7 +2073,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -2156,7 +2131,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -2281,7 +2255,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -2340,7 +2313,6 @@ exports[`Modal component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     close
@@ -2444,7 +2416,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close
@@ -2503,7 +2474,6 @@ exports[`Modal component
                     <i
                       class="material-symbols material-symbols-rounded Icon"
                       data-test="DesignSystem-Button--Icon"
-                      role="button"
                       style="font-size: 16px; width: 16px;"
                     >
                       close

--- a/core/components/molecules/overlayHeader/__tests__/__snapshots__/OverlayHeader.test.tsx.snap
+++ b/core/components/molecules/overlayHeader/__tests__/__snapshots__/OverlayHeader.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`OverlayHeader component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 20px; width: 20px;"
           >
             arrow_back

--- a/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             first_page
@@ -42,7 +41,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             navigate_before
@@ -65,7 +63,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             navigate_next
@@ -84,7 +81,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             last_page
@@ -119,7 +115,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             first_page
@@ -138,7 +133,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             navigate_before
@@ -173,7 +167,6 @@ exports[`Pagination component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               keyboard_arrow_up
@@ -188,7 +181,6 @@ exports[`Pagination component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 14px; width: 14px;"
             >
               keyboard_arrow_down
@@ -218,7 +210,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             navigate_next
@@ -237,7 +228,6 @@ exports[`Pagination component
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             last_page

--- a/core/components/molecules/sidesheet/__tests__/__snapshots__/Sidesheet.test.tsx.snap
+++ b/core/components/molecules/sidesheet/__tests__/__snapshots__/Sidesheet.test.tsx.snap
@@ -73,7 +73,6 @@ exports[`Sidesheet component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 20px; width: 20px;"
                   >
                     close
@@ -175,7 +174,6 @@ exports[`Sidesheet component
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 20px; width: 20px;"
                   >
                     close

--- a/core/components/molecules/stepper/__tests__/__snapshots__/Stepper.test.tsx.snap
+++ b/core/components/molecules/stepper/__tests__/__snapshots__/Stepper.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`Stepper component
       <i
         class="material-symbols material-symbols-rounded Icon mr-3 my-4 Stepper-animate"
         data-test="DesignSystem-Step--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -38,7 +37,6 @@ exports[`Stepper component
       <i
         class="material-symbols material-symbols-outlined Icon mr-3 my-4 Stepper-animate"
         data-test="DesignSystem-Step--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         radio_button_unchecked
@@ -60,7 +58,6 @@ exports[`Stepper component
       <i
         class="material-symbols material-symbols-outlined Icon mr-3 my-4 Stepper-animate"
         data-test="DesignSystem-Step--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         radio_button_unchecked
@@ -82,7 +79,6 @@ exports[`Stepper component
       <i
         class="material-symbols material-symbols-outlined Icon mr-3 my-4 Stepper-animate"
         data-test="DesignSystem-Step--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         radio_button_unchecked

--- a/core/components/molecules/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/core/components/molecules/tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`Tabs component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle mr-4 "
             data-test="DesignSystem-Tabs--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             call_received
@@ -181,7 +180,6 @@ exports[`Tabs component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle mr-4 "
             data-test="DesignSystem-Tabs--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             call_received
@@ -295,7 +293,6 @@ exports[`Tabs component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle mr-4 "
             data-test="DesignSystem-Tabs--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             call_received
@@ -409,7 +406,6 @@ exports[`Tabs component
           <i
             class="material-symbols material-symbols-rounded Icon Icon--subtle mr-4 "
             data-test="DesignSystem-Tabs--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             call_received

--- a/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
+++ b/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -51,7 +50,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -69,7 +67,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -89,7 +86,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -672,7 +668,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -694,7 +689,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -712,7 +706,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -733,7 +726,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -1317,7 +1309,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -1339,7 +1330,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -1357,7 +1347,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -1377,7 +1366,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -1961,7 +1949,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -1983,7 +1970,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -2001,7 +1987,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -2022,7 +2007,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -2605,7 +2589,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -2627,7 +2610,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -2645,7 +2627,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -2665,7 +2646,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -3248,7 +3228,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -3270,7 +3249,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -3288,7 +3266,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -3308,7 +3285,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -3891,7 +3867,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -3913,7 +3888,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -3931,7 +3905,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -3951,7 +3924,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -4534,7 +4506,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -4556,7 +4527,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -4574,7 +4544,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -4594,7 +4563,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -5177,7 +5145,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -5199,7 +5166,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -5217,7 +5183,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -5237,7 +5202,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -5820,7 +5784,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -5842,7 +5805,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -5860,7 +5822,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -5880,7 +5841,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -6463,7 +6423,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -6485,7 +6444,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -6503,7 +6461,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -6523,7 +6480,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -7106,7 +7062,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -7128,7 +7083,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -7146,7 +7100,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -7166,7 +7119,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -7749,7 +7701,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -7771,7 +7722,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -7789,7 +7739,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -8251,7 +8200,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -8269,7 +8217,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -8289,7 +8236,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -8770,7 +8716,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -8792,7 +8737,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -8810,7 +8754,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -9272,7 +9215,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -9290,7 +9232,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -9745,7 +9686,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -9763,7 +9703,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -9783,7 +9722,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -10331,7 +10269,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -10353,7 +10290,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -10371,7 +10307,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -10391,7 +10326,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -10974,7 +10908,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -10996,7 +10929,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -11016,7 +10948,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -11211,7 +11142,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -11245,7 +11175,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -11440,7 +11369,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -11462,7 +11390,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -11480,7 +11407,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -11500,7 +11426,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -12083,7 +12008,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -12105,7 +12029,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -12123,7 +12046,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -12585,7 +12507,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -12603,7 +12524,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -12623,7 +12543,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -13104,7 +13023,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -13126,7 +13044,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -13144,7 +13061,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -13606,7 +13522,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -13624,7 +13539,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -14079,7 +13993,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -14097,7 +14010,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -14117,7 +14029,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -14665,7 +14576,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -14687,7 +14597,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -14705,7 +14614,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -14725,7 +14633,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -15308,7 +15215,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -15330,7 +15236,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -15350,7 +15255,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -15545,7 +15449,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -15579,7 +15482,6 @@ exports[`Calendar component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -33,7 +33,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -55,7 +54,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -73,7 +71,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -93,7 +90,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledAfter
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -706,7 +702,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -728,7 +723,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -746,7 +740,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -766,7 +759,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -1379,7 +1371,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -1401,7 +1392,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -1419,7 +1409,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -1439,7 +1428,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:disabledBefore
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -2051,7 +2039,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -2073,7 +2060,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -2091,7 +2077,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -2111,7 +2096,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -2723,7 +2707,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -2745,7 +2728,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -2763,7 +2745,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -2783,7 +2764,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:open
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -3395,7 +3375,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -3417,7 +3396,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -3435,7 +3413,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -3455,7 +3432,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -4067,7 +4043,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -4089,7 +4064,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -4109,7 +4083,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -4333,7 +4306,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -4367,7 +4339,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:view
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -4591,7 +4562,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_back
@@ -4613,7 +4583,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -4631,7 +4600,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                     data-test="DesignSystem-Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     keyboard_arrow_down
@@ -4651,7 +4619,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
                   <i
                     class="material-symbols material-symbols-rounded Icon"
                     data-test="DesignSystem-Button--Icon"
-                    role="button"
                     style="font-size: 16px; width: 16px;"
                   >
                     arrow_forward
@@ -5255,7 +5222,6 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events

--- a/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/core/components/organisms/dateRangePicker/__tests__/__snapshots__/DateRangePicker.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -73,7 +72,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -656,7 +654,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -700,7 +697,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -1284,7 +1280,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -1328,7 +1323,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -1912,7 +1906,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -1956,7 +1949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -2539,7 +2531,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -2583,7 +2574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -3166,7 +3156,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -3210,7 +3199,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -3793,7 +3781,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -3837,7 +3824,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -4420,7 +4406,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -4464,7 +4449,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -5047,7 +5031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -5091,7 +5074,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -5674,7 +5656,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -5718,7 +5699,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -6301,7 +6281,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -6345,7 +6324,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -6928,7 +6906,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -6972,7 +6949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -7555,7 +7531,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -7599,7 +7574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -8182,7 +8156,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -8226,7 +8199,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -8809,7 +8781,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -8853,7 +8824,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -9436,7 +9406,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -9480,7 +9449,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -10063,7 +10031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -10107,7 +10074,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -10690,7 +10656,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -10734,7 +10699,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -11317,7 +11281,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -11361,7 +11324,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -11944,7 +11906,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -11988,7 +11949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -12571,7 +12531,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -12615,7 +12574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -13198,7 +13156,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -13242,7 +13199,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -13825,7 +13781,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -13869,7 +13824,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -14452,7 +14406,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -14496,7 +14449,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -15079,7 +15031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -15123,7 +15074,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -15706,7 +15656,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -15750,7 +15699,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -16333,7 +16281,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -16377,7 +16324,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -16960,7 +16906,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -17004,7 +16949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -17587,7 +17531,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -17631,7 +17574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -18214,7 +18156,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -18258,7 +18199,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -18841,7 +18781,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -18885,7 +18824,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -19468,7 +19406,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -19512,7 +19449,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -20095,7 +20031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -20139,7 +20074,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -20722,7 +20656,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -20766,7 +20699,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -21349,7 +21281,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -21393,7 +21324,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -21976,7 +21906,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -22020,7 +21949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -22603,7 +22531,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -22647,7 +22574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -23230,7 +23156,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -23274,7 +23199,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -23857,7 +23781,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -23901,7 +23824,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -24484,7 +24406,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -24528,7 +24449,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -25111,7 +25031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -25155,7 +25074,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -25738,7 +25656,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -25782,7 +25699,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -26365,7 +26281,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -26409,7 +26324,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -26992,7 +26906,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -27036,7 +26949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -27619,7 +27531,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -27663,7 +27574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -28246,7 +28156,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -28290,7 +28199,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -28873,7 +28781,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -28917,7 +28824,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -29500,7 +29406,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -29544,7 +29449,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -30127,7 +30031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -30621,7 +30524,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -31116,7 +31018,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -32074,7 +31975,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -32548,7 +32448,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -32592,7 +32491,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -33175,7 +33073,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -33690,7 +33587,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -34164,7 +34060,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -35136,7 +35031,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -35677,7 +35571,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -35721,7 +35614,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -36304,7 +36196,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -36833,7 +36724,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -37374,7 +37264,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -38399,7 +38288,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -38887,7 +38775,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -38931,7 +38818,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -39514,7 +39400,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -39548,7 +39433,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -39743,7 +39627,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -39777,7 +39660,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -39987,7 +39869,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -40049,7 +39930,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -40130,7 +40010,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -40192,7 +40071,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -40273,7 +40151,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -40335,7 +40212,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -40401,7 +40277,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -40445,7 +40320,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -41028,7 +40902,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -41062,7 +40935,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -41257,7 +41129,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -41291,7 +41162,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -41501,7 +41371,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -41563,7 +41432,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -41644,7 +41512,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -41706,7 +41573,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -41787,7 +41653,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -41849,7 +41714,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -41915,7 +41779,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -41959,7 +41822,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -42542,7 +42404,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -42576,7 +42437,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -42771,7 +42631,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -42805,7 +42664,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -43015,7 +42873,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -43077,7 +42934,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -43142,7 +42998,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -43657,7 +43512,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -44146,7 +44000,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -44208,7 +44061,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -44273,7 +44125,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -44788,7 +44639,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -45277,7 +45127,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -45339,7 +45188,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -45404,7 +45252,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -45919,7 +45766,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -46393,7 +46239,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -46437,7 +46282,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -47020,7 +46864,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -47054,7 +46897,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -47249,7 +47091,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -47283,7 +47124,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -47493,7 +47333,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -47555,7 +47394,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -47620,7 +47458,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -48135,7 +47972,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -48624,7 +48460,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -48686,7 +48521,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -48751,7 +48585,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -49266,7 +49099,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -49755,7 +49587,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -49817,7 +49648,6 @@ exports[`DateRangePicker component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   events
@@ -49882,7 +49712,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_back
@@ -50397,7 +50226,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 14px; width: 14px;"
               >
                 arrow_forward
@@ -50871,7 +50699,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -50915,7 +50742,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -51498,7 +51324,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -51542,7 +51367,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52125,7 +51949,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52167,7 +51990,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52263,7 +52085,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52305,7 +52126,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52401,7 +52221,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52443,7 +52262,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52539,7 +52357,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52581,7 +52398,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52677,7 +52493,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52719,7 +52534,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52815,7 +52629,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52857,7 +52670,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -52953,7 +52765,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -52995,7 +52806,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53091,7 +52901,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53133,7 +52942,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53229,7 +53037,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53271,7 +53078,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53367,7 +53173,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53409,7 +53214,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53505,7 +53309,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53547,7 +53350,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53643,7 +53445,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53685,7 +53486,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53781,7 +53581,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53823,7 +53622,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -53919,7 +53717,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -53961,7 +53758,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -54057,7 +53853,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -54099,7 +53894,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -54195,7 +53989,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -54237,7 +54030,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -54333,7 +54125,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -54377,7 +54168,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -54960,7 +54750,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -55004,7 +54793,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -55587,7 +55375,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -55631,7 +55418,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -56214,7 +56000,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -56258,7 +56043,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -56841,7 +56625,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -56885,7 +56668,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -57468,7 +57250,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -57512,7 +57293,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -58095,7 +57875,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -58139,7 +57918,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -58722,7 +58500,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -58766,7 +58543,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -59349,7 +59125,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -59393,7 +59168,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -59976,7 +59750,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -60020,7 +59793,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -60603,7 +60375,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -60647,7 +60418,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -61230,7 +61000,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -61274,7 +61043,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -61857,7 +61625,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -61901,7 +61668,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -62484,7 +62250,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -62528,7 +62293,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -63111,7 +62875,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -63155,7 +62918,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -63738,7 +63500,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -63782,7 +63543,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -64365,7 +64125,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -64407,7 +64166,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -64503,7 +64261,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -64545,7 +64302,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -64641,7 +64397,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -64683,7 +64438,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -64779,7 +64533,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -64821,7 +64574,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -64917,7 +64669,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -64959,7 +64710,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65055,7 +64805,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65097,7 +64846,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65193,7 +64941,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65235,7 +64982,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65331,7 +65077,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65373,7 +65118,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65469,7 +65213,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65511,7 +65254,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65607,7 +65349,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65649,7 +65390,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65745,7 +65485,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65787,7 +65526,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -65883,7 +65621,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -65925,7 +65662,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -66021,7 +65757,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -66063,7 +65798,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -66159,7 +65893,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -66201,7 +65934,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -66297,7 +66029,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -66339,7 +66070,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -66435,7 +66165,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -66477,7 +66206,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -66573,7 +66301,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -66617,7 +66344,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -67200,7 +66926,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -67244,7 +66969,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -67827,7 +67551,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -67871,7 +67594,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -68454,7 +68176,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -68498,7 +68219,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -69081,7 +68801,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -69125,7 +68844,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -69708,7 +69426,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -69752,7 +69469,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -70335,7 +70051,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -70379,7 +70094,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -70962,7 +70676,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -71006,7 +70719,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -71589,7 +71301,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -71633,7 +71344,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -72216,7 +71926,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -72260,7 +71969,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -72843,7 +72551,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -72887,7 +72594,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -73470,7 +73176,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -73514,7 +73219,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -74097,7 +73801,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -74141,7 +73844,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -74724,7 +74426,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -74768,7 +74469,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -75351,7 +75051,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -75395,7 +75094,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -75978,7 +75676,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -76022,7 +75719,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -76605,7 +76301,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -76649,7 +76344,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -77232,7 +76926,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -77276,7 +76969,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward
@@ -77859,7 +77551,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_back
@@ -77903,7 +77594,6 @@ exports[`DateRangePicker component
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Button--Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 arrow_forward

--- a/core/components/organisms/horizontalNav/__tests__/__snapshots__/HorizontalNav.test.tsx.snap
+++ b/core/components/organisms/horizontalNav/__tests__/__snapshots__/HorizontalNav.test.tsx.snap
@@ -18,7 +18,6 @@ exports[`Horizontal Navigation component
         <i
           class="material-symbols material-symbols-rounded Icon mr-3 HorizontalNav-animate"
           data-test="DesignSystem-HorizontalNav--Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           events

--- a/core/components/organisms/inlineMessage/__tests__/__snapshots__/InlineMessage.test.tsx.snap
+++ b/core/components/organisms/inlineMessage/__tests__/__snapshots__/InlineMessage.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`InlineMessage component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--alert InlineMessage-icon--regular"
         data-test="DesignSystem-InlineMessage--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         error
@@ -60,7 +59,6 @@ exports[`InlineMessage component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--info InlineMessage-icon--regular"
         data-test="DesignSystem-InlineMessage--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         info
@@ -88,7 +86,6 @@ exports[`InlineMessage component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--success InlineMessage-icon--regular"
         data-test="DesignSystem-InlineMessage--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         check_circle
@@ -116,7 +113,6 @@ exports[`InlineMessage component
       <i
         class="material-symbols material-symbols-rounded Icon Icon--warning InlineMessage-icon--warning InlineMessage-icon--regular"
         data-test="DesignSystem-InlineMessage--Icon"
-        role="button"
         style="font-size: 16px; width: 16px;"
       >
         warning

--- a/core/components/organisms/listbox/__tests__/__snapshots__/Listbox.test.tsx.snap
+++ b/core/components/organisms/listbox/__tests__/__snapshots__/Listbox.test.tsx.snap
@@ -2369,7 +2369,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2414,7 +2413,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2464,7 +2462,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2509,7 +2506,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2559,7 +2555,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2604,7 +2599,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2654,7 +2648,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2699,7 +2692,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2749,7 +2741,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2794,7 +2785,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2844,7 +2834,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2889,7 +2878,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2939,7 +2927,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -2984,7 +2971,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3034,7 +3020,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3079,7 +3064,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3129,7 +3113,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3174,7 +3157,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3224,7 +3206,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3269,7 +3250,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3319,7 +3299,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3364,7 +3343,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3414,7 +3392,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3459,7 +3436,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3509,7 +3485,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3554,7 +3529,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3604,7 +3578,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3649,7 +3622,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3699,7 +3671,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3744,7 +3715,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3794,7 +3764,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3839,7 +3808,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3889,7 +3857,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3934,7 +3901,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -3984,7 +3950,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4029,7 +3994,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4079,7 +4043,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4149,7 +4112,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4192,7 +4154,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4242,7 +4203,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4287,7 +4247,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4337,7 +4296,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4382,7 +4340,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4432,7 +4389,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4477,7 +4433,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4527,7 +4482,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4572,7 +4526,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4622,7 +4575,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4667,7 +4619,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4717,7 +4668,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4762,7 +4712,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4812,7 +4761,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4857,7 +4805,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4907,7 +4854,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -4952,7 +4898,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5002,7 +4947,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5047,7 +4991,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5097,7 +5040,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5142,7 +5084,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5192,7 +5133,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5237,7 +5177,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5287,7 +5226,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5332,7 +5270,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5382,7 +5319,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5427,7 +5363,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5477,7 +5412,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5522,7 +5456,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5572,7 +5505,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5617,7 +5549,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5667,7 +5598,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5712,7 +5642,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5762,7 +5691,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator
@@ -5807,7 +5735,6 @@ exports[`Listbox component snapshot
             <i
               class="material-symbols material-symbols-rounded Icon Icon--subtle Listbox-item--drag-icon"
               data-test="DesignSystem-Listbox-DragIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               drag_indicator

--- a/core/components/organisms/menu/__tests__/__snapshots__/Menu.test.tsx.snap
+++ b/core/components/organisms/menu/__tests__/__snapshots__/Menu.test.tsx.snap
@@ -170,7 +170,6 @@ exports[`Menu component with Nesting snapshot
               <i
                 class="material-symbols material-symbols-rounded Icon"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 chevron_right
@@ -208,7 +207,6 @@ exports[`Menu component with Trigger snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             more_horiz
@@ -244,7 +242,6 @@ exports[`Menu component with Trigger snapshot
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             more_horiz

--- a/core/components/organisms/navigation/__tests__/__snapshots__/Navigation.test.tsx.snap
+++ b/core/components/organisms/navigation/__tests__/__snapshots__/Navigation.test.tsx.snap
@@ -408,7 +408,6 @@ Object {
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--default Navigation-menuIcon"
                 data-test="DesignSystem-Navigation-VerticalNavigation--menuIcon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 event
@@ -468,7 +467,6 @@ Object {
             <i
               class="material-symbols material-symbols-rounded Icon Icon--default Navigation-menuIcon"
               data-test="DesignSystem-Navigation-VerticalNavigation--menuIcon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               event

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -59,7 +59,6 @@ exports[`Navigation component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 14px; width: 14px;"
                 >
                   arrow_back
@@ -158,7 +157,6 @@ exports[`Navigation component
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
                     data-test="DesignSystem-MetaList--rightSeperator"
-                    role="button"
                     style="font-size: 8px; width: 8px;"
                   >
                     fiber_manual_record
@@ -385,7 +383,6 @@ exports[`Navigation component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 14px; width: 14px;"
                 >
                   arrow_back
@@ -523,7 +520,6 @@ exports[`Navigation component
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
                     data-test="DesignSystem-MetaList--rightSeperator"
-                    role="button"
                     style="font-size: 8px; width: 8px;"
                   >
                     fiber_manual_record
@@ -716,7 +712,6 @@ exports[`Navigation component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 14px; width: 14px;"
                 >
                   arrow_back
@@ -815,7 +810,6 @@ exports[`Navigation component
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
                     data-test="DesignSystem-MetaList--rightSeperator"
-                    role="button"
                     style="font-size: 8px; width: 8px;"
                   >
                     fiber_manual_record
@@ -1193,7 +1187,6 @@ exports[`Navigation component
                       <i
                         class="material-symbols material-symbols-outlined Icon mr-3 my-4 Stepper-animate"
                         data-test="DesignSystem-Step--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         radio_button_unchecked
@@ -1215,7 +1208,6 @@ exports[`Navigation component
                       <i
                         class="material-symbols material-symbols-outlined Icon mr-3 my-4 Stepper-animate"
                         data-test="DesignSystem-Step--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         radio_button_unchecked
@@ -1237,7 +1229,6 @@ exports[`Navigation component
                       <i
                         class="material-symbols material-symbols-outlined Icon mr-3 my-4 Stepper-animate"
                         data-test="DesignSystem-Step--Icon"
-                        role="button"
                         style="font-size: 16px; width: 16px;"
                       >
                         radio_button_unchecked
@@ -1543,7 +1534,6 @@ exports[`Navigation component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 14px; width: 14px;"
                 >
                   arrow_back
@@ -1643,7 +1633,6 @@ exports[`Navigation component
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 14px; width: 14px;"
                 >
                   arrow_back
@@ -1781,7 +1770,6 @@ exports[`Navigation component
                   <i
                     class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
                     data-test="DesignSystem-MetaList--rightSeperator"
-                    role="button"
                     style="font-size: 8px; width: 8px;"
                   >
                     fiber_manual_record

--- a/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
+++ b/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -88,7 +87,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -138,7 +136,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -188,7 +185,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -238,7 +234,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -288,7 +283,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -338,7 +332,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -388,7 +381,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -438,7 +430,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -488,7 +479,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -538,7 +528,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -588,7 +577,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -638,7 +626,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -688,7 +675,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -738,7 +724,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -788,7 +773,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -838,7 +822,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -888,7 +871,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -938,7 +920,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -988,7 +969,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1038,7 +1018,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1088,7 +1067,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1138,7 +1116,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1188,7 +1165,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1238,7 +1214,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1288,7 +1263,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1338,7 +1312,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1388,7 +1361,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1438,7 +1410,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1488,7 +1459,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1538,7 +1508,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1588,7 +1557,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1638,7 +1606,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1688,7 +1655,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1738,7 +1704,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1788,7 +1753,6 @@ exports[`Select List component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1838,7 +1802,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1888,7 +1851,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1938,7 +1900,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -1988,7 +1949,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2038,7 +1998,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2088,7 +2047,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2138,7 +2096,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2188,7 +2145,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2238,7 +2194,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2288,7 +2243,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2338,7 +2292,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2388,7 +2341,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2438,7 +2390,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2488,7 +2439,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2538,7 +2488,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2588,7 +2537,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2638,7 +2586,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2688,7 +2635,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2738,7 +2684,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2788,7 +2733,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2838,7 +2782,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2888,7 +2831,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2938,7 +2880,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -2988,7 +2929,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3038,7 +2978,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3088,7 +3027,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3138,7 +3076,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3188,7 +3125,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3238,7 +3174,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3288,7 +3223,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3338,7 +3272,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3388,7 +3321,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3438,7 +3370,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3488,7 +3419,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3538,7 +3468,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3588,7 +3517,6 @@ exports[`Select Option component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3638,7 +3566,6 @@ exports[`Select component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -3688,7 +3615,6 @@ exports[`Select component snapshots
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down

--- a/core/components/organisms/textField/__test__/__snapshots__/Textarea.test.tsx.snap
+++ b/core/components/organisms/textField/__test__/__snapshots__/Textarea.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`TextField component matches snapshot when input exceeds maximum charact
         <i
           class="material-symbols material-symbols-rounded Icon Icon--alert InlineMessage-icon--small"
           data-test="DesignSystem-InlineMessage--Icon"
-          role="button"
           style="font-size: 14px; width: 14px;"
         >
           error

--- a/core/components/organisms/timePicker/__tests__/__snapshots__/TimePickerWithSearch.test.tsx.snap
+++ b/core/components/organisms/timePicker/__tests__/__snapshots__/TimePickerWithSearch.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -76,7 +75,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -120,7 +118,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -164,7 +161,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -208,7 +204,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -252,7 +247,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -296,7 +290,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down
@@ -340,7 +333,6 @@ exports[`TimePicker component snapshots renders snapshot for all props
           <i
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             keyboard_arrow_down

--- a/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
+++ b/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`Vertical Navigation component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-VerticalNav--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               assignment_ind
@@ -57,7 +56,6 @@ exports[`Vertical Navigation component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-VerticalNav--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               forum
@@ -82,7 +80,6 @@ exports[`Vertical Navigation component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-VerticalNav--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               assignment_ind
@@ -107,7 +104,6 @@ exports[`Vertical Navigation component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-VerticalNav--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               events
@@ -134,7 +130,6 @@ exports[`Vertical Navigation component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-VerticalNav--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               airline_seat_flat_angled
@@ -161,7 +156,6 @@ exports[`Vertical Navigation component
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-VerticalNav--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               favorite
@@ -210,7 +204,6 @@ exports[`Vertical Navigation component
           <i
             class="material-symbols material-symbols-rounded Icon mr-4"
             data-test="DesignSystem-VerticalNav--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assignment_ind
@@ -254,7 +247,6 @@ exports[`Vertical Navigation component
           <i
             class="material-symbols material-symbols-rounded Icon mr-4"
             data-test="DesignSystem-VerticalNav--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             forum
@@ -269,7 +261,6 @@ exports[`Vertical Navigation component
         <i
           class="material-symbols material-symbols-rounded Icon mx-4"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           keyboard_arrow_up
@@ -288,7 +279,6 @@ exports[`Vertical Navigation component
           <i
             class="material-symbols material-symbols-rounded Icon mr-4"
             data-test="DesignSystem-VerticalNav--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             assignment_ind
@@ -314,7 +304,6 @@ exports[`Vertical Navigation component
           <i
             class="material-symbols material-symbols-rounded Icon mr-4"
             data-test="DesignSystem-VerticalNav--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             events
@@ -342,7 +331,6 @@ exports[`Vertical Navigation component
           <i
             class="material-symbols material-symbols-rounded Icon mr-4"
             data-test="DesignSystem-VerticalNav--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             airline_seat_flat_angled
@@ -376,7 +364,6 @@ exports[`Vertical Navigation component
           <i
             class="material-symbols material-symbols-rounded Icon mr-4"
             data-test="DesignSystem-VerticalNav--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             favorite
@@ -391,7 +378,6 @@ exports[`Vertical Navigation component
         <i
           class="material-symbols material-symbols-rounded Icon mx-4"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           keyboard_arrow_down

--- a/core/components/patterns/forms/CreatePassword.story.tsx
+++ b/core/components/patterns/forms/CreatePassword.story.tsx
@@ -118,7 +118,7 @@ const customCode = `
                 type={this.state.passwordVisible ? 'text' : 'password'}
                 value={this.state.password}
                 onChange={this.onPasswordChange}
-                autocomplete="new-password"
+                autocomplete="off"
                 actionIcon={(
                   <Icon
                     name={this.state.passwordVisible ? 'visibility' : 'visibility_off'}
@@ -135,7 +135,7 @@ const customCode = `
                 type={this.state.confirmPasswordVisible ? 'text' : 'password'}
                 value={this.state.confirmPassword}
                 onChange={this.onConfirmPasswordChange}
-                autocomplete="new-password"
+                autocomplete="off"
                 actionIcon={(
                   <Icon
                     name={this.state.confirmPasswordVisible ? 'visibility' : 'visibility_off'}

--- a/core/components/patterns/forms/CreatePassword.story.tsx
+++ b/core/components/patterns/forms/CreatePassword.story.tsx
@@ -118,7 +118,7 @@ const customCode = `
                 type={this.state.passwordVisible ? 'text' : 'password'}
                 value={this.state.password}
                 onChange={this.onPasswordChange}
-                autocomplete="off"
+                autocomplete="new-password"
                 actionIcon={(
                   <Icon
                     name={this.state.passwordVisible ? 'visibility' : 'visibility_off'}
@@ -135,7 +135,7 @@ const customCode = `
                 type={this.state.confirmPasswordVisible ? 'text' : 'password'}
                 value={this.state.confirmPassword}
                 onChange={this.onConfirmPasswordChange}
-                autocomplete="off"
+                autocomplete="new-password"
                 actionIcon={(
                   <Icon
                     name={this.state.confirmPasswordVisible ? 'visibility' : 'visibility_off'}

--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -61,7 +61,11 @@ const customCode = `
             </div>
             <Link target="_blank" href="#">Add organizations</Link>
             <div className="my-6 pt-6" style={{ borderTop: 'var(--border-width-2-5) solid var(--secondary-light)' }}>
+<<<<<<< HEAD
               <Heading size="s">Time Period</Heading>
+=======
+              <Heading size="xs">Time Period</Heading>
+>>>>>>> b0ac8189e (fix(patterns): update patterns stories with a11y issues)
               <div className="mt-5">
                 <DateRangePicker withInput />
               </div>

--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -61,11 +61,7 @@ const customCode = `
             </div>
             <Link target="_blank" href="#">Add organizations</Link>
             <div className="my-6 pt-6" style={{ borderTop: 'var(--border-width-2-5) solid var(--secondary-light)' }}>
-<<<<<<< HEAD
               <Heading size="s">Time Period</Heading>
-=======
-              <Heading size="xs">Time Period</Heading>
->>>>>>> b0ac8189e (fix(patterns): update patterns stories with a11y issues)
               <div className="mt-5">
                 <DateRangePicker withInput />
               </div>

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`TS renders children 1`] = `
         <i
           class="material-symbols material-symbols-rounded Icon Icon--inverse"
           data-test="DesignSystem-Avatar--Icon"
-          role="button"
           style="font-size: 20px; width: 20px;"
         >
           person
@@ -133,7 +132,6 @@ exports[`TS renders children 1`] = `
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   arrow_back
@@ -155,7 +153,6 @@ exports[`TS renders children 1`] = `
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   keyboard_arrow_down
@@ -173,7 +170,6 @@ exports[`TS renders children 1`] = `
                 <i
                   class="material-symbols material-symbols-rounded Icon Icon--inverse pl-3"
                   data-test="DesignSystem-Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   keyboard_arrow_down
@@ -193,7 +189,6 @@ exports[`TS renders children 1`] = `
                 <i
                   class="material-symbols material-symbols-rounded Icon"
                   data-test="DesignSystem-Button--Icon"
-                  role="button"
                   style="font-size: 16px; width: 16px;"
                 >
                   arrow_forward
@@ -794,7 +789,6 @@ exports[`TS renders children 1`] = `
         <i
           class="material-symbols material-symbols-rounded Icon Icon--default"
           data-test="DesignSystem-Icon"
-          role="button"
           style="font-size: 16px; width: 16px;"
         >
           keyboard_arrow_down
@@ -836,7 +830,6 @@ exports[`TS renders children 1`] = `
               <i
                 class="material-symbols material-symbols-rounded Icon Icon--default"
                 data-test="DesignSystem-Icon"
-                role="button"
                 style="font-size: 16px; width: 16px;"
               >
                 keyboard_arrow_down
@@ -881,7 +874,6 @@ exports[`TS renders children 1`] = `
   <i
     class="material-symbols material-symbols-rounded Icon"
     data-test="DesignSystem-Icon"
-    role="button"
     style="font-size: 16px; width: 16px;"
   >
     Hello World!
@@ -968,9 +960,9 @@ exports[`TS renders children 1`] = `
     role="status"
   >
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Icon--info Message-icon--info Message-icon--regular"
       data-test="DesignSystem-Message--Icon"
-      role="button"
       style="font-size: 16px; width: 16px;"
     >
       info
@@ -1584,9 +1576,9 @@ exports[`TS renders children 1`] = `
     role="status"
   >
     <i
+      aria-hidden="true"
       class="material-symbols material-symbols-rounded Icon Toast-icon Toast-icon--left Toast-icon--info"
       data-test="DesignSystem-Icon"
-      role="button"
       style="font-size: 16px; width: 16px;"
     >
       info
@@ -1665,7 +1657,6 @@ exports[`TS renders children 1`] = `
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             close
@@ -1720,7 +1711,6 @@ exports[`TS renders children 1`] = `
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             first_page
@@ -1740,7 +1730,6 @@ exports[`TS renders children 1`] = `
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             navigate_before
@@ -1764,7 +1753,6 @@ exports[`TS renders children 1`] = `
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             navigate_next
@@ -1784,7 +1772,6 @@ exports[`TS renders children 1`] = `
           <i
             class="material-symbols material-symbols-rounded Icon"
             data-test="DesignSystem-Button--Icon"
-            role="button"
             style="font-size: 16px; width: 16px;"
           >
             last_page
@@ -1873,7 +1860,6 @@ exports[`TS renders children 1`] = `
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               arrow_back
@@ -1917,7 +1903,6 @@ exports[`TS renders children 1`] = `
             <i
               class="material-symbols material-symbols-rounded Icon"
               data-test="DesignSystem-Button--Icon"
-              role="button"
               style="font-size: 16px; width: 16px;"
             >
               arrow_forward


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
