### PR TITLE
fix(VerticalNav): resolve click regression and focus visibility

### DIFF
--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -164,8 +164,6 @@ export const MenuItem = (props: MenuItemProps) => {
     return null;
   };
 
-  if (!expanded && !menu.icon) return null;
-
   const MenuIconFn = React.useCallback(() => MenuIcon({ isChildrenVisible }), [isChildrenVisible]);
 
   const MenuLabelFn = React.useCallback(
@@ -180,6 +178,8 @@ export const MenuItem = (props: MenuItemProps) => {
       menu.count !== undefined ? MenuPills({ disabled: menu.disabled, isActive: isActive, count: menu.count }) : <></>,
     [menu.count, menu.disabled, isActive]
   );
+
+  if (!expanded && !menu.icon) return null;
 
   const customItemProps = {
     ...props,

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -166,14 +166,28 @@ export const MenuItem = (props: MenuItemProps) => {
 
   if (!expanded && !menu.icon) return null;
 
+  const MenuIconFn = React.useCallback(() => MenuIcon({ isChildrenVisible }), [isChildrenVisible]);
+
+  const MenuLabelFn = React.useCallback(
+    () => MenuLabel({ label: menu.label, labelColor: itemColor }),
+    [MenuLabel, menu.label, itemColor]
+  );
+
+  const MenuWrapperFn = React.useCallback((wrapperProps: any) => MenuWrapper(wrapperProps), []);
+
+  const MenuPillsFn = React.useCallback(
+    () =>
+      menu.count !== undefined ? MenuPills({ disabled: menu.disabled, isActive: isActive, count: menu.count }) : <></>,
+    [menu.count, menu.disabled, isActive]
+  );
+
   const customItemProps = {
     ...props,
     contentRef,
-    MenuIcon: () => MenuIcon({ isChildrenVisible }),
-    MenuLabel: () => MenuLabel({ label: menu.label, labelColor: itemColor }),
-    MenuWrapper: (props: any) => MenuWrapper(props),
-    MenuPills: () =>
-      menu.count !== undefined ? MenuPills({ disabled: menu.disabled, isActive: isActive, count: menu.count }) : <></>,
+    MenuIcon: MenuIconFn,
+    MenuLabel: MenuLabelFn,
+    MenuWrapper: MenuWrapperFn,
+    MenuPills: MenuPillsFn,
   };
 
   return customItemRenderer ? (

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -90,29 +90,32 @@ export const MenuItem = (props: MenuItemProps) => {
 
   const [isTextTruncated, setIsTextTruncated] = React.useState(false);
   const { detectTruncation } = Tooltip.useAutoTooltip();
-  const contentRef = React.createRef<HTMLElement>();
+  const contentRef = React.useRef<HTMLElement>(null);
 
   React.useEffect(() => {
     const isTruncated = detectTruncation(contentRef);
     setIsTextTruncated(isTruncated);
-  }, [contentRef]);
+  }, [menu.label, expanded]);
 
-  const MenuLabel = (props: MenuLabelProps) => {
-    const { label, labelColor } = props;
+  const MenuLabel = React.useCallback(
+    (props: MenuLabelProps) => {
+      const { label, labelColor } = props;
 
-    const labelClass = classNames({
-      [styles['MenuItem-Text']]: true,
-      [styles['MenuItem--overflow']]: true,
-      ['mr-5']: !hasSubmenu && menu.count,
-      ['ellipsis--noWrap']: true,
-    });
+      const labelClass = classNames({
+        [styles['MenuItem-Text']]: true,
+        [styles['MenuItem--overflow']]: true,
+        ['mr-5']: !hasSubmenu && menu.count,
+        ['ellipsis--noWrap']: true,
+      });
 
-    return (
-      <Text data-test="DesignSystem-VerticalNav--Text" ref={contentRef} color={labelColor} className={labelClass}>
-        {label}
-      </Text>
-    );
-  };
+      return (
+        <Text data-test="DesignSystem-VerticalNav--Text" ref={contentRef} color={labelColor} className={labelClass}>
+          {label}
+        </Text>
+      );
+    },
+    [hasSubmenu, menu.count]
+  );
 
   const onClickHandler = (ev: { preventDefault: () => void }) => {
     ev.preventDefault();

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -95,7 +95,7 @@ export const MenuItem = (props: MenuItemProps) => {
   React.useEffect(() => {
     const isTruncated = detectTruncation(contentRef);
     setIsTextTruncated(isTruncated);
-  }, [menu.label, expanded]);
+  }, [menu.label, expanded, menu.count, hasSubmenu]);
 
   const MenuLabel = React.useCallback(
     (props: MenuLabelProps) => {

--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -95,7 +95,7 @@ export const MenuItem = (props: MenuItemProps) => {
   React.useEffect(() => {
     const isTruncated = detectTruncation(contentRef);
     setIsTextTruncated(isTruncated);
-  }, [menu.label, expanded, menu.count, hasSubmenu]);
+  }, [menu.label, expanded, menu.count, hasSubmenu, menu.icon]);
 
   const MenuLabel = React.useCallback(
     (props: MenuLabelProps) => {

--- a/css/src/components/verticalNav.module.css
+++ b/css/src/components/verticalNav.module.css
@@ -74,20 +74,24 @@
   background: var(--secondary-dark);
 }
 
-.MenuItem:focus {
+.MenuItem:focus-visible {
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
 
-.MenuItem--expanded:focus {
+.MenuItem:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.MenuItem--expanded:focus-visible {
   clip-path: inset(-6px -6px -6px 0);
 }
 
-.MenuItem--expandedRounded:focus {
+.MenuItem--expandedRounded:focus-visible {
   clip-path: inset(-6px);
 }
 
-.MenuItem--disabled:focus {
+.MenuItem--disabled:focus-visible {
   outline: none;
 }
 
@@ -130,9 +134,13 @@
   color: var(--primary-darker);
 }
 
-.MenuItem--active:focus {
+.MenuItem--active:focus-visible {
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
+}
+
+.MenuItem--active:focus:not(:focus-visible) {
+  outline: none;
 }
 
 .MenuItem--rounded {


### PR DESCRIPTION
## Summary
- Prevents the internal `MenuLabel` from unmounting during the `mousedown`/`mouseup` lifecycle by wrapping it in `React.useCallback()`. This resolves the regression where clicking on the label text failed to trigger the `onClick` event.
- Fixes a reference bug by replacing `React.createRef()` with `React.useRef()` so that `contentRef` does not mutate across renders. Also fixes the `detectTruncation` effect to depend on `[menu.label, expanded]`.
- Updates `css/src/components/verticalNav.module.css` to use `:focus-visible` instead of `:focus`. This strictly applies keyboard focus styling and prevents the outline from incorrectly displaying when users click items with their mouse.