### PR TITLE
fix(Calendar): new codex comments

### DIFF
--- a/core/components/organisms/calendar/Calendar.tsx
+++ b/core/components/organisms/calendar/Calendar.tsx
@@ -513,7 +513,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     return false;
   };
 
-  selectYear = (year: number) => () => {
+  selectYear = (year: number, disabled?: boolean) => () => {
+    if (disabled) return;
     this.updateState(year);
     this.setState({
       view: 'month',
@@ -536,7 +537,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
     if (onYearHover) onYearHover(yearData, ev);
   };
 
-  selectMonth = (month: number) => () => {
+  selectMonth = (month: number, disabled?: boolean) => () => {
+    if (disabled) return;
     this.updateState(this.state.yearNav, month);
     this.setState({
       view: 'date',
@@ -870,7 +872,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                 aria-label={year.toString()}
                 aria-disabled={disabled}
                 aria-selected={active}
-                onClick={this.selectYear(year)}
+                onClick={this.selectYear(year, disabled)}
                 onKeyDown={(ev) => this.handleYearCellKeyDown(ev, year, offset, disabled)}
                 onFocus={() => this.setState({ focusedYearIndex: offset })}
                 onMouseOver={this.yearMouseOverHandler.bind(this, year, isCurrentYear(), disabled)}
@@ -975,7 +977,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                 aria-label={months[month]}
                 aria-disabled={disabled}
                 aria-selected={active}
-                onClick={this.selectMonth(month)}
+                onClick={this.selectMonth(month, disabled)}
                 onKeyDown={(ev) => this.handleMonthCellKeyDown(ev, month, disabled)}
                 onFocus={() => this.setState({ focusedMonth: month })}
                 onMouseOver={this.monthMouseOverHandler.bind(this, month, isCurrentMonth(), disabled)}
@@ -1134,6 +1136,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
       event: ev,
       container,
       focusedDate,
+      startOfWeekIndex: getIndexOfDay(this.props.firstDayOfWeek),
       isDateDisabled: (d: Date) => {
         return (
           compareDate(this.props.disabledBefore, 'more', d.getFullYear(), d.getMonth(), d.getDate()) ||
@@ -1304,7 +1307,8 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
 
     const events = this.props.events;
 
-    const onClickHandler = (date: number) => () => {
+    const onClickHandler = (date: number, disabled: boolean) => () => {
+      if (disabled) return;
       if (rangePicker) {
         if (startDate && endDate) {
           this.selectDate(index, date, prevMonthDayRange, dayRange);
@@ -1593,7 +1597,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                   aria-label={formatDateAriaLabel(fullDate)}
                   aria-disabled={disabled}
                   aria-selected={Boolean(active || activeDate)}
-                  onClick={onClickHandler(date)}
+                  onClick={onClickHandler(date, disabled)}
                   onKeyDown={(ev) =>
                     this.handleDateCellKeyDown(
                       ev,

--- a/core/components/organisms/calendar/Calendar.tsx
+++ b/core/components/organisms/calendar/Calendar.tsx
@@ -1381,9 +1381,10 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
           else if (index === monthsInView - 1) renders = d > dayRange;
         }
         if (!renders) return false;
+        const actualD = this.getDateValue(yearNavVal, monthNavVal, d) || new Date();
         const disabled =
-          compareDate(disabledBefore, 'more', yearNavVal, monthNavVal, d) ||
-          compareDate(disabledAfter, 'less', yearNavVal, monthNavVal, d);
+          compareDate(disabledBefore, 'more', actualD.getFullYear(), actualD.getMonth(), actualD.getDate()) ||
+          compareDate(disabledAfter, 'less', actualD.getFullYear(), actualD.getMonth(), actualD.getDate());
         return !disabled;
       };
 
@@ -1430,9 +1431,22 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
           {Array.from({ length: daysInRow }, (_x, colIndex) => {
             const date = daysInRow * row + colIndex - dummyDays + 1;
             const dummy = date <= 0 || date > dayRange;
+            const actualDateObj = this.getDateValue(yearNavVal, monthNavVal, date) || new Date();
             const disabled =
-              compareDate(disabledBefore, 'more', yearNavVal, monthNavVal, date) ||
-              compareDate(disabledAfter, 'less', yearNavVal, monthNavVal, date);
+              compareDate(
+                disabledBefore,
+                'more',
+                actualDateObj.getFullYear(),
+                actualDateObj.getMonth(),
+                actualDateObj.getDate()
+              ) ||
+              compareDate(
+                disabledAfter,
+                'less',
+                actualDateObj.getFullYear(),
+                actualDateObj.getMonth(),
+                actualDateObj.getDate()
+              );
             let active = !disabled && yearState === yearNavVal && monthState === monthNavVal && dateState === date;
             const today = () => {
               let boolVal;

--- a/core/components/organisms/calendar/utils.ts
+++ b/core/components/organisms/calendar/utils.ts
@@ -130,6 +130,7 @@ export interface HandleDateViewKeyDownParams {
   event: React.KeyboardEvent;
   container: HTMLElement;
   focusedDate: Date;
+  startOfWeekIndex?: number;
   isDateDisabled?: (d: Date) => boolean;
   onNavigate: (newDate: Date) => void;
   onSelect: () => void;
@@ -148,6 +149,7 @@ export const handleDateViewKeyDown = (params: HandleDateViewKeyDownParams): bool
   const {
     event,
     focusedDate,
+    startOfWeekIndex = 0,
     isDateDisabled,
     onNavigate,
     onSelect,
@@ -159,6 +161,8 @@ export const handleDateViewKeyDown = (params: HandleDateViewKeyDownParams): bool
   } = params;
 
   let newDate: Date | null = null;
+  const currentDayIndex = focusedDate.getDay();
+  const visualColumnIndex = (currentDayIndex - startOfWeekIndex + 7) % 7;
 
   switch (event.key) {
     case 'ArrowUp':
@@ -179,11 +183,11 @@ export const handleDateViewKeyDown = (params: HandleDateViewKeyDownParams): bool
       break;
     case 'Home':
       newDate = new Date(focusedDate);
-      newDate.setDate(focusedDate.getDate() - focusedDate.getDay());
+      newDate.setDate(focusedDate.getDate() - visualColumnIndex);
       break;
     case 'End':
       newDate = new Date(focusedDate);
-      newDate.setDate(focusedDate.getDate() + (6 - focusedDate.getDay()));
+      newDate.setDate(focusedDate.getDate() + (6 - visualColumnIndex));
       break;
     case 'PageUp':
       event.preventDefault();

--- a/core/components/organisms/calendar/utils.ts
+++ b/core/components/organisms/calendar/utils.ts
@@ -210,6 +210,7 @@ export const handleDateViewKeyDown = (params: HandleDateViewKeyDownParams): bool
     case 'Spacebar':
       event.preventDefault();
       if (event.repeat) return true;
+      if (isDateDisabled && isDateDisabled(focusedDate)) return true;
       onSelect();
       return true;
     case 'Escape':


### PR DESCRIPTION
## Summary
This pull request brings several accessibility and keyboard navigation improvements to the Calendar component:
- Prevents selection of explicitly disabled calendar values (clicking an `aria-disabled` cell no longer updates the value)
- Fixes `Home`/`End` keyboard boundaries to accurately map to visually rendered rows based on `firstDayOfWeek`
- Adds default `aria-label`s to prev/next navigation buttons
- Exposes active states via `aria-selected` and properly manages disabled states.
- Ensures month and year grids properly respect keyboard interactions and boundary constraints.

## Test plan
- Verify `disabledBefore` and `disabledAfter` logic is not bypassed via clicks.
- Using keyboard navigation, ensure `Home` and `End` properly seek to the bounds of the rendered weeks irrespective of `firstDayOfWeek`.