### PR TITLE
Fix inputmaskp1

### DIFF
--- a/core/components/atoms/helpText/HelpText.tsx
+++ b/core/components/atoms/helpText/HelpText.tsx
@@ -12,10 +12,14 @@ export interface HelpTextProps extends BaseProps {
    * Shows error state in case of failed validation
    */
   error?: boolean;
+  /**
+   * HTML id attribute for the help text element, used for aria-describedby associations
+   */
+  id?: string;
 }
 
 export const HelpText = (props: HelpTextProps) => {
-  const { error, message, className } = props;
+  const { error, message, className, id } = props;
   const baseProps = extractBaseProps(props);
 
   const classes = classNames(
@@ -28,11 +32,12 @@ export const HelpText = (props: HelpTextProps) => {
   if (!message) return null;
 
   if (error) {
-    return <InlineMessage size="small" className={classes} appearance="alert" description={message} />;
+    const inlineMessage = <InlineMessage size="small" className={classes} appearance="alert" description={message} />;
+    return id ? <div id={id}>{inlineMessage}</div> : inlineMessage;
   }
 
   return (
-    <div {...baseProps} className={classes}>
+    <div id={id} {...baseProps} className={classes}>
       <Text appearance="subtle" size="small" weight="medium">
         {message}
       </Text>

--- a/core/components/molecules/inputMask/InputMask.tsx
+++ b/core/components/molecules/inputMask/InputMask.tsx
@@ -62,6 +62,8 @@ type InputMaskType = React.ForwardRefExoticComponent<InputProps & MaskProps & Re
   };
 };
 
+let helpTextIdCounter = 0;
+
 /**
  * It works as Uncontrolled Input
  *
@@ -125,6 +127,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
   const defaultSelection = React.useMemo(() => getDefaultSelection(), [getDefaultSelection]);
 
   const ref = React.useRef<HTMLInputElement>(null);
+  const helpTextId = React.useRef(`DesignSystem-InputMask--helpText-${++helpTextIdCounter}`).current;
   const deferId = React.useRef<number | undefined>();
   const selectionPos = React.useRef<SelectionPos>(defaultSelection);
   const newSelectionPos = React.useRef<number>(0);
@@ -387,6 +390,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
   );
 
   const isValueEqualPlaceholder = value === defaultPlaceholderValue;
+  const helpMessage = error ? caption : helpText;
 
   return (
     <div className={classes} data-test="DesignSystem-InputMask--Wrapper">
@@ -406,9 +410,10 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
         onBlur={onBlurHandler}
         onPaste={onPasteHandler}
         autoComplete={'off'}
+        aria-describedby={helpMessage ? helpTextId : undefined}
         ref={ref}
       />
-      <HelpText message={error ? caption : helpText} error={error} />
+      <HelpText message={helpMessage} error={error} id={helpMessage ? helpTextId : undefined} />
     </div>
   );
 });

--- a/core/components/molecules/inputMask/InputMask.tsx
+++ b/core/components/molecules/inputMask/InputMask.tsx
@@ -89,6 +89,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
     className,
     id,
     helpText,
+    'aria-describedby': ariaDescribedBy,
     ...rest
   } = props;
 
@@ -410,7 +411,9 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
         onBlur={onBlurHandler}
         onPaste={onPasteHandler}
         autoComplete={'off'}
-        aria-describedby={helpMessage ? helpTextId : undefined}
+        aria-describedby={
+          [ariaDescribedBy, helpMessage ? helpTextId : undefined].filter(Boolean).join(' ') || undefined
+        }
         ref={ref}
       />
       <HelpText message={helpMessage} error={error} id={helpMessage ? helpTextId : undefined} />


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Screen readers had no programmatic association between the InputMask's <input> and its rendered HelpText/caption. Generates a unique ID per instance and sets aria-describedby on the input, with the matching id on the HelpText container. HelpText gains an optional id prop to support this without changing its DOM structure for existing usages.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
