### PR TITLE
fix(MetricInput): resolve WCAG 2.2 AA a11y issues

### DIFF
--- a/core/components/atoms/metricInput/MetricInput.tsx
+++ b/core/components/atoms/metricInput/MetricInput.tsx
@@ -277,6 +277,10 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
     }
   };
 
+  const numericValue = Number(value ?? 0);
+  const isAtMin = min !== undefined && numericValue <= min;
+  const isAtMax = max !== undefined && numericValue >= max;
+
   return (
     <div data-test="DesignSystem-MetricInputWrapper" className={classes} onKeyDown={onKeyDown} role="presentation">
       {icon && (
@@ -307,6 +311,8 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
         value={value}
         disabled={disabled}
         readOnly={readOnly}
+        min={min}
+        max={max}
         onChange={onChangeHandler}
         onBlur={onBlur}
         onClick={onClick}
@@ -326,6 +332,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
             onClick={(e) => onArrowClick(e, 'up')}
             aria-label="Increment value"
             data-test="DesignSystem-MetricInput--upIcon"
+            disabled={disabled || readOnly || isAtMax}
           >
             <Icon name="keyboard_arrow_up" size={actionButtonIconSize} />
           </button>
@@ -335,6 +342,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
             onClick={(e) => onArrowClick(e, 'down')}
             aria-label="Decrement value"
             data-test="DesignSystem-MetricInput--downIcon"
+            disabled={disabled || readOnly || isAtMin}
           >
             <Icon name="keyboard_arrow_down" size={actionButtonIconSize} />
           </button>

--- a/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
+++ b/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
@@ -139,6 +139,8 @@ exports[`MetricInput component
       <input
         class="MetricInput-input MetricInput-input--large"
         data-test="DesignSystem-MetricInput"
+        max="100"
+        min="0"
         name="name"
         type="number"
         value="10"
@@ -205,6 +207,8 @@ exports[`MetricInput component
       <input
         class="MetricInput-input MetricInput-input--regular"
         data-test="DesignSystem-MetricInput"
+        max="100"
+        min="0"
         name="name"
         type="number"
         value="10"
@@ -271,6 +275,8 @@ exports[`MetricInput component
       <input
         class="MetricInput-input MetricInput-input--small"
         data-test="DesignSystem-MetricInput"
+        max="100"
+        min="0"
         name="name"
         type="number"
         value="10"


### PR DESCRIPTION
## Summary

- **Issue 1 (P1):** Add `disabled={disabled || readOnly}` to both stepper buttons so keyboard users cannot tab to and activate them when the field is non-editable (previously activation was silently ignored but the buttons remained focusable)
- **Issue 2 (P1):** Add boundary-aware disabling: decrement button is disabled when `value <= min`, increment when `value >= max`, giving keyboard and AT users a clear signal that the boundary has been reached
- **Issue 3 (P1):** Pass `min={min}` and `max={max}` as native HTML attributes on the `<input type="number">` so browsers and assistive technologies can report permitted numeric bounds (JS clamping was already honoring these values, but the DOM attributes were missing)

## Test plan
- [ ] All 124 existing tests pass (`npx jest core/components/atoms/metricInput`)
- [ ] When `disabled` or `readOnly`, both stepper buttons are disabled and skipped by keyboard Tab navigation
- [ ] With `min={0}`, decrement button is disabled when value equals 0; increment button remains active
- [ ] With `max={10}`, increment button is disabled when value equals 10; decrement button remains active
- [ ] `min` / `max` attributes visible on the `<input>` in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)