### PR TITLE
fix(StatusHint): add aria-label to status icon, hide skeletons from AT

### DIFF
--- a/core/components/atoms/placeholderImage/PlaceholderImage.tsx
+++ b/core/components/atoms/placeholderImage/PlaceholderImage.tsx
@@ -31,7 +31,7 @@ export const PlaceholderImage = (props: PlaceholderImageProps) => {
     className
   );
 
-  return <span {...baseProps} className={classes} />;
+  return <span {...baseProps} className={classes} aria-hidden="true" />;
 };
 
 PlaceholderImage.displayName = 'PlaceholderImage';

--- a/core/components/atoms/placeholderImage/__tests__/__snapshots__/PlaceholderImage.test.tsx.snap
+++ b/core/components/atoms/placeholderImage/__tests__/__snapshots__/PlaceholderImage.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--small"
     />
   </div>
@@ -18,6 +19,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--round PlaceholderImage--small"
     />
   </div>
@@ -30,6 +32,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--large"
     />
   </div>
@@ -42,6 +45,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--medium"
     />
   </div>
@@ -54,6 +58,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--small"
     />
   </div>

--- a/core/components/atoms/placeholderParagraph/PlaceholderParagraph.tsx
+++ b/core/components/atoms/placeholderParagraph/PlaceholderParagraph.tsx
@@ -56,7 +56,7 @@ export const PlaceholderParagraph = (props: PlaceholderParagraphProps) => {
   );
 
   return (
-    <div {...baseProps} className={wrapperClass}>
+    <div {...baseProps} className={wrapperClass} aria-hidden="true">
       <span className={classes} />
     </div>
   );

--- a/core/components/atoms/placeholderParagraph/__tests__/__snapshots__/PlaceholderParagraph.test.tsx.snap
+++ b/core/components/atoms/placeholderParagraph/__tests__/__snapshots__/PlaceholderParagraph.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <div
+      aria-hidden="true"
       class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-large"
     >
       <span
@@ -22,6 +23,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <div
+      aria-hidden="true"
       class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-medium"
     >
       <span
@@ -38,6 +40,7 @@ exports[`Image placeholder component
 <body>
   <div>
     <div
+      aria-hidden="true"
       class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
     >
       <span

--- a/core/components/atoms/statusHint/StatusHint.tsx
+++ b/core/components/atoms/statusHint/StatusHint.tsx
@@ -105,7 +105,12 @@ export const StatusHint = (props: StatusHintProps) => {
       tabIndex={isClickable ? 0 : undefined}
     >
       {/* eslint-enable */}
-      <span data-test="DesignSystem-StatusHint--Icon" aria-hidden="true" className={StatusHintIconClass} />
+      <span
+        data-test="DesignSystem-StatusHint--Icon"
+        role="img"
+        aria-label={`${appearance} status`}
+        className={StatusHintIconClass}
+      />
       {renderChildren()}
     </div>
   );

--- a/core/components/atoms/statusHint/__tests__/__snapshots__/StatusHint.test.tsx.snap
+++ b/core/components/atoms/statusHint/__tests__/__snapshots__/StatusHint.test.tsx.snap
@@ -10,9 +10,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="alert status"
         class="StatusHint-icon StatusHint--alert mr-4"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--regular"
@@ -35,9 +36,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="alert status"
         class="StatusHint-icon StatusHint--alert mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--small"
@@ -60,9 +62,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="default status"
         class="StatusHint-icon StatusHint--default mr-4"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--regular"
@@ -85,9 +88,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="default status"
         class="StatusHint-icon StatusHint--default mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--small"
@@ -110,9 +114,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="info status"
         class="StatusHint-icon StatusHint--info mr-4"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--regular"
@@ -135,9 +140,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="info status"
         class="StatusHint-icon StatusHint--info mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--small"
@@ -160,9 +166,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="success status"
         class="StatusHint-icon StatusHint--success mr-4"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--regular"
@@ -185,9 +192,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="success status"
         class="StatusHint-icon StatusHint--success mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--small"
@@ -210,9 +218,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="warning status"
         class="StatusHint-icon StatusHint--warning mr-4"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--regular"
@@ -235,9 +244,10 @@ exports[`StatusHint component
       data-test="DesignSystem-StatusHint"
     >
       <span
-        aria-hidden="true"
+        aria-label="warning status"
         class="StatusHint-icon StatusHint--warning mr-3-5"
         data-test="DesignSystem-StatusHint--Icon"
+        role="img"
       />
       <span
         class="Text Text--default Text--medium Text--small"

--- a/core/components/molecules/placeholder/Placeholder.tsx
+++ b/core/components/molecules/placeholder/Placeholder.tsx
@@ -42,7 +42,7 @@ export const Placeholder = (props: PlaceholderProps) => {
   );
 
   return (
-    <div data-test="DesignSystem-Placeholder" {...baseProps} className={classes}>
+    <div data-test="DesignSystem-Placeholder" {...baseProps} className={classes} aria-hidden="true">
       {withImage && <PlaceholderImage round={round} size={imageSize} data-test="DesignSystem-Placeholder--Image" />}
       {children && (
         <div className={paragraphClasses} data-test="DesignSystem-Placeholder--Paragraph">

--- a/core/components/molecules/placeholder/__tests__/__snapshots__/Placeholder.test.tsx.snap
+++ b/core/components/molecules/placeholder/__tests__/__snapshots__/Placeholder.test.tsx.snap
@@ -5,10 +5,12 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--large"
       data-test="DesignSystem-Placeholder--Image"
     />
@@ -17,6 +19,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span
@@ -33,10 +36,12 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--medium"
       data-test="DesignSystem-Placeholder--Image"
     />
@@ -45,6 +50,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span
@@ -61,10 +67,12 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--small"
       data-test="DesignSystem-Placeholder--Image"
     />
@@ -73,6 +81,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span
@@ -89,6 +98,7 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
@@ -97,6 +107,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span
@@ -113,10 +124,12 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--small"
       data-test="DesignSystem-Placeholder--Image"
     />
@@ -125,6 +138,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span
@@ -141,6 +155,7 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
@@ -149,6 +164,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span
@@ -165,10 +181,12 @@ exports[`Placeholder component
  1`] = `
 <DocumentFragment>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--round PlaceholderImage--small"
       data-test="DesignSystem-Placeholder--Image"
     />
@@ -177,6 +195,7 @@ exports[`Placeholder component
       data-test="DesignSystem-Placeholder--Paragraph"
     >
       <div
+        aria-hidden="true"
         class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-small"
       >
         <span

--- a/core/components/organisms/combobox/trigger/MultiselectTrigger.tsx
+++ b/core/components/organisms/combobox/trigger/MultiselectTrigger.tsx
@@ -5,6 +5,7 @@ import { ChipProps } from '@/index.type';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { OptionType } from '@/common.type';
 import styles from '@css/components/chipInput.module.css';
+import inputStyles from '@css/components/input.module.css';
 
 const keyCodes = {
   BACKSPACE: 'Backspace',
@@ -327,15 +328,28 @@ export const MultiSelectTrigger = React.forwardRef<HTMLElement, MultiSelectTrigg
           />
           {/* eslint-enable */}
         </div>
-        {(chips.length > 0 || inputValue.length > 0) && (
-          <Icon
+        {!disabled && (chips.length > 0 || inputValue.length > 0) && (
+          <div
             data-test="DesignSystem-MultiSelectTrigger--Icon"
-            name="close"
-            appearance={disabled ? 'disabled' : 'subtle'}
-            className={styles['ChipInput-icon']}
+            className={classNames(
+              inputStyles['Input-icon'],
+              inputStyles['Input-iconWrapper--right'],
+              'align-items-center',
+              'flex-shrink-0'
+            )}
+            tabIndex={0}
+            role="button"
+            aria-label="Clear all"
             onClick={onDeleteAllHandler}
-            tabIndex={disabled ? -1 : 0}
-          />
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onDeleteAllHandler(e as any);
+              }
+            }}
+          >
+            <Icon name="close" size={16} className={classNames(inputStyles['Input-icon--right'], 'p-3')} />
+          </div>
         )}
       </div>
     </div>

--- a/core/components/organisms/grid/GridCell.tsx
+++ b/core/components/organisms/grid/GridCell.tsx
@@ -465,7 +465,7 @@ export const GridCell = (props: GridCellProps) => {
 
     case 'STATUS_HINT':
       return (
-        <div className={statusHintCellClass}>
+        <div className={statusHintCellClass} aria-busy={loading || undefined}>
           {loading ? (
             <Placeholder className="w-75 flex-grow-0" imageSize={'small'} round={true}>
               <PlaceholderParagraph length="large" />

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -126,9 +126,10 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
-                  aria-hidden="true"
+                  aria-label="default status"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
+                  role="img"
                 />
                 <span
                   class="Text Text--default Text--medium Text--regular"
@@ -490,9 +491,10 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
-                  aria-hidden="true"
+                  aria-label="default status"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
+                  role="img"
                 />
                 <span
                   class="Text Text--default Text--medium Text--regular"
@@ -781,9 +783,10 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
-                  aria-hidden="true"
+                  aria-label="default status"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
+                  role="img"
                 />
                 <span
                   class="Text Text--default Text--medium Text--regular"
@@ -1745,9 +1748,10 @@ exports[`Navigation component
                 data-test="DesignSystem-StatusHint"
               >
                 <span
-                  aria-hidden="true"
+                  aria-label="default status"
                   class="StatusHint-icon StatusHint--default mr-4"
                   data-test="DesignSystem-StatusHint--Icon"
+                  role="img"
                 />
                 <span
                   class="Text Text--default Text--medium Text--regular"

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -1555,9 +1555,10 @@ exports[`TS renders children 1`] = `
     data-test="DesignSystem-StatusHint"
   >
     <span
-      aria-hidden="true"
+      aria-label="default status"
       class="StatusHint-icon StatusHint--default mr-4"
       data-test="DesignSystem-StatusHint--Icon"
+      role="img"
     />
     <span
       class="Text Text--default Text--medium Text--regular"
@@ -2296,15 +2297,18 @@ exports[`TS renders children 1`] = `
     </div>
   </div>
   <div
+    aria-hidden="true"
     class="Placeholder"
     data-test="DesignSystem-Placeholder"
   >
     <span
+      aria-hidden="true"
       class="PlaceholderImage Placeholder--animation PlaceholderImage--small"
       data-test="DesignSystem-Placeholder--Image"
     />
   </div>
   <div
+    aria-hidden="true"
     class="PlaceholderParagraph-wrapper PlaceholderParagraph-wrapper--length-medium"
   >
     <span

--- a/css/src/components/chatInput.module.css
+++ b/css/src/components/chatInput.module.css
@@ -32,10 +32,9 @@
 .ChatInput:focus-within,
 .ChatInput:focus,
 .ChatInput:focus-visible {
-  outline: none;
   background: var(--white);
-  border: var(--border-width-2-5) solid var(--primary);
-  box-shadow: var(--shadow-spread) var(--primary-shadow);
+  outline: var(--border-width-05) solid var(--primary-focus);
+  outline-offset: var(--spacing-05);
 }
 
 .ChatInput-textarea {


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

• add aria-label to status icon and hide skeleton placeholders from assistive technology

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
