### PR TITLE
fix(FileUploader): keyboard file picker and SSR-stable ids

### DIFF
--- a/core/components/molecules/fileUploader/FileUploader.tsx
+++ b/core/components/molecules/fileUploader/FileUploader.tsx
@@ -4,7 +4,7 @@ import { Text } from '@/index';
 import FileUploaderFormat, { FileUploaderFormatProps } from './FileUploaderFormat';
 import FileUploaderButton, { FileUploaderButtonProps } from './FileUploaderButton';
 import { BaseProps, extractBaseProps } from '@/utils/types';
-import uidGenerator from '@/utils/uidGenerator';
+import { useStableDomId } from '@/utils/useStableDomId';
 import styles from '@css/components/fileUploader.module.css';
 
 export interface FileUploaderProps extends FileUploaderButtonProps, FileUploaderFormatProps, BaseProps {
@@ -39,11 +39,7 @@ export const FileUploader = (props: FileUploaderProps) => {
   } = props;
 
   const baseProps = extractBaseProps(props);
-  const baseIdRef = React.useRef<string | null>(null);
-  if (!baseIdRef.current) {
-    baseIdRef.current = `file-uploader-${uidGenerator()}`;
-  }
-  const baseId = baseIdRef.current;
+  const baseId = useStableDomId('file-uploader');
   const titleId = `${baseId}-title`;
   const sizeLabelId = `${baseId}-size`;
 

--- a/core/components/molecules/fileUploader/FileUploaderButton.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { Button } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
+import uidGenerator from '@/utils/uidGenerator';
 import styles from '@css/components/fileUploader.module.css';
 
 export interface FileUploaderButtonProps extends BaseProps {
@@ -58,6 +59,14 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
   } = props;
 
   const baseProps = extractBaseProps(props);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const inputId = React.useMemo(() => id || `ds-file-uploader-input-${uidGenerator()}`, [id]);
+
+  const openFilePicker = React.useCallback(() => {
+    if (disabled) return;
+    inputRef.current?.click();
+  }, [disabled]);
 
   const FileUploaderButtonClass = classNames(
     {
@@ -68,12 +77,13 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
 
   return (
     <div {...baseProps} className={FileUploaderButtonClass}>
-      <Button type="button" disabled={disabled} icon="backup">
+      <Button type="button" disabled={disabled} icon="backup" onClick={openFilePicker} aria-controls={inputId}>
         {uploadButtonLabel}
       </Button>
       <input
+        ref={inputRef}
         name={name}
-        id={id}
+        id={inputId}
         data-test="DesignSystem-FileUploaderButton--Input"
         accept={accept && accept.join(', ')}
         multiple={multiple}

--- a/core/components/molecules/fileUploader/FileUploaderButton.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { Button } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
-import uidGenerator from '@/utils/uidGenerator';
+import { useStableDomId } from '@/utils/useStableDomId';
 import styles from '@css/components/fileUploader.module.css';
 
 export interface FileUploaderButtonProps extends BaseProps {
@@ -11,7 +11,7 @@ export interface FileUploaderButtonProps extends BaseProps {
    */
   name?: string;
   /**
-   * Id of `FileUploaderInput`
+   * Id of `FileUploaderInput`. Prefer setting this in SSR apps on React &lt; 18 so server and client markup match.
    */
   id?: string;
   /**
@@ -60,8 +60,9 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
 
   const baseProps = extractBaseProps(props);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const generatedInputId = useStableDomId('ds-file-uploader-input');
 
-  const inputId = React.useMemo(() => id || `ds-file-uploader-input-${uidGenerator()}`, [id]);
+  const inputId = id || generatedInputId;
 
   const openFilePicker = React.useCallback(() => {
     if (disabled) return;

--- a/core/components/molecules/fileUploader/__tests__/FileUploader.test.tsx
+++ b/core/components/molecules/fileUploader/__tests__/FileUploader.test.tsx
@@ -163,6 +163,28 @@ describe('FileUploader component prop:onChange', () => {
     fireEvent.change(getByTestId('DesignSystem-FileUploaderButton--Input'));
     expect(FunctionValue).toHaveBeenCalled();
   });
+
+  it('forwards button click to file input so keyboard and mouse use the same path', () => {
+    const { getByTestId } = render(<FileUploader onChange={FunctionValue} />);
+    const input = getByTestId('DesignSystem-FileUploaderButton--Input') as HTMLInputElement;
+    const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {});
+
+    fireEvent.click(getByTestId('DesignSystem-Button'));
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    clickSpy.mockRestore();
+  });
+
+  it('does not call file input click when disabled', () => {
+    const { getByTestId } = render(<FileUploader onChange={FunctionValue} disabled />);
+    const input = getByTestId('DesignSystem-FileUploaderButton--Input') as HTMLInputElement;
+    const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {});
+
+    fireEvent.click(getByTestId('DesignSystem-Button'));
+
+    expect(clickSpy).not.toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
 });
 
 describe('FileUploader component prop:disabled', () => {

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`FileUploader component
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -60,6 +61,7 @@ exports[`FileUploader component
         aria-labelledby="file-uploader-Test-uid-title"
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -94,6 +96,7 @@ exports[`FileUploader component prop:accept snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -123,6 +126,7 @@ exports[`FileUploader component prop:accept snapshot
         aria-labelledby="file-uploader-Test-uid-title"
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -157,6 +161,7 @@ exports[`FileUploader component prop:disabled snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -185,6 +190,7 @@ exports[`FileUploader component prop:disabled snapshot
         aria-labelledby="file-uploader-Test-uid-title"
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -219,6 +225,7 @@ exports[`FileUploader component prop:disabled snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         disabled=""
@@ -249,6 +256,7 @@ exports[`FileUploader component prop:disabled snapshot
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
         disabled=""
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -283,6 +291,7 @@ exports[`FileUploader component prop:multiple snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -311,6 +320,7 @@ exports[`FileUploader component prop:multiple snapshot
         aria-labelledby="file-uploader-Test-uid-title"
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         tabindex="-1"
         type="file"
       />
@@ -345,6 +355,7 @@ exports[`FileUploader component prop:multiple snapshot
       class="FileUploaderButton mt-5"
     >
       <button
+        aria-controls="ds-file-uploader-input-Test-uid"
         class="Button Button--regular Button--basic Button--iconAlign-left"
         data-test="DesignSystem-Button"
         tabindex="0"
@@ -373,6 +384,7 @@ exports[`FileUploader component prop:multiple snapshot
         aria-labelledby="file-uploader-Test-uid-title"
         class="FileUploaderButton-input"
         data-test="DesignSystem-FileUploaderButton--Input"
+        id="ds-file-uploader-input-Test-uid"
         multiple=""
         tabindex="-1"
         type="file"

--- a/core/utils/useStableDomId.tsx
+++ b/core/utils/useStableDomId.tsx
@@ -3,17 +3,19 @@ import uidGenerator from '@/utils/uidGenerator';
 
 const reactUseId = (React as { useId?: () => string }).useId;
 
-function useStableDomIdWithReactUseId(prefix: string): string {
+function useStableDomIdWithReactUseId(prefix: string): string | undefined {
   const generated = reactUseId!();
   return `${prefix}-${generated}`;
 }
 
-function useStableDomIdWithUidFallback(prefix: string): string {
-  const ref = React.useRef<string | null>(null);
-  if (ref.current === null) {
-    ref.current = `${prefix}-${uidGenerator()}`;
-  }
-  return ref.current;
+function useStableDomIdWithUidFallback(prefix: string): string | undefined {
+  const [id, setId] = React.useState<string>();
+
+  React.useEffect(() => {
+    setId(`${prefix}-${uidGenerator()}`);
+  }, [prefix]);
+
+  return id;
 }
 
 /**

--- a/core/utils/useStableDomId.tsx
+++ b/core/utils/useStableDomId.tsx
@@ -3,19 +3,19 @@ import uidGenerator from '@/utils/uidGenerator';
 
 const reactUseId = (React as { useId?: () => string }).useId;
 
-function useStableDomIdWithReactUseId(prefix: string): string | undefined {
+function useStableDomIdWithReactUseId(prefix: string): string {
   const generated = reactUseId!();
   return `${prefix}-${generated}`;
 }
 
-function useStableDomIdWithUidFallback(prefix: string): string | undefined {
-  const [id, setId] = React.useState<string>();
+function useStableDomIdWithUidFallback(prefix: string): string {
+  const idRef = React.useRef<string | null>(null);
 
-  React.useEffect(() => {
-    setId(`${prefix}-${uidGenerator()}`);
-  }, [prefix]);
+  if (idRef.current === null) {
+    idRef.current = `${prefix}-${uidGenerator()}`;
+  }
 
-  return id;
+  return idRef.current;
 }
 
 /**

--- a/core/utils/useStableDomId.tsx
+++ b/core/utils/useStableDomId.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import uidGenerator from '@/utils/uidGenerator';
+
+const reactUseId = (React as { useId?: () => string }).useId;
+
+function useStableDomIdWithReactUseId(prefix: string): string {
+  const generated = reactUseId!();
+  return `${prefix}-${generated}`;
+}
+
+function useStableDomIdWithUidFallback(prefix: string): string {
+  const ref = React.useRef<string | null>(null);
+  if (ref.current === null) {
+    ref.current = `${prefix}-${uidGenerator()}`;
+  }
+  return ref.current;
+}
+
+/**
+ * DOM `id` prefix helper: stable across SSR + hydration on React 18+ (`useId`).
+ * On React 16/17, falls back to `uidGenerator` (not SSR-stable); pass an explicit `id` prop when SSR matters.
+ */
+export const useStableDomId =
+  typeof reactUseId === 'function' ? useStableDomIdWithReactUseId : useStableDomIdWithUidFallback;

--- a/css/src/components/calendar.module.css
+++ b/css/src/components/calendar.module.css
@@ -208,7 +208,6 @@
   border: var(--border-width-2-5) solid transparent;
   transition: var(--duration--fast-01) var(--standard-productive-curve);
 
-
   /* Button reset (used on <button> for a11y) */
   background: transparent;
   padding: 0;

--- a/css/src/components/fileUploader.module.css
+++ b/css/src/components/fileUploader.module.css
@@ -17,6 +17,8 @@
   font-size: 0;
   z-index: 2;
   cursor: pointer;
+  /* Clicks go to the Button so keyboard (Enter/Space) and mouse share one activation path */
+  pointer-events: none;
 }
 
 .FileUploaderItem {

--- a/css/src/components/fileUploader.module.css
+++ b/css/src/components/fileUploader.module.css
@@ -17,8 +17,7 @@
   font-size: 0;
   z-index: 2;
   cursor: pointer;
-  /* Clicks go to the Button so keyboard (Enter/Space) and mouse share one activation path */
-  pointer-events: none;
+  /* Native clicks on the overlay open the file dialog without JS (SSR / pre-hydration). Keyboard users still use the Button, which calls input.click(). */
 }
 
 .FileUploaderItem {


### PR DESCRIPTION
## Summary
- Opens the system file picker from the visible upload **button** (click + keyboard) via `input.click()`, with `pointer-events: none` removed on the overlay input so mouse clicks natively open the picker before hydration.
- Adds `useStableDomId` to use `React.useId` on React 18+ for SSR-safe generated ids, falling back to `uidGenerator` on React 16.

## Testing
- `npx jest core/components/molecules/fileUploader --no-coverage`