### PR TITLE
fix(TextField): associate label with control and link helpText via aria-describedby

### DIFF
--- a/core/components/organisms/textField/TextFieldCommon.tsx
+++ b/core/components/organisms/textField/TextFieldCommon.tsx
@@ -5,10 +5,12 @@ import { HelpText, Text } from '@/index';
 interface RenderHelpTextProps {
   helpText: string;
   error?: boolean;
+  id?: string;
 }
 
-export const RenderHelpText: React.FC<RenderHelpTextProps> = ({ helpText, error }) => (
+export const RenderHelpText: React.FC<RenderHelpTextProps> = ({ helpText, error, id }) => (
   <HelpText
+    id={id}
     className="d-flex"
     message={helpText.trim().length > 0 ? helpText : ' '}
     error={error ? error : undefined}

--- a/core/components/organisms/textField/TextFieldWithInput.tsx
+++ b/core/components/organisms/textField/TextFieldWithInput.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Input, Label } from '@/index';
 import { InputProps } from '@/index.type';
 import { BaseProps } from '@/utils/types';
+import uidGenerator from '@/utils/uidGenerator';
 import { RenderHelpText, RenderCounter } from './TextFieldCommon';
 
 export interface TextFieldWithInputProps extends BaseProps {
@@ -24,6 +25,15 @@ export const TextFieldWithInput = (props: TextFieldInputProps) => {
 
   const [inputText, setInputText] = React.useState<string>(value);
 
+  const fieldIdRef = React.useRef<string>(`TextField-input-${uidGenerator()}`);
+  const fieldId = props.id || fieldIdRef.current;
+
+  const helpTextIdRef = React.useRef<string | null>(null);
+  if (helpTextIdRef.current === null) {
+    helpTextIdRef.current = `TextField-helpText-${uidGenerator()}`;
+  }
+  const helpTextId = helpTextIdRef.current;
+
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     setInputText(event.target.value);
     if (onChange) onChange(event);
@@ -33,16 +43,26 @@ export const TextFieldWithInput = (props: TextFieldInputProps) => {
 
   const labelSize = size === 'tiny' ? 'small' : 'regular';
 
+  const hasHelpText = inputError || helpText.trim().length > 0;
+  const resolvedDescribedBy =
+    [props['aria-describedby'], hasHelpText ? helpTextId : undefined].filter(Boolean).join(' ') || undefined;
+
   return (
     <div>
       {label && (
-        <Label required={required} withInput={true} size={labelSize}>
+        <Label required={required} withInput={true} size={labelSize} htmlFor={fieldId}>
           {label}
         </Label>
       )}
-      <Input {...props} error={inputError} onChange={onChangeHandler} />
+      <Input
+        {...props}
+        id={fieldId}
+        error={inputError}
+        onChange={onChangeHandler}
+        aria-describedby={resolvedDescribedBy}
+      />
       <div className="d-flex justify-content-between" style={{ minWidth }}>
-        <RenderHelpText helpText={helpText} error={inputError} />
+        <RenderHelpText helpText={helpText} error={inputError} id={helpTextId} />
         <RenderCounter inputText={inputText} max={max} />
       </div>
     </div>

--- a/core/components/organisms/textField/TextFieldWithTextarea.tsx
+++ b/core/components/organisms/textField/TextFieldWithTextarea.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Textarea, Label } from '@/index';
 import { BaseProps } from '@/utils/types';
 import { TextareaProps } from '@/index.type';
+import uidGenerator from '@/utils/uidGenerator';
 import { RenderHelpText, RenderCounter } from './TextFieldCommon';
 
 export interface TextFieldWithTextareaProps extends BaseProps {
@@ -48,12 +49,25 @@ export const TextFieldWithTextarea = (props: TextFieldTextareaProps) => {
   const [inputText, setInputText] = React.useState<string>(value);
   const [helptextWidth, setHelptextWidth] = React.useState(0);
 
+  const fieldIdRef = React.useRef<string>(`TextField-textarea-${uidGenerator()}`);
+  const fieldId = props.id || fieldIdRef.current;
+
+  const helpTextIdRef = React.useRef<string | null>(null);
+  if (helpTextIdRef.current === null) {
+    helpTextIdRef.current = `TextField-helpText-${uidGenerator()}`;
+  }
+  const helpTextId = helpTextIdRef.current;
+
   const onChangeHandler = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInputText(e.target.value);
     if (onChange) onChange(e);
   };
 
   const inputError = error || inputText.length > max;
+
+  const hasHelpText = inputError || helpText.trim().length > 0;
+  const resolvedDescribedBy =
+    [props['aria-describedby'], hasHelpText ? helpTextId : undefined].filter(Boolean).join(' ') || undefined;
 
   React.useEffect(() => {
     const textarea = textareaRef.current;
@@ -75,20 +89,22 @@ export const TextFieldWithTextarea = (props: TextFieldTextareaProps) => {
   return (
     <div>
       {label && (
-        <Label required={required} withInput={true} size={size}>
+        <Label required={required} withInput={true} size={size} htmlFor={fieldId}>
           {label}
         </Label>
       )}
       <Textarea
         {...props}
+        id={fieldId}
         resize={resize}
         rows={rows}
         onChange={onChangeHandler}
         error={inputError}
+        aria-describedby={resolvedDescribedBy}
         ref={textareaRef}
       />
       <div className="d-flex justify-content-between" style={{ width: helptextWidth }}>
-        <RenderHelpText helpText={helpText} error={inputError} />
+        <RenderHelpText helpText={helpText} error={inputError} id={helpTextId} />
         <RenderCounter inputText={inputText} max={max} />
       </div>
     </div>

--- a/core/components/organisms/textField/__test__/__snapshots__/Textarea.test.tsx.snap
+++ b/core/components/organisms/textField/__test__/__snapshots__/Textarea.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`TextField component matches snapshot when input exceeds maximum charact
       <label
         class="Label-text"
         data-test="DesignSystem-Label--Text"
+        for="TextField-input-Test-uid"
       >
         Test Label
       </label>
@@ -21,9 +22,11 @@ exports[`TextField component matches snapshot when input exceeds maximum charact
       style="min-width: 256px;"
     >
       <input
+        aria-describedby="TextField-helpText-Test-uid"
         aria-invalid="true"
         class="Input-input Input-input--regular"
         data-test="DesignSystem-Input"
+        id="TextField-input-Test-uid"
         label="Test Label"
         max="298"
         name="test-name"
@@ -39,7 +42,7 @@ exports[`TextField component matches snapshot when input exceeds maximum charact
       <div
         class="InlineMessage mt-3 d-flex"
         data-test="DesignSystem-InlineMessage"
-        id="HelpText-Test-uid"
+        id="TextField-helpText-Test-uid"
       >
         <i
           aria-hidden="true"
@@ -98,6 +101,7 @@ exports[`textfield component
         <input
           class="Input-input Input-input--regular"
           data-test="DesignSystem-Input"
+          id="TextField-input-Test-uid"
           type="text"
           value=""
         />
@@ -108,7 +112,7 @@ exports[`textfield component
       >
         <div
           class="mt-3 d-flex"
-          id="HelpText-Test-uid"
+          id="TextField-helpText-Test-uid"
         >
           <span
             class="Text Text--subtle Text--medium Text--small"
@@ -160,6 +164,7 @@ exports[`textfield component
         <input
           class="Input-input Input-input--regular"
           data-test="DesignSystem-Input"
+          id="TextField-input-Test-uid"
           type="text"
           value=""
         />
@@ -170,7 +175,7 @@ exports[`textfield component
       >
         <div
           class="mt-3 d-flex"
-          id="HelpText-Test-uid"
+          id="TextField-helpText-Test-uid"
         >
           <span
             class="Text Text--subtle Text--medium Text--small"
@@ -220,6 +225,7 @@ exports[`textfield component
         <label
           class="Label-text"
           data-test="DesignSystem-Label--Text"
+          for="TextField-input-Test-uid"
         >
           description
         </label>
@@ -231,9 +237,11 @@ exports[`textfield component
         style="min-width: 256px;"
       >
         <input
+          aria-describedby="TextField-helpText-Test-uid"
           class="Input-input Input-input--regular"
           data-test="DesignSystem-Input"
           helptext="i am the helptext"
+          id="TextField-input-Test-uid"
           label="description"
           max="50"
           name="name"
@@ -247,7 +255,7 @@ exports[`textfield component
       >
         <div
           class="mt-3 d-flex"
-          id="HelpText-Test-uid"
+          id="TextField-helpText-Test-uid"
         >
           <span
             class="Text Text--subtle Text--medium Text--small"
@@ -297,15 +305,18 @@ exports[`textfield component
         <label
           class="Label-text"
           data-test="DesignSystem-Label--Text"
+          for="TextField-textarea-Test-uid"
         >
           description
         </label>
       </div>
       <textarea
+        aria-describedby="TextField-helpText-Test-uid"
         aria-invalid="false"
         class="Textarea Textarea--resize"
         data-test="DesignSystem-Textarea"
         helptext="i am the helptext"
+        id="TextField-textarea-Test-uid"
         label="description"
         max="50"
         name="name"
@@ -317,7 +328,7 @@ exports[`textfield component
       >
         <div
           class="mt-3 d-flex"
-          id="HelpText-Test-uid"
+          id="TextField-helpText-Test-uid"
         >
           <span
             class="Text Text--subtle Text--medium Text--small"
@@ -367,15 +378,18 @@ exports[`textfield component
         <label
           class="Label-text"
           data-test="DesignSystem-Label--Text"
+          for="TextField-textarea-Test-uid"
         >
           description
         </label>
       </div>
       <textarea
+        aria-describedby="TextField-helpText-Test-uid"
         aria-invalid="false"
         class="Textarea Textarea--resize"
         data-test="DesignSystem-Textarea"
         helptext="i am the helptext"
+        id="TextField-textarea-Test-uid"
         label="description"
         max="50"
         name="name"
@@ -388,7 +402,7 @@ exports[`textfield component
       >
         <div
           class="mt-3 d-flex"
-          id="HelpText-Test-uid"
+          id="TextField-helpText-Test-uid"
         >
           <span
             class="Text Text--subtle Text--medium Text--small"


### PR DESCRIPTION
## Summary

Fixes 3 P1/P0 ARIA audit issues in the TextField component (Input and Textarea variants):

- **Label–control association (P0)**: Generate a stable `fieldId` via `useRef` + `uidGenerator()`. Consumer `id` prop takes priority. Passed as `id` to `Input`/`Textarea` and as `htmlFor` to `Label` — clicking the visible label now correctly focuses the field.
- **HelpText linked via `aria-describedby` (P1)**: Generate a stable `helpTextId` and pass it as `id` to `HelpText`. Only include it in `aria-describedby` when help text content is non-empty or the field is in error — no empty IDs polluting the description.
- **Consumer `aria-describedby` merged**: Existing consumer-provided `aria-describedby` is merged with `helpTextId`.

Applied to both `TextFieldWithInput` and `TextFieldWithTextarea`.

## Test plan

- [ ] `<TextField label="Email" />` — clicking "Email" label focuses the input
- [ ] `<TextField label="Notes" helpText="Max 50 chars" />` — screen reader announces help text on focus
- [ ] `<TextField helpText=" " />` (default empty help) — `aria-describedby` omitted
- [ ] All 26 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)