### PR TITLE
fix(Label): add aria-hidden to required dot and sr-only text for screen

### DIFF
--- a/core/components/atoms/label/Label.tsx
+++ b/core/components/atoms/label/Label.tsx
@@ -73,7 +73,10 @@ export const Label = (props: LabelProps) => {
         'mb-3-5 mt-2': size && size === 'small',
       });
       return (
-        <span className={requiredIndicator} aria-label="required" data-test="DesignSystem-Label--RequiredIndicator" />
+        <>
+          <span className={requiredIndicator} aria-hidden="true" data-test="DesignSystem-Label--RequiredIndicator" />
+          <span className={styles['Label-srOnly']}>(required)</span>
+        </>
       );
     }
 

--- a/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -246,10 +246,15 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
       >
         Complex Small Label
         <span
-          aria-label="required"
+          aria-hidden="true"
           class="Label-requiredIndicator mb-3-5 mt-2"
           data-test="DesignSystem-Label--RequiredIndicator"
         />
+        <span
+          class="Label-srOnly"
+        >
+          (required)
+        </span>
         
         <div
           class="PopperWrapper-trigger"
@@ -306,10 +311,15 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
       >
         Small Required Label
         <span
-          aria-label="required"
+          aria-hidden="true"
           class="Label-requiredIndicator mb-3-5 mt-2"
           data-test="DesignSystem-Label--RequiredIndicator"
         />
+        <span
+          class="Label-srOnly"
+        >
+          (required)
+        </span>
       </label>
     </div>
   </div>

--- a/css/src/components/label.module.css
+++ b/css/src/components/label.module.css
@@ -33,6 +33,18 @@
   color: var(--text-disabled);
 }
 
+.Label-srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .Label-requiredIndicator {
   height: var(--spacing-15);
   width: var(--spacing-15);

--- a/css/src/components/label.module.css
+++ b/css/src/components/label.module.css
@@ -35,10 +35,10 @@
 
 .Label-srOnly {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: var(--spacing-2-5);
+  height: var(--spacing-2-5);
   padding: 0;
-  margin: -1px;
+  margin: calc(-1 * var(--spacing-2-5));
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;


### PR DESCRIPTION

### What does this implement/fix? Explain your changes.

core/components/atoms/label/Label.tsx


• Added aria-hidden="true" to the required indicator <span> — the visual red dot is now hidden from screen readers
• Added <span className={styles['Label-srOnly']}>(required)</span> — screen readers announce "(required)" instead of ignoring it
• Moved requiredIndicator classNames inside renderInfo so the small-size offset (mb-3-5 mt-2) applies conditionally
• Moved iconClass for the info icon into a proper classNames call to handle the mb-3-5 small-size offset

css/src/components/label.module.css

• Added .Label-srOnly — standard visually-hidden CSS class (position: absolute; width/height: 1px; clip; overflow: hidden) that keeps content accessible to screen readers while invisible on screen

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
