### PR TITLE
fix(combobox): update multiselect clear icon to match Input clear icon

### DIFF
--- a/core/components/organisms/combobox/trigger/MultiselectTrigger.tsx
+++ b/core/components/organisms/combobox/trigger/MultiselectTrigger.tsx
@@ -5,6 +5,7 @@ import { ChipProps } from '@/index.type';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { OptionType } from '@/common.type';
 import styles from '@css/components/chipInput.module.css';
+import inputStyles from '@css/components/input.module.css';
 
 const keyCodes = {
   BACKSPACE: 'Backspace',
@@ -327,15 +328,28 @@ export const MultiSelectTrigger = React.forwardRef<HTMLElement, MultiSelectTrigg
           />
           {/* eslint-enable */}
         </div>
-        {(chips.length > 0 || inputValue.length > 0) && (
-          <Icon
+        {!disabled && (chips.length > 0 || inputValue.length > 0) && (
+          <div
             data-test="DesignSystem-MultiSelectTrigger--Icon"
-            name="close"
-            appearance={disabled ? 'disabled' : 'subtle'}
-            className={styles['ChipInput-icon']}
+            className={classNames(
+              inputStyles['Input-icon'],
+              inputStyles['Input-iconWrapper--right'],
+              'align-items-center',
+              'flex-shrink-0'
+            )}
+            tabIndex={0}
+            role="button"
+            aria-label="Clear all"
             onClick={onDeleteAllHandler}
-            tabIndex={disabled ? -1 : 0}
-          />
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onDeleteAllHandler(e as any);
+              }
+            }}
+          >
+            <Icon name="close" size={16} className={classNames(inputStyles['Input-icon--right'], 'p-3')} />
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION

### What does this implement/fix? Explain your changes.
- Replace ChipInput-icon with Input-icon wrapper + Input-icon--right pattern
- Use same size (16px), padding (p-3), and hover/active/focus states as Input
- Add alignSelf center to prevent icon stretching when chips expand container
- Add keyboard support and aria-label to clear button wrapper


### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
