### PR TITLE
fix(MultiSlider): remove misleading role="button" from track and tick labels

### DIFF
--- a/core/components/atoms/multiSlider/index.tsx
+++ b/core/components/atoms/multiSlider/index.tsx
@@ -360,17 +360,9 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
         ['bg-dark']: active,
       });
 
-      // TODO(a11y): fix accessibility
-      /* eslint-disable */
       labels.push(
         <div
           onClick={onClickHandler}
-          onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
-            if (!this.props.disabled && (event.key === 'Enter' || event.key === ' ')) {
-              event.preventDefault();
-              onClickHandler(event as unknown as React.MouseEvent<HTMLElement>);
-            }
-          }}
           className={styles['Slider-label']}
           key={i}
           style={style}
@@ -379,11 +371,8 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
           onMouseLeave={this.handleLabelMouseLeave}
           onBlur={this.handleLabelMouseLeave}
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
-          // tabIndex={disabled ? -1 : 0}
-          aria-disabled={disabled || undefined}
+          aria-hidden="true"
         >
-          {/* eslint-enable  */}
           <span className={SliderTicksClass} />
           {labelRenderer !== false && (
             <Text
@@ -474,25 +463,13 @@ export class MultiSlider extends React.Component<InternalMultiSliderProps, Multi
           </Label>
         )}
         <div className={WrapperClass}>
-          {/* TODO(a11y): fix accessibility  */}
-          {/* eslint-disable */}
           <div
             className={styles['Slider-track']}
             ref={(ref) => (this.trackElement = ref)}
             onMouseDown={this.maybeHandleTrackClick}
-            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
-              if (!this.props.disabled && (event.key === 'Enter' || event.key === ' ')) {
-                event.preventDefault();
-                this.maybeHandleTrackClick(event as unknown as React.MouseEvent<HTMLDivElement>);
-              }
-            }}
             data-test="DesignSystem-MultiSlider-Slider-Track"
-            role="button"
-            aria-label={label || 'Slider track'}
-            // tabIndex={this.props.disabled ? -1 : 0}
-            aria-disabled={this.props.disabled || undefined}
+            aria-hidden="true"
           >
-            {/* eslint-enable */}
             {this.renderTracks()}
           </div>
           <div className={styles['Slider-axis']}>{this.renderLabels()}</div>

--- a/core/components/atoms/slider/__tests__/__snapshots__/Slider.test.tsx.snap
+++ b/core/components/atoms/slider/__tests__/__snapshots__/Slider.test.tsx.snap
@@ -13,10 +13,9 @@ exports[`Slider component
         class="Slider-wrapper"
       >
         <div
-          aria-label="Slider track"
+          aria-hidden="true"
           class="Slider-track"
           data-test="DesignSystem-MultiSlider-Slider-Track"
-          role="button"
         >
           <div
             class="Slider-progress Slider-progress--inRange"
@@ -31,9 +30,9 @@ exports[`Slider component
           class="Slider-axis"
         >
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 0.00%;"
           >
             <span
@@ -47,9 +46,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 10.00%;"
           >
             <span
@@ -63,9 +62,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 20.00%;"
           >
             <span
@@ -79,9 +78,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 30.00%;"
           >
             <span
@@ -95,9 +94,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 40.00%;"
           >
             <span
@@ -111,9 +110,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 50.00%;"
           >
             <span
@@ -127,9 +126,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 60.00%;"
           >
             <span
@@ -143,9 +142,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 70.00%;"
           >
             <span
@@ -159,9 +158,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 80.00%;"
           >
             <span
@@ -175,9 +174,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 90.00%;"
           >
             <span
@@ -191,9 +190,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 100.00%;"
           >
             <span
@@ -244,10 +243,9 @@ exports[`Slider component
         class="Slider-wrapper"
       >
         <div
-          aria-label="Slider track"
+          aria-hidden="true"
           class="Slider-track"
           data-test="DesignSystem-MultiSlider-Slider-Track"
-          role="button"
         >
           <div
             class="Slider-progress Slider-progress--inRange"
@@ -262,9 +260,9 @@ exports[`Slider component
           class="Slider-axis"
         >
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 0.00%;"
           >
             <span
@@ -278,9 +276,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 10.00%;"
           >
             <span
@@ -294,9 +292,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 20.00%;"
           >
             <span
@@ -310,9 +308,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 30.00%;"
           >
             <span
@@ -326,9 +324,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 40.00%;"
           >
             <span
@@ -342,9 +340,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 50.00%;"
           >
             <span
@@ -358,9 +356,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 60.00%;"
           >
             <span
@@ -374,9 +372,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 70.00%;"
           >
             <span
@@ -390,9 +388,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 80.00%;"
           >
             <span
@@ -406,9 +404,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 90.00%;"
           >
             <span
@@ -422,9 +420,9 @@ exports[`Slider component
             </span>
           </div>
           <div
+            aria-hidden="true"
             class="Slider-label"
             data-test="DesignSystem-MultiSlider-Label"
-            role="button"
             style="left: 100.00%;"
           >
             <span

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -1750,10 +1750,9 @@ exports[`TS renders children 1`] = `
       class="Slider-wrapper"
     >
       <div
-        aria-label="Slider track"
+        aria-hidden="true"
         class="Slider-track"
         data-test="DesignSystem-MultiSlider-Slider-Track"
-        role="button"
       >
         <div
           class="Slider-progress Slider-progress--inRange"
@@ -1768,9 +1767,9 @@ exports[`TS renders children 1`] = `
         class="Slider-axis"
       >
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 0.00%;"
         >
           <span
@@ -1784,9 +1783,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 10.00%;"
         >
           <span
@@ -1800,9 +1799,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 20.00%;"
         >
           <span
@@ -1816,9 +1815,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 30.00%;"
         >
           <span
@@ -1832,9 +1831,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 40.00%;"
         >
           <span
@@ -1848,9 +1847,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 50.00%;"
         >
           <span
@@ -1864,9 +1863,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 60.00%;"
         >
           <span
@@ -1880,9 +1879,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 70.00%;"
         >
           <span
@@ -1896,9 +1895,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 80.00%;"
         >
           <span
@@ -1912,9 +1911,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 90.00%;"
         >
           <span
@@ -1928,9 +1927,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 100.00%;"
         >
           <span
@@ -1972,10 +1971,9 @@ exports[`TS renders children 1`] = `
       class="Slider-wrapper"
     >
       <div
-        aria-label="Slider track"
+        aria-hidden="true"
         class="Slider-track"
         data-test="DesignSystem-MultiSlider-Slider-Track"
-        role="button"
       >
         <div
           class="Slider-progress"
@@ -1994,9 +1992,9 @@ exports[`TS renders children 1`] = `
         class="Slider-axis"
       >
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 0.00%;"
         >
           <span
@@ -2010,9 +2008,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 10.00%;"
         >
           <span
@@ -2026,9 +2024,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 20.00%;"
         >
           <span
@@ -2042,9 +2040,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 30.00%;"
         >
           <span
@@ -2058,9 +2056,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 40.00%;"
         >
           <span
@@ -2074,9 +2072,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 50.00%;"
         >
           <span
@@ -2090,9 +2088,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 60.00%;"
         >
           <span
@@ -2106,9 +2104,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 70.00%;"
         >
           <span
@@ -2122,9 +2120,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 80.00%;"
         >
           <span
@@ -2138,9 +2136,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 90.00%;"
         >
           <span
@@ -2154,9 +2152,9 @@ exports[`TS renders children 1`] = `
           </span>
         </div>
         <div
+          aria-hidden="true"
           class="Slider-label"
           data-test="DesignSystem-MultiSlider-Label"
-          role="button"
           style="left: 100.00%;"
         >
           <span


### PR DESCRIPTION
## Summary
- Remove `role="button"` from the slider track div and axis label divs; replace with `aria-hidden="true"` since these are pointer-only surfaces that duplicate handle functionality

## Test plan
- [ ] All 65 MultiSlider/Slider/RangeSlider tests pass
- [ ] axe no-violations check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)