### PR TITLE
fix(FileUploader): open file picker from button for keyboard users

### DIFF
--- a/core/components/molecules/fileUploader/FileUploaderButton.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { Button } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
+import uidGenerator from '@/utils/uidGenerator';
 import styles from '@css/components/fileUploader.module.css';
 
 export interface FileUploaderButtonProps extends BaseProps {
@@ -39,6 +40,14 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
   const { accept, multiple, uploadButtonLabel, disabled, name, className, id, onChange } = props;
 
   const baseProps = extractBaseProps(props);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const inputId = React.useMemo(() => id || `ds-file-uploader-input-${uidGenerator()}`, [id]);
+
+  const openFilePicker = React.useCallback(() => {
+    if (disabled) return;
+    inputRef.current?.click();
+  }, [disabled]);
 
   const FileUploaderButtonClass = classNames(
     {
@@ -49,12 +58,13 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
 
   return (
     <div {...baseProps} className={FileUploaderButtonClass}>
-      <Button type="button" disabled={disabled} icon="backup">
+      <Button type="button" disabled={disabled} icon="backup" onClick={openFilePicker} aria-controls={inputId}>
         {uploadButtonLabel}
       </Button>
       <input
+        ref={inputRef}
         name={name}
-        id={id}
+        id={inputId}
         data-test="DesignSystem-FileUploaderButton--Input"
         accept={accept && accept.join(', ')}
         multiple={multiple}

--- a/core/components/molecules/fileUploader/__tests__/FileUploader.test.tsx
+++ b/core/components/molecules/fileUploader/__tests__/FileUploader.test.tsx
@@ -163,6 +163,28 @@ describe('FileUploader component prop:onChange', () => {
     fireEvent.change(getByTestId('DesignSystem-FileUploaderButton--Input'));
     expect(FunctionValue).toHaveBeenCalled();
   });
+
+  it('forwards button click to file input so keyboard and mouse use the same path', () => {
+    const { getByTestId } = render(<FileUploader onChange={FunctionValue} />);
+    const input = getByTestId('DesignSystem-FileUploaderButton--Input') as HTMLInputElement;
+    const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {});
+
+    fireEvent.click(getByTestId('DesignSystem-Button'));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    clickSpy.mockRestore();
+  });
+
+  it('does not call file input click when disabled', () => {
+    const { getByTestId } = render(<FileUploader onChange={FunctionValue} disabled />);
+    const input = getByTestId('DesignSystem-FileUploaderButton--Input') as HTMLInputElement;
+    const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {});
+
+    fireEvent.click(getByTestId('DesignSystem-Button'));
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
 });
 
 describe('FileUploader component prop:disabled', () => {

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`FileUploader component
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -56,6 +57,7 @@ exports[`FileUploader component
       <input
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -88,6 +90,7 @@ exports[`FileUploader component prop:accept snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -115,6 +118,7 @@ exports[`FileUploader component prop:accept snapshot
         accept="jpg, pdf, png"
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -147,6 +151,7 @@ exports[`FileUploader component prop:disabled snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -173,6 +178,7 @@ exports[`FileUploader component prop:disabled snapshot
       <input
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -205,6 +211,7 @@ exports[`FileUploader component prop:disabled snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         disabled=""
@@ -233,6 +240,7 @@ exports[`FileUploader component prop:disabled snapshot
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
         disabled=""
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -265,6 +273,7 @@ exports[`FileUploader component prop:multiple snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -291,6 +300,7 @@ exports[`FileUploader component prop:multiple snapshot
       <input
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -323,6 +333,7 @@ exports[`FileUploader component prop:multiple snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -349,6 +360,7 @@ exports[`FileUploader component prop:multiple snapshot
       <input
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         multiple=""
         tabindex="-1"
         type="file"

--- a/css/src/components/fileUploader.module.css
+++ b/css/src/components/fileUploader.module.css
@@ -17,6 +17,8 @@
   font-size: 0;
   z-index: 2;
   cursor: pointer;
+  /* Clicks go to the Button so keyboard (Enter/Space) and mouse share one activation path */
+  pointer-events: none;
 }
 
 .FileUploaderItem {


### PR DESCRIPTION
Wire Button onClick to programmatically activate the hidden file input so Enter/Space on the focused button matches mouse behavior. Keep file input out of tab order; generate stable id when none provided for aria-controls.

### What does this implement/fix? Explain your changes.

...

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
