### PR TITLE
fix(MetricInput): resolve WCAG 2.2 AA a11y issues

### DIFF
--- a/core/components/atoms/metricInput/MetricInput.tsx
+++ b/core/components/atoms/metricInput/MetricInput.tsx
@@ -277,6 +277,10 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
     }
   };
 
+  const numericValue = Number(value ?? 0);
+  const isAtMin = min !== undefined && numericValue <= min;
+  const isAtMax = max !== undefined && numericValue >= max;
+
   return (
     <div data-test="DesignSystem-MetricInputWrapper" className={classes} onKeyDown={onKeyDown} role="presentation">
       {icon && (
@@ -307,6 +311,8 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
         value={value}
         disabled={disabled}
         readOnly={readOnly}
+        min={min}
+        max={max}
         onChange={onChangeHandler}
         onBlur={onBlur}
         onClick={onClick}
@@ -326,6 +332,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
             onClick={(e) => onArrowClick(e, 'up')}
             aria-label="Increment value"
             data-test="DesignSystem-MetricInput--upIcon"
+            disabled={disabled || readOnly || isAtMax}
           >
             <Icon name="keyboard_arrow_up" size={actionButtonIconSize} />
           </button>
@@ -335,6 +342,7 @@ export const MetricInput = React.forwardRef<HTMLInputElement, MetricInputProps>(
             onClick={(e) => onArrowClick(e, 'down')}
             aria-label="Decrement value"
             data-test="DesignSystem-MetricInput--downIcon"
+            disabled={disabled || readOnly || isAtMin}
           >
             <Icon name="keyboard_arrow_down" size={actionButtonIconSize} />
           </button>

--- a/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
+++ b/core/components/atoms/metricInput/__tests__/__snapshots__/MetricInput.test.tsx.snap
@@ -139,6 +139,8 @@ exports[`MetricInput component
       <input
         class="MetricInput-input MetricInput-input--large"
         data-test="DesignSystem-MetricInput"
+        max="100"
+        min="0"
         name="name"
         type="number"
         value="10"
@@ -205,6 +207,8 @@ exports[`MetricInput component
       <input
         class="MetricInput-input MetricInput-input--regular"
         data-test="DesignSystem-MetricInput"
+        max="100"
+        min="0"
         name="name"
         type="number"
         value="10"
@@ -271,6 +275,8 @@ exports[`MetricInput component
       <input
         class="MetricInput-input MetricInput-input--small"
         data-test="DesignSystem-MetricInput"
+        max="100"
+        min="0"
         name="name"
         type="number"
         value="10"


### PR DESCRIPTION
## Summary
- Pass `min` and `max` as HTML attributes on the `<input>` so AT receives declared numeric bounds
- Disable increment button at max boundary and decrement button at min boundary
- Both stepper buttons now inherit `disabled` and `readOnly` state from the field

## Test plan
- [ ] All 124 MetricInput tests pass
- [ ] axe no-violations check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)