### PR TITLE
fix(Calendar): resolve WCAG 2.2 AA a11y issues

### DIFF
--- a/core/components/organisms/calendar/Calendar.tsx
+++ b/core/components/organisms/calendar/Calendar.tsx
@@ -754,7 +754,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             type="button"
             className={styles['Calendar-headerButton']}
             onClick={this.onNavHeadingClickHandler(view)}
-            aria-label={view === 'year' ? 'Select date' : 'Select year'}
+            aria-label={view === 'year' ? `${headerContent}, select date` : `${headerContent}, select year`}
           >
             {renderHeading(headerContent)}
           </button>
@@ -766,7 +766,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
               type="button"
               className={styles['Calendar-headerButton']}
               onClick={this.onNavHeadingClickHandler(view)}
-              aria-label="Select month"
+              aria-label={`${months[monthNavVal]}, select month`}
             >
               {renderHeading(months[monthNavVal])}
             </button>
@@ -774,7 +774,7 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
               type="button"
               className={classNames(styles['Calendar-headerButton'], 'ml-4')}
               onClick={this.onNavHeadingClickHandler('month')}
-              aria-label="Select year"
+              aria-label={`${yearNavVal}, select year`}
             >
               {renderHeading(yearNavVal)}
             </button>
@@ -860,18 +860,21 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
           const isFocused = effectiveFocusedYearIndex === offset;
 
           return (
-            <div key={`${row}-${col}`} className={wrapperClass}>
+            <div
+              key={`${row}-${col}`}
+              className={wrapperClass}
+              role="gridcell"
+              aria-selected={active}
+              aria-disabled={disabled}
+            >
               <button
                 type="button"
-                role="gridcell"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-calendar-year-cell
                 data-year-index={offset}
                 className={valueClass}
                 tabIndex={isFocused ? 0 : -1}
                 aria-label={year.toString()}
-                aria-disabled={disabled}
-                aria-selected={active}
                 onClick={this.selectYear(year, disabled)}
                 onKeyDown={(ev) => this.handleYearCellKeyDown(ev, year, offset, disabled)}
                 onFocus={() => this.setState({ focusedYearIndex: offset })}
@@ -965,18 +968,21 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
           const isFocused = effectiveFocusedMonth === month;
 
           return (
-            <div key={`${row}-${col}`} className={wrapperClass}>
+            <div
+              key={`${row}-${col}`}
+              className={wrapperClass}
+              role="gridcell"
+              aria-selected={active}
+              aria-disabled={disabled}
+            >
               <button
                 type="button"
-                role="gridcell"
                 data-test="DesignSystem-Calendar--monthValue"
                 data-calendar-month-cell
                 data-month={month}
                 className={valueClass}
                 tabIndex={isFocused ? 0 : -1}
                 aria-label={months[month]}
-                aria-disabled={disabled}
-                aria-selected={active}
                 onClick={this.selectMonth(month, disabled)}
                 onKeyDown={(ev) => this.handleMonthCellKeyDown(ev, month, disabled)}
                 onFocus={() => this.setState({ focusedMonth: month })}
@@ -1601,7 +1607,6 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
               <>
                 <button
                   type="button"
-                  role="gridcell"
                   data-calendar-date-cell
                   data-row={row}
                   data-col={colIndex}
@@ -1610,7 +1615,6 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
                   tabIndex={isFocused ? 0 : -1}
                   aria-label={formatDateAriaLabel(fullDate)}
                   aria-disabled={disabled}
-                  aria-selected={Boolean(active || activeDate)}
                   onClick={onClickHandler(date, disabled)}
                   onKeyDown={(ev) =>
                     this.handleDateCellKeyDown(
@@ -1666,7 +1670,14 @@ export class Calendar extends React.Component<CalendarProps, CalendarState> {
             }
 
             return (
-              <div key={`${row}-${colIndex}`} className={wrapperClass} data-test="designSystem-Calendar-WrapperClass">
+              <div
+                key={`${row}-${colIndex}`}
+                className={wrapperClass}
+                data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
+                aria-selected={shouldRenderDummy ? Boolean(active || activeDate) : undefined}
+                aria-disabled={shouldRenderDummy ? disabled : undefined}
+              >
                 {shouldRenderDummy && dateCellContent}
               </div>
             );

--- a/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
+++ b/core/components/organisms/calendar/__tests__/__snapshots__/Calendar.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -61,7 +61,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -196,19 +196,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -221,19 +222,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -246,19 +248,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -271,19 +274,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -296,19 +300,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -321,19 +326,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -346,19 +352,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -376,19 +383,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -401,19 +409,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -426,19 +435,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -451,19 +461,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -476,19 +487,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -501,19 +513,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -526,19 +539,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -556,19 +570,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -581,19 +596,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -606,19 +622,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -631,19 +648,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -656,19 +674,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -681,19 +700,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -706,19 +726,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -736,19 +757,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -761,19 +783,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -786,19 +809,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -811,19 +835,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -836,19 +861,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -861,19 +887,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -886,19 +913,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -916,19 +944,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -941,19 +970,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -966,19 +996,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -991,19 +1022,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1016,19 +1048,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1041,19 +1074,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1066,19 +1100,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1096,19 +1131,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1121,19 +1157,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1146,19 +1183,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1171,19 +1209,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1196,19 +1235,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1221,19 +1261,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1246,19 +1287,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1321,7 +1363,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -1340,7 +1382,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -1476,19 +1518,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1501,19 +1544,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1526,19 +1570,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1551,19 +1596,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1576,19 +1622,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1601,19 +1648,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1626,19 +1674,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1656,19 +1705,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1681,19 +1731,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1706,19 +1757,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1731,19 +1783,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1756,19 +1809,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1781,19 +1835,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1806,19 +1861,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1836,19 +1892,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -1861,19 +1918,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1886,19 +1944,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1911,19 +1970,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1936,19 +1996,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1961,19 +2022,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -1986,19 +2048,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2016,19 +2079,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2041,19 +2105,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2066,19 +2131,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2091,19 +2157,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2116,19 +2183,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2141,19 +2209,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2166,19 +2235,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2196,19 +2266,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2221,19 +2292,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2246,19 +2318,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2271,19 +2344,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2296,19 +2370,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2321,19 +2396,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2346,19 +2422,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2376,19 +2453,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2401,19 +2479,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2426,19 +2505,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2451,19 +2531,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2476,19 +2557,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2501,19 +2583,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2526,19 +2609,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2602,7 +2686,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -2621,7 +2705,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -2756,19 +2840,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2781,19 +2866,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2806,19 +2892,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2831,19 +2918,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2856,19 +2944,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2881,19 +2970,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2906,19 +2996,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2936,19 +3027,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2961,19 +3053,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -2986,19 +3079,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3011,19 +3105,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3036,19 +3131,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3061,19 +3157,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3086,19 +3183,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3116,19 +3214,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -3141,19 +3240,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3166,19 +3266,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3191,19 +3292,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3216,19 +3318,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3241,19 +3344,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3266,19 +3370,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3296,19 +3401,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3321,19 +3427,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3346,19 +3453,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3371,19 +3479,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3396,19 +3505,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3421,19 +3531,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3446,19 +3557,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3476,19 +3588,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3501,19 +3614,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3526,19 +3640,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3551,19 +3666,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3576,19 +3692,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3601,19 +3718,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3626,19 +3744,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3656,19 +3775,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3681,19 +3801,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3706,19 +3827,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3731,19 +3853,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3756,19 +3879,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3781,19 +3905,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3806,19 +3931,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -3882,7 +4008,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -3901,7 +4027,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -4037,19 +4163,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4062,19 +4189,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4087,19 +4215,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4112,19 +4241,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4137,19 +4267,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4162,19 +4293,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4187,19 +4319,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4217,19 +4350,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4242,19 +4376,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4267,19 +4402,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4292,19 +4428,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4317,19 +4454,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4342,19 +4480,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4367,19 +4506,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4397,19 +4537,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -4422,19 +4563,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4447,19 +4589,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4472,19 +4615,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4497,19 +4641,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4522,19 +4667,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4547,19 +4693,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4577,19 +4724,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4602,19 +4750,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4627,19 +4776,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4652,19 +4802,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4677,19 +4828,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4702,19 +4854,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4727,19 +4880,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4757,19 +4911,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4782,19 +4937,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4807,19 +4963,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4832,19 +4989,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4857,19 +5015,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4882,19 +5041,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4907,19 +5067,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4937,19 +5098,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4962,19 +5124,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -4987,19 +5150,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5012,19 +5176,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5037,19 +5202,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5062,19 +5228,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5087,19 +5254,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="true"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--disabled"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="true"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-value--disabled Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5162,7 +5330,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -5181,7 +5349,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -5316,19 +5484,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5341,19 +5510,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5366,19 +5536,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5391,19 +5562,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5416,19 +5588,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5441,19 +5614,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5466,19 +5640,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5496,19 +5671,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5521,19 +5697,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5546,19 +5723,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5571,19 +5749,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5596,19 +5775,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5621,19 +5801,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5646,19 +5827,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5676,19 +5858,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5701,19 +5884,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5726,19 +5910,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -5751,19 +5936,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5776,19 +5962,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5801,19 +5988,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5826,19 +6014,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5856,19 +6045,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5881,19 +6071,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5906,19 +6097,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5931,19 +6123,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5956,19 +6149,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -5981,19 +6175,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6006,19 +6201,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6036,19 +6232,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6061,19 +6258,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6086,19 +6284,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6111,19 +6310,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6136,19 +6336,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6161,19 +6362,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6186,19 +6388,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6216,19 +6419,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6241,19 +6445,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6266,19 +6471,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6291,19 +6497,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6316,19 +6523,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6341,19 +6549,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6366,19 +6575,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6441,7 +6651,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -6460,7 +6670,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -6595,19 +6805,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6620,19 +6831,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6645,19 +6857,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6670,19 +6883,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6695,19 +6909,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6720,19 +6935,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6745,19 +6961,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6775,19 +6992,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6800,19 +7018,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6825,19 +7044,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6850,19 +7070,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6875,19 +7096,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6900,19 +7122,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6925,19 +7148,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6955,19 +7179,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -6980,19 +7205,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7005,19 +7231,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7030,19 +7257,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7055,19 +7283,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7080,19 +7309,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7105,19 +7335,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -7135,19 +7366,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7160,19 +7392,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7185,19 +7418,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7210,19 +7444,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7235,19 +7470,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7260,19 +7496,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7285,19 +7522,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7315,19 +7553,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7340,19 +7579,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7365,19 +7605,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7390,19 +7631,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7415,19 +7657,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7440,19 +7683,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7465,19 +7709,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7495,19 +7740,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7520,19 +7766,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7545,19 +7792,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7570,19 +7818,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7595,19 +7844,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7620,19 +7870,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7645,19 +7896,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7720,7 +7972,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -7739,7 +7991,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -7874,19 +8126,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7899,19 +8152,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7924,19 +8178,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7949,19 +8204,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7974,19 +8230,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -7999,19 +8256,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8024,19 +8282,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8054,19 +8313,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8079,19 +8339,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8104,19 +8365,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8129,19 +8391,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8154,19 +8417,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8179,19 +8443,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8204,19 +8469,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8234,19 +8500,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8259,19 +8526,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -8284,19 +8552,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8309,19 +8578,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8334,19 +8604,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8359,19 +8630,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8384,19 +8656,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8414,19 +8687,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8439,19 +8713,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8464,19 +8739,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8489,19 +8765,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8514,19 +8791,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8539,19 +8817,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8564,19 +8843,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8594,19 +8874,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8619,19 +8900,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8644,19 +8926,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8669,19 +8952,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8694,19 +8978,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8719,19 +9004,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8744,19 +9030,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8774,19 +9061,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8799,19 +9087,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8824,19 +9113,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8849,19 +9139,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8874,19 +9165,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8899,19 +9191,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8924,19 +9217,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -8999,7 +9293,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -9018,7 +9312,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -9153,19 +9447,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9178,19 +9473,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9203,19 +9499,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9228,19 +9525,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9253,19 +9551,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9278,19 +9577,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9303,19 +9603,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9333,19 +9634,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9358,19 +9660,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9383,19 +9686,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9408,19 +9712,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9433,19 +9738,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9458,19 +9764,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9483,19 +9790,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9513,19 +9821,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -9538,19 +9847,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9563,19 +9873,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9588,19 +9899,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9613,19 +9925,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9638,19 +9951,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9663,19 +9977,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9693,19 +10008,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9718,19 +10034,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9743,19 +10060,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9768,19 +10086,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9793,19 +10112,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9818,19 +10138,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9843,19 +10164,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9873,19 +10195,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9898,19 +10221,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9923,19 +10247,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9948,19 +10273,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9973,19 +10299,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -9998,19 +10325,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10023,19 +10351,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10053,19 +10382,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10078,19 +10408,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10103,19 +10434,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10128,19 +10460,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10153,19 +10486,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10178,19 +10512,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10203,19 +10538,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10278,7 +10614,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -10297,7 +10633,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -10432,19 +10768,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10457,19 +10794,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10482,19 +10820,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10507,19 +10846,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10532,19 +10872,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10557,19 +10898,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10582,19 +10924,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10612,19 +10955,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10637,19 +10981,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10662,19 +11007,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10687,19 +11033,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10712,19 +11059,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10737,19 +11085,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10762,19 +11111,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10792,19 +11142,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10817,19 +11168,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10842,19 +11194,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10867,19 +11220,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -10892,19 +11246,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10917,19 +11272,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10942,19 +11298,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10972,19 +11329,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -10997,19 +11355,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11022,19 +11381,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11047,19 +11407,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11072,19 +11433,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11097,19 +11459,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11122,19 +11485,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11152,19 +11516,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11177,19 +11542,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11202,19 +11568,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11227,19 +11594,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11252,19 +11620,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11277,19 +11646,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11302,19 +11672,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11332,19 +11703,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11357,19 +11729,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11382,19 +11755,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11407,19 +11781,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11432,19 +11807,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11457,19 +11833,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11482,19 +11859,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11557,7 +11935,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -11576,7 +11954,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -11711,19 +12089,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11736,19 +12115,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11761,19 +12141,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11786,19 +12167,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11811,19 +12193,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11836,19 +12219,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11861,19 +12245,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11891,19 +12276,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11916,19 +12302,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11941,19 +12328,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11966,19 +12354,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -11991,19 +12380,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12016,19 +12406,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12041,19 +12432,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12071,19 +12463,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12096,19 +12489,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12121,19 +12515,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12146,19 +12541,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12171,19 +12567,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12196,19 +12593,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -12221,19 +12619,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12251,19 +12650,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12276,19 +12676,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12301,19 +12702,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12326,19 +12728,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12351,19 +12754,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12376,19 +12780,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12401,19 +12806,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12431,19 +12837,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12456,19 +12863,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12481,19 +12889,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12506,19 +12915,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12531,19 +12941,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12556,19 +12967,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12581,19 +12993,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12611,19 +13024,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12636,19 +13050,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12661,19 +13076,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12686,19 +13102,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12711,19 +13128,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12736,19 +13154,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12761,19 +13180,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -12836,7 +13256,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -12855,7 +13275,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -12990,19 +13410,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13015,19 +13436,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13040,19 +13462,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13065,19 +13488,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="February 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13090,19 +13514,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13115,19 +13540,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13140,19 +13566,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13170,19 +13597,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13195,19 +13623,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13220,19 +13649,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13245,19 +13675,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13270,19 +13701,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13295,19 +13727,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13320,19 +13753,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13350,19 +13784,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13375,19 +13810,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13400,19 +13836,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13425,19 +13862,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13450,19 +13888,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -13475,19 +13914,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13500,19 +13940,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13530,19 +13971,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13555,19 +13997,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13580,19 +14023,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13605,19 +14049,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13630,19 +14075,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13655,19 +14101,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13680,19 +14127,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13710,19 +14158,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13735,19 +14184,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13760,19 +14210,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13785,19 +14236,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13810,19 +14262,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13835,19 +14288,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13860,19 +14314,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13890,19 +14345,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13915,19 +14371,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13940,19 +14397,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13965,19 +14423,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -13990,19 +14449,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14015,19 +14475,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14040,19 +14501,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14115,7 +14577,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -14134,7 +14596,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -14269,19 +14731,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14294,19 +14757,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14319,19 +14783,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14344,19 +14809,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14369,19 +14835,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14394,19 +14861,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14419,19 +14887,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14449,19 +14918,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14474,19 +14944,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14499,19 +14970,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14524,19 +14996,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14549,19 +15022,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14574,19 +15048,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14599,19 +15074,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14629,19 +15105,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -14654,19 +15131,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14679,19 +15157,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14704,19 +15183,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14729,19 +15209,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14754,19 +15235,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14779,19 +15261,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14809,19 +15292,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14834,19 +15318,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14859,19 +15344,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14884,19 +15370,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14909,19 +15396,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14934,19 +15422,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14959,19 +15448,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -14989,19 +15479,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15014,19 +15505,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15039,19 +15531,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15064,19 +15557,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15089,19 +15583,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15114,19 +15609,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15139,19 +15635,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15169,19 +15666,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15194,19 +15692,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15219,19 +15718,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15244,19 +15744,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15269,19 +15770,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15294,19 +15796,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15319,19 +15822,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15394,7 +15898,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -15413,7 +15917,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -15528,19 +16032,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15553,19 +16058,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15578,19 +16084,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15603,19 +16110,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15628,19 +16136,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15653,19 +16162,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15678,19 +16188,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15708,19 +16219,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15733,19 +16245,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15758,19 +16271,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15783,19 +16297,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15808,19 +16323,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15833,19 +16349,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15858,19 +16375,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15888,19 +16406,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -15913,19 +16432,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15938,19 +16458,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15963,19 +16484,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -15988,19 +16510,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16013,19 +16536,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16038,19 +16562,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16068,19 +16593,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16093,19 +16619,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16118,19 +16645,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16143,19 +16671,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16168,19 +16697,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16193,19 +16723,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16218,19 +16749,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16248,19 +16780,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16273,19 +16806,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16298,19 +16832,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16325,18 +16860,22 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
             </div>
           </div>
@@ -16354,7 +16893,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left"
           >
             <button
-              aria-label="Select month"
+              aria-label="Apr, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -16373,7 +16912,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -16510,29 +17049,33 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16545,19 +17088,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16570,19 +17114,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16595,19 +17140,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16625,19 +17171,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16650,19 +17197,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16675,19 +17223,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16700,19 +17249,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16725,19 +17275,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16750,19 +17301,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16775,19 +17327,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16805,19 +17358,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16830,19 +17384,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16855,19 +17410,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16880,19 +17436,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 15, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16905,19 +17462,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16930,19 +17488,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16955,19 +17514,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -16985,19 +17545,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17010,19 +17571,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17035,19 +17597,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17060,19 +17623,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17085,19 +17649,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17110,19 +17675,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17135,19 +17701,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17165,19 +17732,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17190,19 +17758,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17215,19 +17784,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17240,19 +17810,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17265,19 +17836,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17290,19 +17862,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17315,19 +17888,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17390,7 +17964,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -17409,7 +17983,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -17524,19 +18098,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17549,19 +18124,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17574,19 +18150,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17599,19 +18176,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17624,19 +18202,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17649,19 +18228,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17674,19 +18254,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17704,19 +18285,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17729,19 +18311,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17754,19 +18337,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17779,19 +18363,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17804,19 +18389,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17829,19 +18415,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17854,19 +18441,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17884,19 +18472,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -17909,19 +18498,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17934,19 +18524,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17959,19 +18550,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -17984,19 +18576,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18009,19 +18602,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18034,19 +18628,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18064,19 +18659,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18089,19 +18685,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18114,19 +18711,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18139,19 +18737,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18164,19 +18763,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18189,19 +18789,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18214,19 +18815,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18244,19 +18846,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18269,19 +18872,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18294,19 +18898,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18321,18 +18926,22 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
             </div>
           </div>
@@ -18350,7 +18959,7 @@ exports[`Calendar component
             class="Calendar-headerContent"
           >
             <button
-              aria-label="Select month"
+              aria-label="Apr, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -18369,7 +18978,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -18486,29 +19095,33 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18521,19 +19134,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18546,19 +19160,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18571,19 +19186,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18601,19 +19217,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18626,19 +19243,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18651,19 +19269,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18676,19 +19295,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18701,19 +19321,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18726,19 +19347,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18751,19 +19373,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18781,19 +19404,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18806,19 +19430,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18831,19 +19456,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18856,19 +19482,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 15, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18881,19 +19508,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18906,19 +19534,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18931,19 +19560,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18961,19 +19591,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -18986,19 +19617,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19011,19 +19643,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19036,19 +19669,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19061,19 +19695,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19086,19 +19721,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19111,19 +19747,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19141,19 +19778,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19166,19 +19804,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19191,19 +19830,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19216,19 +19856,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19241,19 +19882,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19268,10 +19910,12 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
             </div>
           </div>
@@ -19289,7 +19933,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left"
           >
             <button
-              aria-label="Select month"
+              aria-label="May, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -19308,7 +19952,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -19445,37 +20089,43 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19488,19 +20138,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19518,19 +20169,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19543,19 +20195,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19568,19 +20221,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19593,19 +20247,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19618,19 +20273,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19643,19 +20299,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19668,19 +20325,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19698,19 +20356,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19723,19 +20382,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19748,19 +20408,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19773,19 +20434,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19798,19 +20460,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19823,19 +20486,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 15, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19848,19 +20512,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19878,19 +20543,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19903,19 +20569,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19928,19 +20595,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19953,19 +20621,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -19978,19 +20647,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20003,19 +20673,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20028,19 +20699,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20058,19 +20730,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20083,19 +20756,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20108,19 +20782,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20133,19 +20808,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20158,19 +20834,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20183,19 +20860,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20208,19 +20886,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20238,19 +20917,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20263,19 +20943,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20288,19 +20969,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20313,19 +20995,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20338,19 +21021,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20363,19 +21047,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20388,19 +21073,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20463,7 +21149,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -20482,7 +21168,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -20617,19 +21303,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20642,19 +21329,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20667,19 +21355,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20692,19 +21381,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20717,19 +21407,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20742,19 +21433,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20767,19 +21459,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20797,19 +21490,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20822,19 +21516,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20847,19 +21542,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20872,19 +21568,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20897,19 +21594,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20922,19 +21620,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20947,19 +21646,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -20977,19 +21677,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -21002,19 +21703,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21027,19 +21729,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21052,19 +21755,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21077,19 +21781,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21102,19 +21807,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21127,19 +21833,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21157,19 +21864,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21182,19 +21890,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21207,19 +21916,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21232,19 +21942,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21257,19 +21968,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21282,19 +21994,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21307,19 +22020,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21337,19 +22051,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21362,19 +22077,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21387,19 +22103,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21412,19 +22129,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21437,19 +22155,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21462,19 +22181,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21487,19 +22207,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21517,19 +22238,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21542,19 +22264,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21567,19 +22290,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21592,19 +22316,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21617,19 +22342,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21642,19 +22368,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21667,19 +22394,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--large"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -21742,7 +22470,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton"
               type="button"
             >
@@ -21791,17 +22519,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Jan"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="0"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21814,17 +22542,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Feb"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="1"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21837,17 +22565,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="true"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Mar"
-                aria-selected="true"
                 class="Calendar-value Calendar-value--active Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="2"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="0"
                 type="button"
               >
@@ -21865,17 +22593,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Apr"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="3"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21888,17 +22616,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="May"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="4"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21911,17 +22639,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Jun"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="5"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21939,17 +22667,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Jul"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="6"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21962,17 +22690,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Aug"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="7"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -21985,17 +22713,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Sep"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="8"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22013,17 +22741,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Oct"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="9"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22036,17 +22764,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Nov"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="10"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22059,17 +22787,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Dec"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--large"
                 data-calendar-month-cell="true"
                 data-month="11"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22131,7 +22859,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select date"
+              aria-label="2016 - 2027, select date"
               class="Calendar-headerButton"
               type="button"
             >
@@ -22173,17 +22901,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2016"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="0"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22196,17 +22924,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2017"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="1"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22219,17 +22947,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2018"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="2"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22247,17 +22975,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2019"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="3"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22270,17 +22998,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="true"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2020"
-                aria-selected="true"
                 class="Calendar-value Calendar-value--active Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="4"
-                role="gridcell"
                 tabindex="0"
                 type="button"
               >
@@ -22293,17 +23021,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2021"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large Calendar-value--currDateMonthYear"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="5"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22321,17 +23049,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2022"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="6"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22344,17 +23072,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2023"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="7"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22367,17 +23095,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2024"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="8"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22395,17 +23123,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2025"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="9"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22418,17 +23146,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2026"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="10"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22441,17 +23169,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2027"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--large"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="11"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -22513,7 +23241,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -22532,7 +23260,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -22667,19 +23395,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22692,19 +23421,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22717,19 +23447,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22742,19 +23473,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22767,19 +23499,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22792,19 +23525,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22817,19 +23551,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22847,19 +23582,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22872,19 +23608,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22897,19 +23634,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22922,19 +23660,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22947,19 +23686,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22972,19 +23712,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -22997,19 +23738,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23027,19 +23769,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -23052,19 +23795,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23077,19 +23821,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23102,19 +23847,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23127,19 +23873,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23152,19 +23899,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23177,19 +23925,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23207,19 +23956,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23232,19 +23982,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23257,19 +24008,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23282,19 +24034,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23307,19 +24060,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23332,19 +24086,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23357,19 +24112,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23387,19 +24143,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23412,19 +24169,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23437,19 +24195,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23462,19 +24221,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23487,19 +24247,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23512,19 +24273,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23537,19 +24299,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23567,19 +24330,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23592,19 +24356,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23617,19 +24382,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23642,19 +24408,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23667,19 +24434,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23692,19 +24460,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23717,19 +24486,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23792,7 +24562,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -23811,7 +24581,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -23926,19 +24696,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23951,19 +24722,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -23976,19 +24748,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24001,19 +24774,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24026,19 +24800,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24051,19 +24826,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24076,19 +24852,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24106,19 +24883,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24131,19 +24909,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24156,19 +24935,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24181,19 +24961,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24206,19 +24987,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24231,19 +25013,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24256,19 +25039,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24286,19 +25070,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -24311,19 +25096,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24336,19 +25122,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24361,19 +25148,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24386,19 +25174,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24411,19 +25200,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24436,19 +25226,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24466,19 +25257,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24491,19 +25283,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24516,19 +25309,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24541,19 +25335,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24566,19 +25361,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24591,19 +25387,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24616,19 +25413,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24646,19 +25444,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24671,19 +25470,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24696,19 +25496,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24723,18 +25524,22 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
             </div>
           </div>
@@ -24752,7 +25557,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left"
           >
             <button
-              aria-label="Select month"
+              aria-label="Apr, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -24771,7 +25576,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -24908,29 +25713,33 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24943,19 +25752,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24968,19 +25778,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -24993,19 +25804,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25023,19 +25835,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25048,19 +25861,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25073,19 +25887,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25098,19 +25913,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25123,19 +25939,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25148,19 +25965,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25173,19 +25991,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25203,19 +26022,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25228,19 +26048,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25253,19 +26074,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25278,19 +26100,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 15, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25303,19 +26126,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25328,19 +26152,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25353,19 +26178,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25383,19 +26209,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25408,19 +26235,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25433,19 +26261,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25458,19 +26287,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25483,19 +26313,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25508,19 +26339,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25533,19 +26365,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25563,19 +26396,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25588,19 +26422,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25613,19 +26448,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25638,19 +26474,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25663,19 +26500,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25688,19 +26526,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25713,19 +26552,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25788,7 +26628,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -25807,7 +26647,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -25922,19 +26762,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25947,19 +26788,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25972,19 +26814,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -25997,19 +26840,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26022,19 +26866,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26047,19 +26892,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26072,19 +26918,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26102,19 +26949,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26127,19 +26975,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26152,19 +27001,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26177,19 +27027,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26202,19 +27053,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26227,19 +27079,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26252,19 +27105,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26282,19 +27136,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -26307,19 +27162,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26332,19 +27188,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26357,19 +27214,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26382,19 +27240,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26407,19 +27266,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26432,19 +27292,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26462,19 +27323,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26487,19 +27349,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26512,19 +27375,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26537,19 +27401,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26562,19 +27427,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26587,19 +27453,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26612,19 +27479,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26642,19 +27510,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26667,19 +27536,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26692,19 +27562,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26719,18 +27590,22 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
             </div>
           </div>
@@ -26748,7 +27623,7 @@ exports[`Calendar component
             class="Calendar-headerContent"
           >
             <button
-              aria-label="Select month"
+              aria-label="Apr, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -26767,7 +27642,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -26884,29 +27759,33 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26919,19 +27798,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26944,19 +27824,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26969,19 +27850,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -26999,19 +27881,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27024,19 +27907,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27049,19 +27933,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27074,19 +27959,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27099,19 +27985,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27124,19 +28011,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27149,19 +28037,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27179,19 +28068,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27204,19 +28094,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27229,19 +28120,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27254,19 +28146,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 15, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27279,19 +28172,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27304,19 +28198,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27329,19 +28224,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27359,19 +28255,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27384,19 +28281,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27409,19 +28307,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27434,19 +28333,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27459,19 +28359,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27484,19 +28385,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27509,19 +28411,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27539,19 +28442,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27564,19 +28468,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27589,19 +28494,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27614,19 +28520,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27639,19 +28546,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27666,10 +28574,12 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
             </div>
           </div>
@@ -27687,7 +28597,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left"
           >
             <button
-              aria-label="Select month"
+              aria-label="May, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -27706,7 +28616,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -27843,37 +28753,43 @@ exports[`Calendar component
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               />
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27886,19 +28802,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27916,19 +28833,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27941,19 +28859,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27966,19 +28885,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -27991,19 +28911,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28016,19 +28937,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28041,19 +28963,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28066,19 +28989,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28096,19 +29020,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28121,19 +29046,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28146,19 +29072,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28171,19 +29098,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28196,19 +29124,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28221,19 +29150,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 15, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28246,19 +29176,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28276,19 +29207,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28301,19 +29233,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28326,19 +29259,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28351,19 +29285,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28376,19 +29311,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28401,19 +29337,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28426,19 +29363,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28456,19 +29394,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28481,19 +29420,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28506,19 +29446,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28531,19 +29472,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28556,19 +29498,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28581,19 +29524,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28606,19 +29550,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28636,19 +29581,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="May 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28661,19 +29607,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28686,19 +29633,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28711,19 +29659,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28736,19 +29685,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28761,19 +29711,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28786,19 +29737,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="June 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -28861,7 +29813,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select month"
+              aria-label="Mar, select month"
               class="Calendar-headerButton"
               type="button"
             >
@@ -28880,7 +29832,7 @@ exports[`Calendar component
               </i>
             </button>
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton ml-4"
               type="button"
             >
@@ -29015,19 +29967,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29040,19 +29993,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29065,19 +30019,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29090,19 +30045,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29115,19 +30071,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29140,19 +30097,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29165,19 +30123,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="0"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29195,19 +30154,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29220,19 +30180,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29245,19 +30206,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29270,19 +30232,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29295,19 +30258,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 12, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29320,19 +30284,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 13, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29345,19 +30310,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 14, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="1"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29375,19 +30341,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="true"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 15, 2020"
-                  aria-selected="true"
                   class="Calendar-value Calendar-value--active Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="0"
                   type="button"
                 >
@@ -29400,19 +30367,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 16, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29425,19 +30393,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 17, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29450,19 +30419,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 18, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29475,19 +30445,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 19, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29500,19 +30471,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 20, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29525,19 +30497,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 21, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="2"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29555,19 +30528,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 22, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29580,19 +30554,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 23, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29605,19 +30580,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 24, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29630,19 +30606,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 25, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29655,19 +30632,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 26, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29680,19 +30658,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 27, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29705,19 +30684,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 28, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="3"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29735,19 +30715,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 29, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29760,19 +30741,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 30, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29785,19 +30767,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="March 31, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29810,19 +30793,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 1, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29835,19 +30819,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 2, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29860,19 +30845,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 3, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29885,19 +30871,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 4, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="4"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29915,19 +30902,20 @@ exports[`Calendar component
               role="row"
             >
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 5, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="0"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29940,19 +30928,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 6, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="1"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29965,19 +30954,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 7, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="2"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -29990,19 +30980,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 8, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="3"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -30015,19 +31006,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 9, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="4"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -30040,19 +31032,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 10, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="5"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -30065,19 +31058,20 @@ exports[`Calendar component
                 </button>
               </div>
               <div
+                aria-disabled="false"
+                aria-selected="false"
                 class="Calendar-valueWrapper Calendar-valueWrapper--dummy"
                 data-test="designSystem-Calendar-WrapperClass"
+                role="gridcell"
               >
                 <button
                   aria-disabled="false"
                   aria-label="April 11, 2020"
-                  aria-selected="false"
                   class="Calendar-value Calendar-inRangeValue Calendar-dateValue Calendar-dateValue--small"
                   data-calendar-date-cell="true"
                   data-col="6"
                   data-row="5"
                   data-test="DesignSystem-Calendar--dateValue"
-                  role="gridcell"
                   tabindex="-1"
                   type="button"
                 >
@@ -30140,7 +31134,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select year"
+              aria-label="2020, select year"
               class="Calendar-headerButton"
               type="button"
             >
@@ -30189,17 +31183,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Jan"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="0"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30212,17 +31206,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Feb"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="1"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30235,17 +31229,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="true"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Mar"
-                aria-selected="true"
                 class="Calendar-value Calendar-value--active Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="2"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="0"
                 type="button"
               >
@@ -30263,17 +31257,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Apr"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="3"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30286,17 +31280,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="May"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="4"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30309,17 +31303,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Jun"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="5"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30337,17 +31331,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Jul"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="6"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30360,17 +31354,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Aug"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="7"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30383,17 +31377,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Sep"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="8"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30411,17 +31405,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Oct"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="9"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30434,17 +31428,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Nov"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="10"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30457,17 +31451,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-monthValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="Dec"
-                aria-selected="false"
                 class="Calendar-value Calendar-monthValue Calendar-monthValue--small"
                 data-calendar-month-cell="true"
                 data-month="11"
                 data-test="DesignSystem-Calendar--monthValue"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30529,7 +31523,7 @@ exports[`Calendar component
             class="Calendar-headerContent Calendar-headerContent--noIcon-left Calendar-headerContent--noIcon-right"
           >
             <button
-              aria-label="Select date"
+              aria-label="2016 - 2027, select date"
               class="Calendar-headerButton"
               type="button"
             >
@@ -30571,17 +31565,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2016"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="0"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30594,17 +31588,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2017"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="1"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30617,17 +31611,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2018"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="2"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30645,17 +31639,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2019"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="3"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30668,17 +31662,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="true"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2020"
-                aria-selected="true"
                 class="Calendar-value Calendar-value--active Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="4"
-                role="gridcell"
                 tabindex="0"
                 type="button"
               >
@@ -30691,17 +31685,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2021"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small Calendar-value--currDateMonthYear"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="5"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30719,17 +31713,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2022"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="6"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30742,17 +31736,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2023"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="7"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30765,17 +31759,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2024"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="8"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30793,17 +31787,17 @@ exports[`Calendar component
             role="row"
           >
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2025"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="9"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30816,17 +31810,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2026"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="10"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >
@@ -30839,17 +31833,17 @@ exports[`Calendar component
               </button>
             </div>
             <div
+              aria-disabled="false"
+              aria-selected="false"
               class="Calendar-yearValueWrapper"
+              role="gridcell"
             >
               <button
-                aria-disabled="false"
                 aria-label="2027"
-                aria-selected="false"
                 class="Calendar-value Calendar-yearValue Calendar-yearValue--small"
                 data-calendar-year-cell="true"
                 data-test="DesignSystem-Calendar--yearValue"
                 data-year-index="11"
-                role="gridcell"
                 tabindex="-1"
                 type="button"
               >


### PR DESCRIPTION
## Summary

- **Issue 1 (P1):** Header navigation buttons previously overrode visible month/year text with a generic `aria-label` ("Select month" / "Select year"), hiding the current value from screen reader and voice-control users. Updated labels now include both the visible value and the action (e.g. `"January, select month"`, `"2026, select year"`), matching the APG recommendation to prefer visible text as the primary name.
- **Issue 2 (P1):** `role="gridcell"` was placed on native `<button>` elements across all three calendar views (date, month, year). The override conflicts with the button's implicit role, causing inconsistent behavior in AT. Moved `role="gridcell"` (plus `aria-selected` / `aria-disabled`) to the outer wrapper `<div>` per the APG grid widget pattern, leaving the `<button>` to carry its native role for correct activation semantics.

## Test plan
- [ ] All 75 existing tests pass (`npx jest core/components/organisms/calendar`)
- [ ] Screen reader announces e.g. "January, select month" for the month header button (not just "Select month")
- [ ] Date/month/year cell buttons are announced as "button" (not "gridcell") by AT
- [ ] `aria-selected` state is still reflected correctly on grid cells
- [ ] Keyboard navigation within calendar grids functions as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)