### PR TITLE
fix(Textarea): correct htmlFor/id and aria-labelledby in Size story

### DIFF
--- a/core/components/atoms/textarea/__stories__/Size.story.tsx
+++ b/core/components/atoms/textarea/__stories__/Size.story.tsx
@@ -4,16 +4,28 @@ import { Textarea, Label } from '@/index';
 export const Size = () => (
   <div className="d-flex justify-content-between">
     <div className="w-50 pr-4">
-      <Label withInput={true} htmlFor="regular">
+      <Label id="label-regular" withInput={true} htmlFor="textarea-regular">
         Regular
       </Label>
-      <Textarea name="regular" size="regular" aria-labelledby="Regular" placeholder="Enter your comments here" />
+      <Textarea
+        id="textarea-regular"
+        name="regular"
+        size="regular"
+        aria-labelledby="label-regular"
+        placeholder="Enter your comments here"
+      />
     </div>
     <div className="w-50">
-      <Label withInput={true} size="small" htmlFor="small">
+      <Label id="label-small" withInput={true} size="small" htmlFor="textarea-small">
         Small
       </Label>
-      <Textarea name="small" size="small" aria-labelledby="Small" placeholder="Enter your comments here" />
+      <Textarea
+        id="textarea-small"
+        name="small"
+        size="small"
+        aria-labelledby="label-small"
+        placeholder="Enter your comments here"
+      />
     </div>
   </div>
 );


### PR DESCRIPTION
## Summary

- Adds `id` to each `Textarea` matching the `htmlFor` on the associated `Label`
- Adds `id` to each `Label` and updates `aria-labelledby` to point to those IDs (not text content strings)
- Fixes the broken label–control association in the Size story that could mislead developers who copy the pattern

## WCAG Criteria

- **4.1.2 Name, Role, Value** — `aria-labelledby` must reference the `id` of the labeling element, not the text; the native `<label htmlFor>` association now correctly targets the `<textarea id>`

## Test plan

- [x] `Label htmlFor="textarea-regular"` matches `Textarea id="textarea-regular"`
- [x] `aria-labelledby="label-regular"` resolves to the `<Label id="label-regular">` element
- [x] Lint/type-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)