### PR TITLE
fix(VerificationCodeInput): generate unique IDs per input field

### DIFF
--- a/core/components/molecules/verificationCodeInput/VerificationCodeInput.tsx
+++ b/core/components/molecules/verificationCodeInput/VerificationCodeInput.tsx
@@ -73,6 +73,7 @@ const VerificationCodeInput = (props: VerificationCodeInputProps) => {
     onBlur,
     className,
     value,
+    id,
     ...rest
   } = props;
 
@@ -227,6 +228,7 @@ const VerificationCodeInput = (props: VerificationCodeInputProps) => {
           onKeyDown={onKeyDown}
           onFocus={onFocusHandler}
           onBlur={onBlurHandler}
+          id={id ? `${id}-${index}` : undefined}
           data-id={index}
           ref={refs[index]}
           type={type}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

generate unique IDs per input field

When an `id` prop is passed, each input now receives a suffixed ID
(e.g. `otp-0`, `otp-1`) instead of all inputs sharing the same `id`,
which violated the HTML uniqueness constraint and broke label/a11y associations.


### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
