### PR TITLE
fix(Select): resolve a11y role hierarchy, duplicate ARIA, and ID issues

### DIFF
--- a/core/components/organisms/select/SearchInput.tsx
+++ b/core/components/organisms/select/SearchInput.tsx
@@ -51,7 +51,6 @@ export const SearchInput = (props: SelectInputProps) => {
         onClear={searchClearHandler}
         autoComplete={'off'}
         aria-label="Search"
-        aria-haspopup="listbox"
         className={inputClass}
         data-test="DesignSystem-Select--Input"
       />

--- a/core/components/organisms/select/Select.tsx
+++ b/core/components/organisms/select/Select.tsx
@@ -295,17 +295,12 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
     setHighlightLastItem,
     styleType,
     error,
+    listboxId,
   };
 
   return (
     <SelectContext.Provider value={contextProp}>
-      <div
-        data-test="DesignSystem-Select"
-        style={WrapperStyle}
-        aria-haspopup="listbox"
-        aria-expanded={openPopover}
-        {...baseProps}
-      >
+      <div data-test="DesignSystem-Select" style={WrapperStyle} {...baseProps}>
         <Popover
           open={openPopover}
           onToggle={onToggleHandler}
@@ -318,9 +313,7 @@ export const Select = React.forwardRef<SelectMethods, SelectProps>((props, ref) 
           trigger={getTriggerElement()}
         >
           <OutsideClick onOutsideClick={onOutsideClickHandler}>
-            <div role="listbox" id={listboxId} tabIndex={0} ref={listRef}>
-              {children}
-            </div>
+            <div ref={listRef}>{children}</div>
           </OutsideClick>
         </Popover>
       </div>

--- a/core/components/organisms/select/SelectContext.tsx
+++ b/core/components/organisms/select/SelectContext.tsx
@@ -24,6 +24,7 @@ export type ContextProps = {
   size?: TListboxSize;
   styleType?: SelectStyleType;
   error?: boolean;
+  listboxId?: string;
 };
 
 export const SelectContext = React.createContext<ContextProps>({});

--- a/core/components/organisms/select/SelectEmptyTemplate.tsx
+++ b/core/components/organisms/select/SelectEmptyTemplate.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Text } from '@/index';
 import { SelectContext } from './SelectContext';
 import { BaseProps } from '@/utils/types';
+import uidGenerator from '@/utils/uidGenerator';
 
 interface SelectEmptyTemplateProps extends BaseProps {
   /**
@@ -25,6 +26,9 @@ export const SelectEmptyTemplate = (props: SelectEmptyTemplateProps) => {
 
   const { title, description, children, ...rest } = props;
 
+  const titleId = React.useRef(`select-empty-title-${uidGenerator()}`).current;
+  const descriptionId = React.useRef(`select-empty-desc-${uidGenerator()}`).current;
+
   const searchInputHeight = 33;
 
   const wrapperStyle = {
@@ -41,17 +45,17 @@ export const SelectEmptyTemplate = (props: SelectEmptyTemplateProps) => {
       {...rest}
     >
       <div
-        aria-labelledby={title}
-        aria-describedby={description}
+        aria-labelledby={title ? titleId : undefined}
+        aria-describedby={description ? descriptionId : undefined}
         className="d-flex flex-column justify-content-center align-items-center"
       >
         {title && (
-          <Text id={title} role="heading" className="text-align-center mb-3" weight="strong">
+          <Text id={titleId} role="heading" className="text-align-center mb-3" weight="strong">
             {title}
           </Text>
         )}
         {description && (
-          <Text id={description} className="text-align-center mb-6" weight="medium" size="small" appearance="subtle">
+          <Text id={descriptionId} className="text-align-center mb-6" weight="medium" size="small" appearance="subtle">
             {description}
           </Text>
         )}

--- a/core/components/organisms/select/SelectList.tsx
+++ b/core/components/organisms/select/SelectList.tsx
@@ -31,7 +31,7 @@ export interface SelectListProps extends BaseProps {
 
 export const SelectList = (props: SelectListProps) => {
   const contextProp = React.useContext(SelectContext);
-  const { withSearch, minHeight, maxHeight, multiSelect } = contextProp;
+  const { withSearch, minHeight, maxHeight, multiSelect, listboxId } = contextProp;
   const { children, size, ...rest } = props;
   const searchInputHeight = 33;
 
@@ -49,6 +49,9 @@ export const SelectList = (props: SelectListProps) => {
   return (
     <SelectContext.Provider value={updatedContextProp}>
       <Listbox
+        role="listbox"
+        id={listboxId}
+        tabIndex={0}
         style={wrapperStyle}
         aria-label={props['aria-label'] || 'Options item list'}
         aria-multiselectable={multiSelect}

--- a/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
+++ b/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
@@ -6,8 +6,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -55,8 +53,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -104,8 +100,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -153,8 +147,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -202,8 +194,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -251,8 +241,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -300,8 +288,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -349,8 +335,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -398,8 +382,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -447,8 +429,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -496,8 +476,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -545,8 +523,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -594,8 +570,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -643,8 +617,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -692,8 +664,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -741,8 +711,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -790,8 +758,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -839,8 +805,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -888,8 +852,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -937,8 +899,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -986,8 +946,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1035,8 +993,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1084,8 +1040,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1133,8 +1087,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1182,8 +1134,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1231,8 +1181,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1280,8 +1228,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1329,8 +1275,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1378,8 +1322,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1427,8 +1369,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1476,8 +1416,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1525,8 +1463,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1574,8 +1510,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1623,8 +1557,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1672,8 +1604,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1721,8 +1651,6 @@ exports[`Select List component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1770,8 +1698,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1819,8 +1745,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1868,8 +1792,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1917,8 +1839,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -1966,8 +1886,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2015,8 +1933,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2064,8 +1980,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2113,8 +2027,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2162,8 +2074,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2211,8 +2121,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2260,8 +2168,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2309,8 +2215,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2358,8 +2262,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2407,8 +2309,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2456,8 +2356,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2505,8 +2403,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2554,8 +2450,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2603,8 +2497,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2652,8 +2544,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2701,8 +2591,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2750,8 +2638,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2799,8 +2685,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2848,8 +2732,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2897,8 +2779,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2946,8 +2826,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -2995,8 +2873,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3044,8 +2920,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3093,8 +2967,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3142,8 +3014,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3191,8 +3061,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3240,8 +3108,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3289,8 +3155,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3338,8 +3202,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3387,8 +3249,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3436,8 +3296,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3485,8 +3343,6 @@ exports[`Select Option component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3534,8 +3390,6 @@ exports[`Select component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >
@@ -3583,8 +3437,6 @@ exports[`Select component snapshots
 <body>
   <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
       data-test="DesignSystem-Select"
       style="width: 176px;"
     >


### PR DESCRIPTION
- Move role="listbox" to Listbox so option is direct child
- Remove duplicate aria-haspopup/aria-expanded from wrapper
- Use stable generated IDs for aria-labelledby/describedby
- Remove stray aria-haspopup from SearchInput

### What does this implement/fix? Explain your changes.

• remove unnecessary aria attributes and add listboxId for accessibility

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
