### PR TITLE
fix(MultiSlider): remove misleading role="button" from track and tick labels

### DIFF
--- a/core/components/atoms/multiSlider/index.tsx
+++ b/core/components/atoms/multiSlider/index.tsx
@@ -360,17 +360,9 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
         ['bg-dark']: active,
       });
 
-      // TODO(a11y): fix accessibility
-      /* eslint-disable */
       labels.push(
         <div
           onClick={onClickHandler}
-          onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
-            if (!this.props.disabled && (event.key === 'Enter' || event.key === ' ')) {
-              event.preventDefault();
-              onClickHandler(event as unknown as React.MouseEvent<HTMLElement>);
-            }
-          }}
           className={styles['Slider-label']}
           key={i}
           style={style}
@@ -379,11 +371,8 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
           onMouseLeave={this.handleLabelMouseLeave}
           onBlur={this.handleLabelMouseLeave}
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
-          // tabIndex={disabled ? -1 : 0}
-          aria-disabled={disabled || undefined}
+          aria-hidden="true"
         >
-          {/* eslint-enable  */}
           <span className={SliderTicksClass} />
           {labelRenderer !== false && (
             <Text
@@ -474,25 +463,13 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
           </Label>
         )}
         <div className={WrapperClass}>
-          {/* TODO(a11y): fix accessibility  */}
-          {/* eslint-disable */}
           <div
             className={styles['Slider-track']}
             ref={(ref) => (this.trackElement = ref)}
             onMouseDown={this.maybeHandleTrackClick}
-            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
-              if (!this.props.disabled && (event.key === 'Enter' || event.key === ' ')) {
-                event.preventDefault();
-                this.maybeHandleTrackClick(event as unknown as React.MouseEvent<HTMLDivElement>);
-              }
-            }}
             data-test="DesignSystem-MultiSlider-Slider-Track"
-            role="button"
-            aria-label={label || 'Slider track'}
-            // tabIndex={this.props.disabled ? -1 : 0}
-            aria-disabled={this.props.disabled || undefined}
+            aria-hidden="true"
           >
-            {/* eslint-enable */}
             {this.renderTracks()}
           </div>
           <div className={styles['Slider-axis']}>{this.renderLabels()}</div>


### PR DESCRIPTION
## Summary

- **Issue 1 (P1):** Track div and axis tick/label divs had `role="button"` but `tabIndex` was commented out, making them non-focusable. Screen readers announced unreachable "buttons" with no keyboard activation path. Since clicking the track/labels just delegates to the nearest handle thumb (duplicating handle behaviour), these surfaces are pointer-only affordances and should be hidden from the accessibility tree via `aria-hidden="true"`.
- **Issue 2 (P1):** Already resolved — `getHandleAriaLabel(index, total)` already provides distinct per-thumb labels ("Minimum price" / "Maximum price") via `aria-label` on each handle. No further change needed.

Removes dead `onKeyDown` handlers from track and label elements along with unused ARIA attributes (`aria-label`, `aria-disabled`).

## Test plan
- [ ] All 65 existing tests pass (`npx jest core/components/atoms/multiSlider core/components/atoms/rangeSlider core/components/atoms/slider`)
- [ ] Screen readers no longer announce the track or tick labels as buttons
- [ ] Handle thumbs remain keyboard-focusable with distinct "Minimum" / "Maximum" labels on RangeSlider
- [ ] Pointer drag on track still moves nearest handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)