### PR TITLE
fix(chipInput): update clear icon to match Input component pattern

### DIFF
--- a/core/components/molecules/chipInput/ChipInput.tsx
+++ b/core/components/molecules/chipInput/ChipInput.tsx
@@ -4,6 +4,7 @@ import { Chip, Icon } from '@/index';
 import { ChipProps } from '@/index.type';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import styles from '@css/components/chipInput.module.css';
+import inputStyles from '@css/components/input.module.css';
 
 const keyCodes = {
   BACKSPACE: 'Backspace',
@@ -170,9 +171,15 @@ export const ChipInput = (props: ChipInputProps) => {
     ['my-3']: size === 'regular',
   });
 
-  const IconClass = classNames({
-    [styles['ChipInput-icon']]: true,
-    [styles[`ChipInput-icon--${size}`]]: size,
+  const iconWrapperClass = classNames({
+    [inputStyles['Input-icon']]: true,
+    [inputStyles['Input-iconWrapper--right']]: true,
+  });
+
+  const iconClass = classNames({
+    [inputStyles['Input-icon--right']]: !disabled,
+    ['p-3-5']: size === 'small',
+    ['p-3']: size === 'regular',
   });
 
   const onUpdateChips = (updatedChips: string[]) => {
@@ -330,15 +337,27 @@ export const ChipInput = (props: ChipInputProps) => {
           {/* eslint-enable */}
         </div>
         {chips.length > 0 && (
-          <Icon
+          <div
             data-test="DesignSystem-ChipInput--Icon"
-            name="close"
-            size={iconSize}
-            appearance={disabled ? 'disabled' : 'subtle'}
-            className={IconClass}
-            onClick={onDeleteAllHandler}
+            className={classNames(iconWrapperClass, 'align-self-center', 'flex-shrink-0')}
             tabIndex={disabled ? -1 : 0}
-          />
+            role="button"
+            aria-label="Clear all"
+            aria-disabled={disabled || undefined}
+            onClick={disabled ? undefined : onDeleteAllHandler}
+            onKeyDown={
+              disabled
+                ? undefined
+                : (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      onDeleteAllHandler();
+                    }
+                  }
+            }
+          >
+            <Icon name="close" size={iconSize} appearance={disabled ? 'disabled' : undefined} className={iconClass} />
+          </div>
         )}
       </div>
     </div>

--- a/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
+++ b/core/components/molecules/chipInput/__tests__/ChipInput.test.tsx
@@ -288,8 +288,8 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
       const { getByTestId } = render(<ChipInput {...defaultProps} size="small" defaultValue={['chip1', 'chip2']} />);
 
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
-      expect(icon).toHaveClass('ChipInput-icon--small');
-      expect(icon).not.toHaveClass('ChipInput-icon--regular');
+      expect(icon).toHaveClass('Input-icon');
+      expect(icon).toHaveClass('Input-iconWrapper--right');
     });
 
     it('should maintain consistent height behavior when transitioning from empty to filled state', () => {
@@ -335,8 +335,8 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
       const { getByTestId } = render(<ChipInput {...defaultProps} size="regular" defaultValue={['chip1', 'chip2']} />);
 
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
-      expect(icon).toHaveClass('ChipInput-icon--regular');
-      expect(icon).not.toHaveClass('ChipInput-icon--small');
+      expect(icon).toHaveClass('Input-icon');
+      expect(icon).toHaveClass('Input-iconWrapper--right');
     });
   });
 
@@ -362,7 +362,7 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
       const { getByTestId } = render(<ChipInput {...defaultProps} defaultValue={['chip1']} />);
 
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
-      expect(icon).toHaveClass('ChipInput-icon--regular');
+      expect(icon).toHaveClass('Input-icon');
     });
   });
 
@@ -372,7 +372,7 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
 
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
       expect(icon).toBeInTheDocument();
-      expect(icon).toHaveClass('ChipInput-icon--small');
+      expect(icon).toHaveClass('Input-icon');
     });
 
     it('should render appropriate icon container for regular ChipInput (16px icon in centered container)', () => {
@@ -380,19 +380,19 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
 
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
       expect(icon).toBeInTheDocument();
-      expect(icon).toHaveClass('ChipInput-icon--regular');
+      expect(icon).toHaveClass('Input-icon');
     });
 
     it('should maintain consistent icon positioning across size changes', () => {
       const { rerender, getByTestId } = render(<ChipInput {...defaultProps} size="small" defaultValue={['test']} />);
 
       let icon = getByTestId('DesignSystem-ChipInput--Icon');
-      expect(icon).toHaveClass('ChipInput-icon--small');
+      expect(icon).toHaveClass('Input-icon');
 
       rerender(<ChipInput {...defaultProps} size="regular" defaultValue={['test']} />);
 
       icon = getByTestId('DesignSystem-ChipInput--Icon');
-      expect(icon).toHaveClass('ChipInput-icon--regular');
+      expect(icon).toHaveClass('Input-icon');
     });
 
     it('should not render clear icon when no chips are present regardless of size', () => {
@@ -487,8 +487,8 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
       const { getByTestId } = render(<ChipInput {...defaultProps} size="small" defaultValue={['test']} />);
 
       const icon = getByTestId('DesignSystem-ChipInput--Icon');
-      expect(icon).toHaveClass('ChipInput-icon');
-      expect(icon).toHaveClass('ChipInput-icon--small');
+      expect(icon).toHaveClass('Input-icon');
+      expect(icon).toHaveClass('Input-iconWrapper--right');
     });
   });
 
@@ -503,7 +503,7 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
 
       expect(container).toHaveClass('ChipInput--small');
       expect(input).toHaveClass('ChipInput-input--small');
-      expect(icon).toHaveClass('ChipInput-icon--small');
+      expect(icon).toHaveClass('Input-icon');
       expect(chip).toHaveClass('my-2');
 
       rerender(<ChipInput {...defaultProps} size="regular" defaultValue={['test']} />);
@@ -515,7 +515,7 @@ describe('ChipInput Component - Size Variants and Icon Alignment', () => {
 
       expect(container).toHaveClass('ChipInput--regular');
       expect(input).toHaveClass('ChipInput-input--regular');
-      expect(icon).toHaveClass('ChipInput-icon--regular');
+      expect(icon).toHaveClass('Input-icon');
       expect(chip).toHaveClass('my-3');
     });
 

--- a/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
+++ b/core/components/molecules/chipInput/__tests__/__snapshots__/ChipInput.test.tsx.snap
@@ -92,15 +92,21 @@ exports[`ChipInput component
             value=""
           />
         </div>
-        <i
-          class="material-symbols material-symbols-rounded Icon Icon--subtle ChipInput-icon ChipInput-icon--regular"
+        <div
+          aria-label="Clear all"
+          class="Input-icon Input-iconWrapper--right align-self-center flex-shrink-0"
           data-test="DesignSystem-ChipInput--Icon"
           role="button"
-          style="font-size: 16px; width: 16px;"
           tabindex="0"
         >
-          close
-        </i>
+          <i
+            class="material-symbols material-symbols-rounded Icon Input-icon--right p-3"
+            data-test="DesignSystem-Icon"
+            style="font-size: 16px; width: 16px;"
+          >
+            close
+          </i>
+        </div>
       </div>
     </div>
   </div>
@@ -201,15 +207,22 @@ exports[`ChipInput component
             value=""
           />
         </div>
-        <i
-          class="material-symbols material-symbols-rounded Icon Icon--disabled ChipInput-icon ChipInput-icon--regular"
+        <div
+          aria-disabled="true"
+          aria-label="Clear all"
+          class="Input-icon Input-iconWrapper--right align-self-center flex-shrink-0"
           data-test="DesignSystem-ChipInput--Icon"
           role="button"
-          style="font-size: 16px; width: 16px;"
           tabindex="-1"
         >
-          close
-        </i>
+          <i
+            class="material-symbols material-symbols-rounded Icon Icon--disabled p-3"
+            data-test="DesignSystem-Icon"
+            style="font-size: 16px; width: 16px;"
+          >
+            close
+          </i>
+        </div>
       </div>
     </div>
   </div>
@@ -308,15 +321,21 @@ exports[`ChipInput component
             value=""
           />
         </div>
-        <i
-          class="material-symbols material-symbols-rounded Icon Icon--subtle ChipInput-icon ChipInput-icon--regular"
+        <div
+          aria-label="Clear all"
+          class="Input-icon Input-iconWrapper--right align-self-center flex-shrink-0"
           data-test="DesignSystem-ChipInput--Icon"
           role="button"
-          style="font-size: 16px; width: 16px;"
           tabindex="0"
         >
-          close
-        </i>
+          <i
+            class="material-symbols material-symbols-rounded Icon Input-icon--right p-3"
+            data-test="DesignSystem-Icon"
+            style="font-size: 16px; width: 16px;"
+          >
+            close
+          </i>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION

### What does this implement/fix? Explain your changes.

- Replace ChipInput-icon with Input-icon wrapper + Input-icon--right pattern
- Use same size, padding, and hover/active/focus states as Input clear icon
- Add alignSelf center to prevent icon stretching with chip expansion
- Add keyboard support and aria-label to clear button wrapper
- Update tests to match new icon class structure


### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
