### PR TITLE
fix(linkbutton): add aria label to icon

### DIFF
--- a/core/components/atoms/linkButton/LinkButton.tsx
+++ b/core/components/atoms/linkButton/LinkButton.tsx
@@ -40,7 +40,7 @@ export interface LinkButtonProps extends BaseProps, BaseHtmlProps<HTMLButtonElem
   /**
    * Text to be added inside `Button`
    */
-  children: React.ReactText;
+  children?: React.ReactText;
   /**
    * Specifies tab index of `Button`
    * @default 0
@@ -99,6 +99,7 @@ export const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>((
       disabled={disabled}
       tabIndex={tabIndex}
       {...rest}
+      aria-label={rest['aria-label'] || (!children && icon ? icon : undefined)}
     >
       <>
         {icon && (

--- a/core/components/atoms/linkButton/__tests__/LinkButton.test.tsx
+++ b/core/components/atoms/linkButton/__tests__/LinkButton.test.tsx
@@ -99,6 +99,23 @@ describe('Link Button component Event Handlers', () => {
   });
 });
 
+describe('Link Button component accessibility', () => {
+  it('uses icon name as aria-label for icon-only button', () => {
+    const { getByTestId } = render(<LinkButton icon="events" />);
+    expect(getByTestId('DesignSystem-LinkButton')).toHaveAttribute('aria-label', 'events');
+  });
+
+  it('uses explicit aria-label over icon name', () => {
+    const { getByTestId } = render(<LinkButton icon="events" aria-label="View events" />);
+    expect(getByTestId('DesignSystem-LinkButton')).toHaveAttribute('aria-label', 'View events');
+  });
+
+  it('does not add aria-label when children are present', () => {
+    const { getByTestId } = render(<LinkButton icon="events">LinkButton</LinkButton>);
+    expect(getByTestId('DesignSystem-LinkButton')).not.toHaveAttribute('aria-label');
+  });
+});
+
 describe('Link Button component appearance', () => {
   it('check for subtle class in link button', () => {
     const { getByTestId } = render(<LinkButton subtle={true}>LinkButton</LinkButton>);


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

• add aria label to icon in case of no text in link button

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
