### PR TITLE
fix(VerticalNav): add aria-current and aria-selected to active menu items

### DIFF
--- a/core/components/organisms/horizontalNav/HorizontalNav.tsx
+++ b/core/components/organisms/horizontalNav/HorizontalNav.tsx
@@ -118,7 +118,7 @@ export const HorizontalNav = (props: HorizontalNavProps) => {
           key={index}
           {...commonProps}
           href={menu.link}
-          aria-current={isActive ? 'page' : undefined}
+          aria-current={active?.name === menu.name || (active?.link && active.link === menu.link) ? 'page' : undefined}
           onClick={(event) => onClickHandler(event, menu)}
         >
           {content}
@@ -131,7 +131,7 @@ export const HorizontalNav = (props: HorizontalNavProps) => {
         type="button"
         key={index}
         {...commonProps}
-        aria-current={isActive ? 'page' : undefined}
+        aria-current={active?.name === menu.name || (active?.link && active.link === menu.link) ? 'page' : undefined}
         onClick={(event) => onClickHandler(event, menu)}
       >
         {content}

--- a/core/components/organisms/navigation/VerticalNavigation.tsx
+++ b/core/components/organisms/navigation/VerticalNavigation.tsx
@@ -158,6 +158,7 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
           role="button"
           tabIndex={menu.disabled ? -1 : 0}
           aria-disabled={menu.disabled || undefined}
+          aria-current={isMenuActive(menus, menu, active) ? 'page' : undefined}
         >
           {menu.icon && (
             <Icon
@@ -215,6 +216,7 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
                   role="button"
                   tabIndex={subMenu.disabled ? -1 : 0}
                   aria-disabled={subMenu.disabled || undefined}
+                  aria-current={isActive ? 'page' : undefined}
                 >
                   <Text appearance={getTextAppearance(isActive, subMenu.disabled)} className="ellipsis--noWrap">
                     {subMenu.label}

--- a/core/components/organisms/navigation/VerticalNavigation.tsx
+++ b/core/components/organisms/navigation/VerticalNavigation.tsx
@@ -216,7 +216,9 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
                   role="button"
                   tabIndex={subMenu.disabled ? -1 : 0}
                   aria-disabled={subMenu.disabled || undefined}
-                  aria-current={active?.name === subMenu.name || (active?.link && active.link === subMenu.link) ? 'page' : undefined}
+                  aria-current={
+                    active?.name === subMenu.name || (active?.link && active.link === subMenu.link) ? 'page' : undefined
+                  }
                 >
                   <Text appearance={getTextAppearance(isActive, subMenu.disabled)} className="ellipsis--noWrap">
                     {subMenu.label}

--- a/core/components/organisms/navigation/VerticalNavigation.tsx
+++ b/core/components/organisms/navigation/VerticalNavigation.tsx
@@ -158,7 +158,7 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
           role="button"
           tabIndex={menu.disabled ? -1 : 0}
           aria-disabled={menu.disabled || undefined}
-          aria-current={isMenuActive(menus, menu, active) ? 'page' : undefined}
+          aria-current={active?.name === menu.name || (active?.link && active.link === menu.link) ? 'page' : undefined}
         >
           {menu.icon && (
             <Icon
@@ -216,7 +216,7 @@ export const VerticalNavigation = (props: VerticalNavigationProps) => {
                   role="button"
                   tabIndex={subMenu.disabled ? -1 : 0}
                   aria-disabled={subMenu.disabled || undefined}
-                  aria-current={isActive ? 'page' : undefined}
+                  aria-current={active?.name === subMenu.name || (active?.link && active.link === subMenu.link) ? 'page' : undefined}
                 >
                   <Text appearance={getTextAppearance(isActive, subMenu.disabled)} className="ellipsis--noWrap">
                     {subMenu.label}

--- a/core/components/organisms/navigation/__tests__/Navigation.test.tsx
+++ b/core/components/organisms/navigation/__tests__/Navigation.test.tsx
@@ -148,6 +148,34 @@ describe('VerticalNavigation component', () => {
   });
 });
 
+describe('VerticalNavigation component: aria-current', () => {
+  it('sets aria-current="page" on the active menu item', () => {
+    const { getAllByTestId } = render(<Navigation menus={menus} type="vertical" active={{ name: 'tab1' }} />);
+    const menuItems = getAllByTestId('DesignSystem-Navigation-VerticalNavigation--menuItem');
+    expect(menuItems[0]).toHaveAttribute('aria-current', 'page');
+    expect(menuItems[1]).not.toHaveAttribute('aria-current');
+    expect(menuItems[2]).not.toHaveAttribute('aria-current');
+  });
+
+  it('sets aria-current="page" on the active sub-menu item', () => {
+    const { getAllByTestId } = render(
+      <Navigation menus={menus} type="vertical" active={{ name: 'tab3child1' }} autoCollapse={false} />
+    );
+    const parentMenu = getAllByTestId('DesignSystem-Navigation-VerticalNavigation--menuItem')[2];
+    fireEvent.click(parentMenu);
+    const subMenuItems = getAllByTestId('DesignSystem-Navigation-VerticalNavigation--subMenu');
+    expect(subMenuItems[0]).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not set aria-current when no item is active', () => {
+    const { getAllByTestId } = render(<Navigation menus={menus} type="vertical" />);
+    const menuItems = getAllByTestId('DesignSystem-Navigation-VerticalNavigation--menuItem');
+    menuItems.forEach((item) => {
+      expect(item).not.toHaveAttribute('aria-current');
+    });
+  });
+});
+
 describe('Vertical Navigation component prop: onClick', () => {
   it('renders vertical nav  component with  onClick without submenu ', () => {
     const { getAllByTestId } = render(<Navigation onClick={onClick} menus={menus} type="vertical" />);

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -10,6 +10,7 @@ import styles from '@css/components/verticalNav.module.css';
 export interface MenuItemProps extends BaseProps {
   menu: Menu;
   isActive: boolean;
+  isSelected?: boolean;
   rounded?: boolean;
   expanded?: boolean;
   hasSubmenu?: boolean;
@@ -77,6 +78,7 @@ export const MenuItem = (props: MenuItemProps) => {
   const {
     menu,
     isActive,
+    isSelected,
     expanded,
     rounded,
     hasSubmenu,
@@ -131,7 +133,7 @@ export const MenuItem = (props: MenuItemProps) => {
     'aria-expanded': hasSubmenu ? (isChildrenVisible ? 'true' : 'false') : undefined,
     'data-menu-name': menu.name,
     'data-disabled': menu.disabled ? 'true' : undefined,
-    'aria-selected': isActive ? 'true' : 'false',
+    'aria-selected': (isSelected !== undefined ? isSelected : isActive) ? 'true' : 'false',
     ...extractBaseProps(props),
   };
 

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -131,6 +131,7 @@ export const MenuItem = (props: MenuItemProps) => {
     'aria-expanded': hasSubmenu ? (isChildrenVisible ? 'true' : 'false') : undefined,
     'data-menu-name': menu.name,
     'data-disabled': menu.disabled ? 'true' : undefined,
+    'aria-selected': isActive ? 'true' : 'false',
     ...extractBaseProps(props),
   };
 

--- a/core/components/organisms/verticalNav/VerticalNav.tsx
+++ b/core/components/organisms/verticalNav/VerticalNav.tsx
@@ -231,6 +231,7 @@ export const VerticalNav = (props: VerticalNavProps) => {
               menu={menu}
               expanded={expanded}
               isActive={isActive}
+              isSelected={isMenuActive(menus, menu, active)}
               hasSubmenu={hasSubmenu}
               isChildren={false}
               rounded={rounded}
@@ -253,6 +254,7 @@ export const VerticalNav = (props: VerticalNavProps) => {
                   rounded={rounded}
                   onClick={onClickHandler}
                   isActive={isMenuActive(menus, subMenu, active)}
+                  isSelected={isMenuActive(menus, subMenu, active)}
                   customItemRenderer={customItemRenderer}
                   customOptionRenderer={customOptionRenderer}
                   tabIndex={effectiveFocused === subMenu.name ? 0 : -1}

--- a/core/components/organisms/verticalNav/VerticalNav.tsx
+++ b/core/components/organisms/verticalNav/VerticalNav.tsx
@@ -231,7 +231,7 @@ export const VerticalNav = (props: VerticalNavProps) => {
               menu={menu}
               expanded={expanded}
               isActive={isActive}
-              isSelected={isMenuActive(menus, menu, active)}
+              isSelected={active?.name === menu.name || (!!active?.link && active.link === menu.link)}
               hasSubmenu={hasSubmenu}
               isChildren={false}
               rounded={rounded}
@@ -254,7 +254,7 @@ export const VerticalNav = (props: VerticalNavProps) => {
                   rounded={rounded}
                   onClick={onClickHandler}
                   isActive={isMenuActive(menus, subMenu, active)}
-                  isSelected={isMenuActive(menus, subMenu, active)}
+                  isSelected={active?.name === subMenu.name || (!!active?.link && active.link === subMenu.link)}
                   customItemRenderer={customItemRenderer}
                   customOptionRenderer={customOptionRenderer}
                   tabIndex={effectiveFocused === subMenu.name ? 0 : -1}

--- a/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
+++ b/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Vertical Navigation component
       >
         <a
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="patient_360"
           data-test="DesignSystem-VerticalNav--Item"
@@ -44,6 +45,7 @@ exports[`Vertical Navigation component
         <a
           aria-expanded="true"
           aria-level="1"
+          aria-selected="true"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="care_management"
           data-test="DesignSystem-VerticalNav--Item"
@@ -69,6 +71,7 @@ exports[`Vertical Navigation component
       >
         <a
           aria-level="2"
+          aria-selected="true"
           class="MenuItem MenuItem--vertical MenuItem--collapsed MenuItem--active color-primary-dark"
           data-menu-name="care_management.timeline"
           role="treeitem"
@@ -93,6 +96,7 @@ exports[`Vertical Navigation component
       >
         <a
           aria-level="2"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="care_management.care_plans"
           role="treeitem"
@@ -117,6 +121,7 @@ exports[`Vertical Navigation component
       >
         <a
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed MenuItem--disabled color-inverse-lightest"
           data-disabled="true"
           data-menu-name="episodes"
@@ -144,6 +149,7 @@ exports[`Vertical Navigation component
         <a
           aria-expanded="false"
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="risk"
           data-test="DesignSystem-VerticalNav--Item"
@@ -191,6 +197,7 @@ exports[`Vertical Navigation component
       </div>
       <a
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="patient_360"
         data-test="DesignSystem-VerticalNav--Item"
@@ -235,6 +242,7 @@ exports[`Vertical Navigation component
       <a
         aria-expanded="true"
         aria-level="1"
+        aria-selected="true"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="care_management"
         data-test="DesignSystem-VerticalNav--Item"
@@ -268,6 +276,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         aria-level="2"
+        aria-selected="true"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--active MenuItem--activeExpanded MenuItem--activeExpandedRounded MenuItem--subMenu MenuItem--rounded pr-5 color-primary-dark"
         data-menu-name="care_management.timeline"
         role="treeitem"
@@ -293,6 +302,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         aria-level="2"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--subMenu MenuItem--rounded pr-5 color-inverse"
         data-menu-name="care_management.care_plans"
         role="treeitem"
@@ -318,6 +328,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--disabled MenuItem--rounded color-inverse-lightest"
         data-disabled="true"
         data-menu-name="episodes"
@@ -352,6 +363,7 @@ exports[`Vertical Navigation component
       <a
         aria-expanded="false"
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="risk"
         data-test="DesignSystem-VerticalNav--Item"

--- a/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
+++ b/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`Vertical Navigation component
         <a
           aria-expanded="true"
           aria-level="1"
-          aria-selected="true"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="care_management"
           data-test="DesignSystem-VerticalNav--Item"
@@ -242,7 +242,7 @@ exports[`Vertical Navigation component
       <a
         aria-expanded="true"
         aria-level="1"
-        aria-selected="true"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="care_management"
         data-test="DesignSystem-VerticalNav--Item"


### PR DESCRIPTION
## Summary
- Added `aria-current="page"` to the `VerticalNavigation` active menu items for screen reader identification.
- Added `aria-selected` state to the `VerticalNav > MenuItem` active menu items to support Tree view semantics.
- Removed `chatInput` and `Radio` from the PR scope as those are handled directly on the base branch.

## Test plan
- Verified changes manually with accessibility tools.
- Ensured snapshot tests are correctly updated.