### PR TITLE
fix(VerificationCodeInput): prevent shared aria-label from overwriting per-digit labels

### DIFF
--- a/core/components/molecules/verificationCodeInput/VerificationCodeInput.tsx
+++ b/core/components/molecules/verificationCodeInput/VerificationCodeInput.tsx
@@ -74,6 +74,7 @@ const VerificationCodeInput = (props: VerificationCodeInputProps) => {
     className,
     value,
     id,
+    'aria-label': groupAriaLabel,
     ...rest
   } = props;
 
@@ -232,8 +233,10 @@ const VerificationCodeInput = (props: VerificationCodeInputProps) => {
           data-id={index}
           ref={refs[index]}
           type={type}
-          aria-label={`Digit ${index + 1} of ${fields}`}
           {...rest}
+          aria-label={
+            groupAriaLabel ? `${groupAriaLabel}, digit ${index + 1} of ${fields}` : `Digit ${index + 1} of ${fields}`
+          }
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Extracts `aria-label` from `...rest` so a consumer-supplied group label (e.g. `aria-label="Verification code"`) is no longer spread verbatim to every `Input` cell, overwriting the per-digit position context
- Synthesizes per-cell labels: when a group label is provided each input gets `"<group label>, digit N of M"`; otherwise the default `"Digit N of M"` label is used

## Test plan
- [ ] All 50 existing `VerificationCodeInput` tests pass
- [ ] Manual: `<VerificationCodeInput aria-label="Verification code" />` → each cell announced as "Verification code, digit 1 of 4", "Verification code, digit 2 of 4", etc.
- [ ] Manual: no `aria-label` supplied → each cell announced as "Digit 1 of 4", "Digit 2 of 4", etc. (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)