### PR TITLE
fix(Pagination): accessible name and description for jump input

### DIFF
--- a/core/components/molecules/pagination/Pagination.tsx
+++ b/core/components/molecules/pagination/Pagination.tsx
@@ -3,11 +3,10 @@ import { debounce } from 'throttle-debounce';
 import { Text, MetricInput, Button } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { isNaturalNumber } from '@/utils/validators';
+import uidGenerator from '@/utils/uidGenerator';
 import styles from '@css/components/pagination.module.css';
 
 import classNames from 'classnames';
-
-let paginationPageTotalDescriptionUid = 0;
 
 export type PaginationType = 'basic' | 'jump';
 
@@ -38,11 +37,11 @@ export const Pagination = (props: PaginationProps) => {
   const { type, totalPages, onPageChange, className, pageJumpDebounceDuration } = props;
 
   const baseProps = extractBaseProps(props);
-  const pageTotalDescriptionIdRef = React.useRef<string>();
-  if (type === 'jump' && !pageTotalDescriptionIdRef.current) {
-    pageTotalDescriptionIdRef.current = `mds-Pagination-pageTotalDesc-${++paginationPageTotalDescriptionUid}`;
-  }
-  const pageTotalDescriptionId = type === 'jump' ? pageTotalDescriptionIdRef.current : undefined;
+  const [descriptionId, setDescriptionId] = React.useState<string | undefined>();
+
+  React.useEffect(() => {
+    setDescriptionId(`mds-Pagination-pageTotalDesc-${uidGenerator()}`);
+  }, []);
 
   const [page, setPage] = React.useState<number>(props.page);
   const [init, setInit] = React.useState<boolean>(false);
@@ -159,9 +158,9 @@ export const Pagination = (props: PaginationProps) => {
             data-test="DesignSystem-Pagination--Input"
             onKeyPress={onKeyPressHandler}
             aria-label="Current page"
-            aria-describedby={pageTotalDescriptionId}
+            aria-describedby={descriptionId}
           />
-          <Text id={pageTotalDescriptionId}>{` of ${totalPages} pages`}</Text>
+          <Text id={descriptionId}>{` of ${totalPages} pages`}</Text>
         </div>
       )}
       <div className={nextButtonWrapperClass}>

--- a/core/components/molecules/pagination/Pagination.tsx
+++ b/core/components/molecules/pagination/Pagination.tsx
@@ -7,6 +7,8 @@ import styles from '@css/components/pagination.module.css';
 
 import classNames from 'classnames';
 
+let paginationPageTotalDescriptionUid = 0;
+
 export type PaginationType = 'basic' | 'jump';
 
 export interface PaginationProps extends BaseProps {
@@ -36,6 +38,11 @@ export const Pagination = (props: PaginationProps) => {
   const { type, totalPages, onPageChange, className, pageJumpDebounceDuration } = props;
 
   const baseProps = extractBaseProps(props);
+  const pageTotalDescriptionIdRef = React.useRef<string>();
+  if (type === 'jump' && !pageTotalDescriptionIdRef.current) {
+    pageTotalDescriptionIdRef.current = `mds-Pagination-pageTotalDesc-${++paginationPageTotalDescriptionUid}`;
+  }
+  const pageTotalDescriptionId = type === 'jump' ? pageTotalDescriptionIdRef.current : undefined;
 
   const [page, setPage] = React.useState<number>(props.page);
   const [init, setInit] = React.useState<boolean>(false);
@@ -151,8 +158,10 @@ export const Pagination = (props: PaginationProps) => {
             value={`${isNaturalNumber(page) ? page : ''}`}
             data-test="DesignSystem-Pagination--Input"
             onKeyPress={onKeyPressHandler}
+            aria-label="Current page"
+            aria-describedby={pageTotalDescriptionId}
           />
-          <Text>{` of ${totalPages} pages`}</Text>
+          <Text id={pageTotalDescriptionId}>{` of ${totalPages} pages`}</Text>
         </div>
       )}
       <div className={nextButtonWrapperClass}>

--- a/core/components/molecules/pagination/Pagination.tsx
+++ b/core/components/molecules/pagination/Pagination.tsx
@@ -40,7 +40,7 @@ export const Pagination = (props: PaginationProps) => {
   const [descriptionId, setDescriptionId] = React.useState<string | undefined>();
 
   React.useEffect(() => {
-    setDescriptionId(`mds-Pagination-pageTotalDesc-${uidGenerator()}`);
+    setDescriptionId(`DesignSystem-Pagination-totalPage-${uidGenerator()}`);
   }, []);
 
   const [page, setPage] = React.useState<number>(props.page);

--- a/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`Pagination component
         role="presentation"
       >
         <input
-          aria-describedby="mds-Pagination-pageTotalDesc-Test-uid"
+          aria-describedby="DesignSystem-Pagination-totalPage-Test-uid"
           aria-label="Current page"
           class="MetricInput-input MetricInput-input--regular"
           data-test="DesignSystem-Pagination--Input"
@@ -199,7 +199,7 @@ exports[`Pagination component
       <span
         class="Text Text--default Text--regular"
         data-test="DesignSystem-Text"
-        id="mds-Pagination-pageTotalDesc-Test-uid"
+        id="DesignSystem-Pagination-totalPage-Test-uid"
       >
          of 50 pages
       </span>

--- a/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`Pagination component
         role="presentation"
       >
         <input
-          aria-describedby="mds-Pagination-pageTotalDesc-1"
+          aria-describedby="mds-Pagination-pageTotalDesc-Test-uid"
           aria-label="Current page"
           class="MetricInput-input MetricInput-input--regular"
           data-test="DesignSystem-Pagination--Input"
@@ -199,7 +199,7 @@ exports[`Pagination component
       <span
         class="Text Text--default Text--regular"
         data-test="DesignSystem-Text"
-        id="mds-Pagination-pageTotalDesc-1"
+        id="mds-Pagination-pageTotalDesc-Test-uid"
       >
          of 50 pages
       </span>

--- a/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
+++ b/core/components/molecules/pagination/__tests__/__snapshots__/Pagination.test.tsx.snap
@@ -155,6 +155,8 @@ exports[`Pagination component
         role="presentation"
       >
         <input
+          aria-describedby="mds-Pagination-pageTotalDesc-1"
+          aria-label="Current page"
           class="MetricInput-input MetricInput-input--regular"
           data-test="DesignSystem-Pagination--Input"
           name="page"
@@ -197,6 +199,7 @@ exports[`Pagination component
       <span
         class="Text Text--default Text--regular"
         data-test="DesignSystem-Text"
+        id="mds-Pagination-pageTotalDesc-1"
       >
          of 50 pages
       </span>


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Fixes the jump-pagination page field having no accessible name (WCAG 4.1.2). The jump control is a `MetricInput` that only had `name="page"`; `name` does not serve as the exposed name for assistive tech.

- Set `aria-label="Current page"` on the jump `MetricInput`.
- Set `aria-describedby` on that input to the adjacent "of N pages" text so the total page count is announced as supplementary description.
- Generates a stable `id` using a two-pass render (`useEffect`) with `uidGenerator` to prevent hydration mismatches in SSR environments (React 16 compliant).
- Updated the Jest snapshot for the jump pagination variant.

### Does this close any currently open issues?

No

### Any other comments?

None

### Dependent PRs/Commits

None

### Describe breaking changes, if any.

None

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch