### PR TITLE
fix(FileUploader): resolve WCAG 2.2 AA a11y issues

### DIFF
--- a/core/components/molecules/fileUploader/FileUploader.tsx
+++ b/core/components/molecules/fileUploader/FileUploader.tsx
@@ -46,6 +46,7 @@ export const FileUploader = (props: FileUploaderProps) => {
   const baseId = baseIdRef.current;
   const titleId = `${baseId}-title`;
   const sizeLabelId = `${baseId}-size`;
+  const formatLabelId = `${baseId}-format`;
 
   const FileUploaderClass = classNames(
     {
@@ -59,7 +60,7 @@ export const FileUploader = (props: FileUploaderProps) => {
       <Text weight="medium" id={titleId}>
         {title}
       </Text>
-      <FileUploaderFormat formatLabel={formatLabel} />
+      <FileUploaderFormat formatLabel={formatLabel} formatLabelId={formatLabelId} />
       <Text size="small" appearance="subtle" className={!formatLabel ? 'mt-4' : ''} id={sizeLabelId}>
         {sizeLabel}
       </Text>
@@ -74,7 +75,7 @@ export const FileUploader = (props: FileUploaderProps) => {
         onChange={onChange}
         className="mt-5"
         aria-labelledby={titleId}
-        aria-describedby={sizeLabelId}
+        aria-describedby={formatLabel ? `${formatLabelId} ${sizeLabelId}` : sizeLabelId}
       />
     </div>
   );

--- a/core/components/molecules/fileUploader/FileUploaderButton.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderButton.tsx
@@ -58,6 +58,7 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
   } = props;
 
   const baseProps = extractBaseProps(props);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   const FileUploaderButtonClass = classNames(
     {
@@ -68,10 +69,11 @@ export const FileUploaderButton = (props: FileUploaderButtonProps) => {
 
   return (
     <div {...baseProps} className={FileUploaderButtonClass}>
-      <Button type="button" disabled={disabled} icon="backup">
+      <Button type="button" disabled={disabled} icon="backup" onClick={() => inputRef.current?.click()}>
         {uploadButtonLabel}
       </Button>
       <input
+        ref={inputRef}
         name={name}
         id={id}
         data-test="DesignSystem-FileUploaderButton--Input"

--- a/core/components/molecules/fileUploader/FileUploaderFormat.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderFormat.tsx
@@ -6,14 +6,18 @@ export interface FileUploaderFormatProps {
    * Description of accepted formats in `FileUploader`
    */
   formatLabel?: string;
+  /**
+   * Id for the format label element (used in aria-describedby on the file input)
+   */
+  formatLabelId?: string;
 }
 
 export const FileUploaderFormat = (props: FileUploaderFormatProps) => {
-  const { formatLabel } = props;
+  const { formatLabel, formatLabelId } = props;
 
   if (formatLabel) {
     return (
-      <Text size="small" appearance="subtle" className="mt-4">
+      <Text id={formatLabelId} size="small" appearance="subtle" className="mt-4">
         {formatLabel}
       </Text>
     );

--- a/core/components/molecules/fileUploader/FileUploaderItem.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderItem.tsx
@@ -46,14 +46,6 @@ export const FileUploaderItem = (props: FileUploaderItemProps) => {
 
   const baseProps = extractBaseProps(props);
   const isClickable = Boolean(onClick);
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!isClickable) return;
-
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      onClick?.(file, id);
-    }
-  };
 
   const FileItemClass = classNames(
     {
@@ -63,19 +55,22 @@ export const FileUploaderItem = (props: FileUploaderItemProps) => {
   );
 
   return (
-    <div
-      {...baseProps}
-      data-test="DesignSystem-FileUploader--Item"
-      className={FileItemClass}
-      onClick={() => onClick && onClick(file, id)}
-      onKeyDown={handleKeyDown}
-      role={isClickable ? 'button' : undefined}
-      tabIndex={isClickable ? 0 : undefined}
-    >
+    <div {...baseProps} data-test="DesignSystem-FileUploader--Item" className={FileItemClass}>
       <div className={styles['FileUploaderItem-file']}>
-        <Text className={styles['FileUploaderItem-text']} appearance={status === 'completed' ? 'default' : 'subtle'}>
-          {name}
-        </Text>
+        {isClickable ? (
+          <button
+            type="button"
+            data-test="DesignSystem-FileUploader--NameButton"
+            className={classNames(styles['FileUploaderItem-text'], styles['FileUploaderItem-nameButton'])}
+            onClick={() => onClick?.(file, id)}
+          >
+            <Text appearance={status === 'completed' ? 'default' : 'subtle'}>{name}</Text>
+          </button>
+        ) : (
+          <Text className={styles['FileUploaderItem-text']} appearance={status === 'completed' ? 'default' : 'subtle'}>
+            {name}
+          </Text>
+        )}
         <div className="d-flex align-items-center">
           <FileUploaderStatus
             file={file}
@@ -88,7 +83,10 @@ export const FileUploaderItem = (props: FileUploaderItemProps) => {
             data-test="DesignSystem-FileUploader--CancelButton"
             appearance="transparent"
             size="regular"
-            onClick={() => onDelete && onDelete(file, id)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete && onDelete(file, id);
+            }}
             icon="close"
           />
         </div>

--- a/core/components/molecules/fileUploader/FileUploaderStatus.tsx
+++ b/core/components/molecules/fileUploader/FileUploaderStatus.tsx
@@ -18,7 +18,18 @@ export const FileUploaderStatus = (props: FileUploaderStatusProps) => {
       return <ProgressRing size="small" value={progress} className="mr-4" />;
 
     case 'error':
-      return <Button appearance="transparent" size="regular" onClick={onRetry} icon="refresh" className="mr-2" />;
+      return (
+        <Button
+          appearance="transparent"
+          size="regular"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRetry?.();
+          }}
+          icon="refresh"
+          className="mr-2"
+        />
+      );
 
     default:
       return null;

--- a/core/components/molecules/fileUploader/__tests__/FileUploaderList.test.tsx
+++ b/core/components/molecules/fileUploader/__tests__/FileUploaderList.test.tsx
@@ -76,7 +76,7 @@ describe('FileUploaderList component prop:fileList', () => {
 describe('FileUploaderList component Event Handler', () => {
   it('check for onClick Event Handler', () => {
     const { getAllByTestId } = render(<FileUploaderList fileList={fileList} onClick={FunctionValue} />);
-    fireEvent.click(getAllByTestId('DesignSystem-FileUploader--Item')[0]);
+    fireEvent.click(getAllByTestId('DesignSystem-FileUploader--NameButton')[0]);
     expect(FunctionValue).toHaveBeenCalled();
   });
 

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploader.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`FileUploader component
     <span
       class="Text Text--subtle Text--small mt-4"
       data-test="DesignSystem-Text"
+      id="file-uploader-Test-uid-format"
     >
       Accepted formats: PDF, jpg, png
     </span>
@@ -56,7 +57,7 @@ exports[`FileUploader component
         </span>
       </button>
       <input
-        aria-describedby="file-uploader-Test-uid-size"
+        aria-describedby="file-uploader-Test-uid-format file-uploader-Test-uid-size"
         aria-label="Upload documents"
         aria-labelledby="file-uploader-Test-uid-title"
         class="FileUploaderButton-input"

--- a/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploaderList.test.tsx.snap
+++ b/core/components/molecules/fileUploader/__tests__/__snapshots__/FileUploaderList.test.tsx.snap
@@ -13,18 +13,22 @@ exports[`FileUploaderList component
     <div
       class="FileUploaderItem"
       data-test="DesignSystem-FileUploader--Item"
-      role="button"
-      tabindex="0"
     >
       <div
         class="FileUploaderItem-file"
       >
-        <span
-          class="Text Text--subtle Text--regular FileUploaderItem-text"
-          data-test="DesignSystem-Text"
+        <button
+          class="FileUploaderItem-text FileUploaderItem-nameButton"
+          data-test="DesignSystem-FileUploader--NameButton"
+          type="button"
         >
-          Audio File.mp3
-        </span>
+          <span
+            class="Text Text--subtle Text--regular"
+            data-test="DesignSystem-Text"
+          >
+            Audio File.mp3
+          </span>
+        </button>
         <div
           class="d-flex align-items-center"
         >
@@ -83,18 +87,22 @@ exports[`FileUploaderList component
     <div
       class="FileUploaderItem"
       data-test="DesignSystem-FileUploader--Item"
-      role="button"
-      tabindex="0"
     >
       <div
         class="FileUploaderItem-file"
       >
-        <span
-          class="Text Text--default Text--regular FileUploaderItem-text"
-          data-test="DesignSystem-Text"
+        <button
+          class="FileUploaderItem-text FileUploaderItem-nameButton"
+          data-test="DesignSystem-FileUploader--NameButton"
+          type="button"
         >
-          Video File.mp4
-        </span>
+          <span
+            class="Text Text--default Text--regular"
+            data-test="DesignSystem-Text"
+          >
+            Video File.mp4
+          </span>
+        </button>
         <div
           class="d-flex align-items-center"
         >
@@ -122,18 +130,22 @@ exports[`FileUploaderList component
     <div
       class="FileUploaderItem"
       data-test="DesignSystem-FileUploader--Item"
-      role="button"
-      tabindex="0"
     >
       <div
         class="FileUploaderItem-file"
       >
-        <span
-          class="Text Text--subtle Text--regular FileUploaderItem-text"
-          data-test="DesignSystem-Text"
+        <button
+          class="FileUploaderItem-text FileUploaderItem-nameButton"
+          data-test="DesignSystem-FileUploader--NameButton"
+          type="button"
         >
-          Image File.jpeg
-        </span>
+          <span
+            class="Text Text--subtle Text--regular"
+            data-test="DesignSystem-Text"
+          >
+            Image File.jpeg
+          </span>
+        </button>
         <div
           class="d-flex align-items-center"
         >

--- a/css/src/components/fileUploader.module.css
+++ b/css/src/components/fileUploader.module.css
@@ -30,6 +30,14 @@
   text-overflow: ellipsis;
 }
 
+.FileUploaderItem-nameButton {
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
 .FileUploaderItem-file {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Wire `inputRef.current?.click()` from the visible Button so keyboard activation opens the file picker (fixes P0: file input not keyboard-operable)
- Replace `role="button"` on the item row with a native `<button>` for the file name when `isClickable`, eliminating nested focusable buttons inside a role=button container
- Call `e.stopPropagation()` on delete/retry buttons so only the intended action fires
- Add `formatLabelId` and include it in the file input's `aria-describedby` alongside `sizeLabelId`

## Test plan
- [ ] All 28 FileUploader tests pass
- [ ] axe no-violations check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)