### PR TITLE
fix(chipInput): update focus ring to outline-based style

### DIFF
--- a/css/src/components/chipInput.module.css
+++ b/css/src/components/chipInput.module.css
@@ -19,7 +19,8 @@
 
 .ChipInput:focus,
 .ChipInput:focus-visible {
-  outline: var(--spacing-2-5) var(--primary);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .ChipInput:hover {
@@ -28,7 +29,6 @@
 }
 
 .ChipInput:focus-within {
-  box-shadow: inset 0 0 0 var(--spacing-2-5) var(--primary);
   background: var(--white);
 }
 
@@ -42,8 +42,7 @@
   padding-right: var(--spacing-20);
 }
 
-.ChipInput--error,
-.ChipInput--error:focus-within {
+.ChipInput--error {
   box-shadow: inset 0 0 0 var(--spacing-2-5) var(--alert);
 }
 
@@ -56,11 +55,13 @@
 
 .ChipInput-border:focus-within {
   border-radius: var(--border-radius-10);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .ChipInput-border--error:focus-within {
-  box-shadow: var(--shadow-spread) var(--alert-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .ChipInput-input {


### PR DESCRIPTION
## Summary
- Fix broken `outline` syntax on `.ChipInput:focus` (was missing `solid` keyword, used wrong color variable)
- Replace old `box-shadow` focus ring on `.ChipInput-border:focus-within` with `outline` + `outline-offset`
- Remove red halo on error+focus state — now shows blue focus ring with red border stroke only
- Aligns ChipInput with the updated Input component focus ring pattern