### PR TITLE
fix(FileList): remove role="button" when onClick is absent; stop action propagation

### DIFF
--- a/core/components/molecules/fileList/FileListItem.tsx
+++ b/core/components/molecules/fileList/FileListItem.tsx
@@ -87,16 +87,22 @@ export const FileListItem = (props: FileListItemProps) => {
     }
   };
 
+  const isClickable = !!onClick;
+
   return (
     <div
       {...baseProps}
       className={FileItemClass}
-      onClick={onClickHandler}
-      onKeyDown={handleKeyDown}
+      onClick={isClickable ? onClickHandler : undefined}
+      onKeyDown={isClickable ? handleKeyDown : undefined}
       data-test="DesignSystem-FileListItem"
-      role="button"
-      tabIndex={0}
-      aria-label={`${name}${status === 'error' ? ', upload failed' : status === 'uploading' ? ', uploading' : ''}`}
+      role={isClickable ? 'button' : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      aria-label={
+        isClickable
+          ? `${name}${status === 'error' ? ', upload failed' : status === 'uploading' ? ', uploading' : ''}`
+          : undefined
+      }
     >
       <div className={styles['FileItem-file']}>
         <div className={styles['FileItem-fileContent']}>
@@ -119,7 +125,11 @@ export const FileListItem = (props: FileListItemProps) => {
           >
             {fileSize || file.size}
           </Text>
-          {!!actions && actions}
+          {!!actions && (
+            // Stop propagation so action buttons don't bubble clicks up to the row handler
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+            <div onClick={(e) => e.stopPropagation()}>{actions}</div>
+          )}
         </div>
       </div>
       {status === 'error' && (


### PR DESCRIPTION
## Summary
- Only applies `role="button"`, `tabIndex`, and `aria-label` to the row when `onClick` is provided; non-clickable rows are now plain `div`s with no misleading role — fixes the WCAG violation where a non-interactive element was announced as a button
- Wraps the `actions` slot in a `stopPropagation` div so action buttons (delete, retry, etc.) never bubble a click up to the row handler, eliminating the nested interactive conflict when both `onClick` and `actionRenderer` are used

## Test plan
- [ ] All 14 existing `FileList` tests pass including `axe` no-violations check
- [ ] Manual: row without `onClick` → no role, not focusable, screen reader announces plain text
- [ ] Manual: row with `onClick` + `actionRenderer` → clicking action button does not trigger row `onClick`

🤖 Generated with [Claude Code](https://claude.com/claude-code)