### PR TITLE
fix(scrollbar): use native browser scrollbar

### DIFF
--- a/css/src/components/grid.module.css
+++ b/css/src/components/grid.module.css
@@ -20,6 +20,7 @@
   z-index: 5;
   overflow-x: hidden;
   -ms-overflow-style: none;
+  scrollbar-width: none;
   border-right: var(--border-width-7-5) solid var(--secondary);
 }
 
@@ -71,6 +72,8 @@
   display: flex;
   flex: 0 0 auto;
   overflow-x: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
   border-bottom: var(--border);
 }
 
@@ -102,7 +105,7 @@
   flex-direction: column;
   flex-grow: 1;
   overflow-x: auto;
-  overflow-y: overlay;
+  overflow-y: auto;
 }
 
 .Grid-rowWrapper {

--- a/css/src/core/utilities.css
+++ b/css/src/core/utilities.css
@@ -18,26 +18,3 @@
 .Overlay-container--close {
   animation-timing-function: cubic-bezier(0.4, 0.14, 1, 1);
 }
-
-::-webkit-scrollbar {
-  width: 16px;
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--secondary-dark);
-  border-radius: 8px;
-  border: 2px solid transparent;
-  background-clip: content-box;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--inverse-lightest);
-  border: 2px solid transparent;
-  background-clip: content-box;
-}
-
-::-webkit-scrollbar-thumb:active {
-  background: var(--inverse-lighter);
-  border: 2px solid transparent;
-  background-clip: content-box;
-}


### PR DESCRIPTION
## Summary
- remove the global DS custom scrollbar skin so components use the browser or OS native scrollbar
- switch grid body scrolling from overlay to auto while keeping existing header alignment behavior
- keep the source free of the added scrollbar gutter and safe-area offset logic
