### PR TITLE
fix(EditableDropdown): return focus to outer container on dropdown close

### DIFF
--- a/core/components/molecules/editableDropdown/EditableDropdown.tsx
+++ b/core/components/molecules/editableDropdown/EditableDropdown.tsx
@@ -43,6 +43,7 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
 
   const containerRef = React.useRef<HTMLDivElement>(null);
   const focusDropdownTriggerAfterOpenRef = React.useRef(false);
+  const wasDropdownOpenRef = React.useRef(false);
 
   const CompClass = classNames(
     {
@@ -121,6 +122,20 @@ export const EditableDropdown = (props: EditableDropdownProps) => {
     });
     return () => cancelAnimationFrame(frame);
   }, [editing, dropdownOpen, isDropdownDisabled]);
+
+  // Return focus to the outer container when the dropdown closes, overriding
+  // DropdownList's internal focus call which would target the now-hidden trigger.
+  React.useEffect(() => {
+    const wasOpen = wasDropdownOpenRef.current;
+    wasDropdownOpenRef.current = dropdownOpen;
+    if (wasOpen && !dropdownOpen && !isDropdownDisabled) {
+      const frame = requestAnimationFrame(() => {
+        containerRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [dropdownOpen, isDropdownDisabled]);
 
   const displayText = label || placeholder;
   const textClass = classNames(styles['EditableDropdown-text'], {


### PR DESCRIPTION
## Summary
- After the dropdown closes, `DropdownList` internally calls `focus()` on its trigger which is immediately hidden (`d-none`) by `EditableDropdown`, leaving focus in an invisible element
- Added a `useEffect` that detects when `dropdownOpen` transitions from `true` to `false` and uses `requestAnimationFrame` to refocus the outer container div (`role="button"`), ensuring predictable focus return for keyboard and AT users

## Test plan
- [ ] All 10 EditableDropdown tests pass including axe no-violations check
- [ ] Manual: open via keyboard → select option / press Escape / click outside → focus returns to outer container

🤖 Generated with [Claude Code](https://claude.com/claude-code)