### PR TITLE
fix(EditableChipInput): add dedicated edit button and remove nested interactive role violation

### DIFF
--- a/core/components/molecules/editableChipInput/EditableChipInput.tsx
+++ b/core/components/molecules/editableChipInput/EditableChipInput.tsx
@@ -149,21 +149,35 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
 
   const renderDefaultState = () => {
     if (inputValue && inputValue.length) {
-      return inputValue.map((val, index) => {
-        return (
-          <Chip
-            data-test="DesignSystem-EditableChipInput--Chip"
-            key={index}
-            name={val}
-            label={val}
-            size={size}
-            className={chipMarginClass}
-            {...chipObject}
-            onClose={() => onChipDelete(index)}
-            onClick={() => onClick && onClick(val, index)}
-          />
-        );
-      });
+      return (
+        <>
+          {inputValue.map((val, index) => (
+            <Chip
+              data-test="DesignSystem-EditableChipInput--Chip"
+              key={index}
+              name={val}
+              label={val}
+              size={size}
+              className={chipMarginClass}
+              {...chipObject}
+              onClose={() => onChipDelete(index)}
+              onClick={() => onClick && onClick(val, index)}
+            />
+          ))}
+          {!chipInputDisabled && (
+            <Button
+              type="button"
+              appearance="transparent"
+              size="tiny"
+              icon="edit"
+              aria-label="Edit"
+              data-test="DesignSystem-EditableChipInput--EditButton"
+              onClick={handleClick}
+              className={styles['EditableChipInput-editButton']}
+            />
+          )}
+        </>
+      );
     }
     return (
       <Text
@@ -205,20 +219,24 @@ export const EditableChipInput = (props: EditableChipInputProps) => {
   const hasChips = inputValue && inputValue.length > 0;
   const computedAriaLabel =
     ariaLabel ||
-    (hasChips
-      ? `Click to edit. Current chips: ${inputValue!.join(', ')}`
-      : `Click to edit. ${placeholder || 'Chip input'}`);
+    (hasChips ? `Current chips: ${inputValue!.join(', ')}` : `Click to edit. ${placeholder || 'Chip input'}`);
+
+  // When chips are present, use role="group" so nested chip buttons are valid.
+  // The dedicated edit button inside the chip list handles keyboard activation.
+  // When no chips, the outer div is the sole interactive target (role="button").
+  const outerRole = showComponent ? undefined : hasChips ? 'group' : 'button';
+  const outerTabIndex = showComponent || hasChips ? undefined : chipInputDisabled ? -1 : 0;
 
   return (
     <div
       className={classes}
       data-test="DesignSystem-EditableChipInput"
       {...baseProps}
-      onKeyDown={handleKeyDown}
-      onClick={handleClick}
-      role={showComponent ? undefined : 'button'}
-      tabIndex={chipInputDisabled ? -1 : showComponent ? -1 : 0}
-      aria-disabled={chipInputDisabled || undefined}
+      onKeyDown={hasChips ? undefined : handleKeyDown}
+      onClick={hasChips ? undefined : handleClick}
+      role={outerRole}
+      tabIndex={outerTabIndex}
+      aria-disabled={!hasChips ? chipInputDisabled || undefined : undefined}
       aria-label={showComponent ? undefined : computedAriaLabel}
     >
       <Editable onChange={onChangeHandler} editing={showComponent}>

--- a/core/components/molecules/editableChipInput/__tests__/EditableChipInput.test.tsx
+++ b/core/components/molecules/editableChipInput/__tests__/EditableChipInput.test.tsx
@@ -80,8 +80,7 @@ describe('EditableChipInput component', () => {
       <EditableChipInput value={value} onChange={onChange} size="regular" chipInputOptions={chipInputOptions} />
     );
 
-    const editableWrapper = getByTestId(editableWrapperTestId);
-    fireEvent.click(editableWrapper);
+    fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
     expect(queryByTestId(defaultComponentTestId)).not.toBeInTheDocument();
     expect(getByTestId(chipInputTestId)).toBeInTheDocument();
@@ -101,7 +100,7 @@ describe('EditableChipInput component', () => {
       />
     );
 
-    fireEvent.click(getByTestId(editableWrapperTestId));
+    fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
     expect(getByTestId('DesignSystem-ChipInput--Input')).toHaveFocus();
   });
 
@@ -119,7 +118,7 @@ describe('EditableChipInput component', () => {
       />
     );
 
-    fireEvent.click(getByTestId(editableWrapperTestId));
+    fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
     expect(getByTestId('DesignSystem-ChipInput--Input')).not.toHaveFocus();
   });
 
@@ -128,15 +127,13 @@ describe('EditableChipInput component', () => {
       <EditableChipInput value={value} onChange={onChange} size="regular" chipInputOptions={chipInputOptions} />
     );
 
-    fireEvent.click(getByTestId(editableWrapperTestId));
+    fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
     let clearAction = getByTestId('DesignSystem-ChipInput--Icon');
     expect(clearAction).toHaveClass('align-self-center');
     expect(clearAction).not.toHaveClass('align-self-start');
 
     rerender(<EditableChipInput value={value} onChange={onChange} size="small" chipInputOptions={chipInputOptions} />);
-
-    fireEvent.click(getByTestId(editableWrapperTestId));
 
     clearAction = getByTestId('DesignSystem-ChipInput--Icon');
     expect(clearAction).toHaveClass('align-self-center');
@@ -164,8 +161,7 @@ describe('EditableChipInput component with action buttons and props: value and c
       <EditableChipInput value={value} onChange={onChange} chipInputOptions={chipInputOptions} size="regular" />
     );
 
-    const editableWrapper = getByTestId(editableWrapperTestId);
-    fireEvent.click(editableWrapper);
+    fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
     const inputTrigger = getByTestId(chipInputTestId);
     fireEvent.change(inputTrigger, { target: { ...newValue } });
@@ -184,8 +180,7 @@ describe('EditableChipInput component with action buttons and props: value and c
       <EditableChipInput value={value} onChange={onChange} chipInputOptions={chipInputOptions} size="regular" />
     );
 
-    const editableWrapper = getByTestId(editableWrapperTestId);
-    fireEvent.click(editableWrapper);
+    fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
     const saveButton = getByTestId('DesignSystem-EditableChipInput--SaveButton');
     fireEvent.click(saveButton);
     expect(onChange).toHaveBeenCalled();
@@ -335,8 +330,7 @@ describe('EditableChipInput component - Size functionality', () => {
         />
       );
 
-      const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.click(editableWrapper);
+      fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
       const chipInput = getByTestId(chipInputTestId);
       expect(chipInput).toHaveClass('ChipInput--regular');
@@ -354,8 +348,7 @@ describe('EditableChipInput component - Size functionality', () => {
         />
       );
 
-      const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.click(editableWrapper);
+      fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
       const chipInput = getByTestId(chipInputTestId);
       expect(chipInput).toHaveClass('ChipInput--regular');
@@ -373,8 +366,7 @@ describe('EditableChipInput component - Size functionality', () => {
         />
       );
 
-      const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.click(editableWrapper);
+      fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
       const chipInput = getByTestId(chipInputTestId);
       expect(chipInput).toHaveClass('ChipInput--small');
@@ -399,8 +391,7 @@ describe('EditableChipInput component - Size functionality', () => {
         expect(chip).toHaveClass('Chip-size--regular');
       });
 
-      const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.click(editableWrapper);
+      fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
       const chipInput = getByTestId(chipInputTestId);
       expect(chipInput).toHaveClass('ChipInput--regular');
@@ -431,8 +422,7 @@ describe('EditableChipInput component - Size functionality', () => {
         expect(chip).toHaveClass('Chip-size--small');
       });
 
-      const editableWrapper = getByTestId(editableWrapperTestId);
-      fireEvent.click(editableWrapper);
+      fireEvent.click(getByTestId('DesignSystem-EditableChipInput--EditButton'));
 
       const chipInput = getByTestId(chipInputTestId);
       expect(chipInput).toHaveClass('ChipInput--small');

--- a/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
+++ b/core/components/molecules/editableChipInput/__tests__/__snapshots__/EditableChipInput.test.tsx.snap
@@ -5,11 +5,10 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
-    aria-label="Click to edit. Current chips: Chip1, Chip2"
+    aria-label="Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
-    role="button"
-    tabindex="0"
+    role="group"
   >
     <div
       class="Editable"
@@ -90,6 +89,26 @@ exports[`EditableChipInput component
               </i>
             </div>
           </div>
+          <button
+            aria-label="Edit"
+            class="Button Button--tiny Button--tinySquare Button--transparent EditableChipInput-editButton"
+            data-test="DesignSystem-EditableChipInput--EditButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="Button-icon"
+              data-test="DesignSystem-Button--Icon-Wrapper"
+            >
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Button--Icon"
+                style="font-size: 14px; width: 14px;"
+              >
+                edit
+              </i>
+            </div>
+          </button>
         </div>
       </div>
     </div>
@@ -102,11 +121,10 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
-    aria-label="Click to edit. Current chips: Chip1, Chip2"
+    aria-label="Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
-    role="button"
-    tabindex="0"
+    role="group"
   >
     <div
       class="Editable"
@@ -187,6 +205,26 @@ exports[`EditableChipInput component
               </i>
             </div>
           </div>
+          <button
+            aria-label="Edit"
+            class="Button Button--tiny Button--tinySquare Button--transparent EditableChipInput-editButton"
+            data-test="DesignSystem-EditableChipInput--EditButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="Button-icon"
+              data-test="DesignSystem-Button--Icon-Wrapper"
+            >
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Button--Icon"
+                style="font-size: 14px; width: 14px;"
+              >
+                edit
+              </i>
+            </div>
+          </button>
         </div>
       </div>
     </div>
@@ -199,11 +237,10 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
-    aria-label="Click to edit. Current chips: Chip1, Chip2"
+    aria-label="Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
-    role="button"
-    tabindex="0"
+    role="group"
   >
     <div
       class="Editable"
@@ -284,6 +321,26 @@ exports[`EditableChipInput component
               </i>
             </div>
           </div>
+          <button
+            aria-label="Edit"
+            class="Button Button--tiny Button--tinySquare Button--transparent EditableChipInput-editButton"
+            data-test="DesignSystem-EditableChipInput--EditButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="Button-icon"
+              data-test="DesignSystem-Button--Icon-Wrapper"
+            >
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Button--Icon"
+                style="font-size: 14px; width: 14px;"
+              >
+                edit
+              </i>
+            </div>
+          </button>
         </div>
       </div>
     </div>
@@ -296,11 +353,10 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
-    aria-label="Click to edit. Current chips: Chip1, Chip2"
+    aria-label="Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
-    role="button"
-    tabindex="0"
+    role="group"
   >
     <div
       class="Editable"
@@ -381,6 +437,26 @@ exports[`EditableChipInput component
               </i>
             </div>
           </div>
+          <button
+            aria-label="Edit"
+            class="Button Button--tiny Button--tinySquare Button--transparent EditableChipInput-editButton"
+            data-test="DesignSystem-EditableChipInput--EditButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="Button-icon"
+              data-test="DesignSystem-Button--Icon-Wrapper"
+            >
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Button--Icon"
+                style="font-size: 14px; width: 14px;"
+              >
+                edit
+              </i>
+            </div>
+          </button>
         </div>
       </div>
     </div>
@@ -393,11 +469,10 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
-    aria-label="Click to edit. Current chips: Chip1, Chip2"
+    aria-label="Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
-    role="button"
-    tabindex="0"
+    role="group"
   >
     <div
       class="Editable"
@@ -478,6 +553,26 @@ exports[`EditableChipInput component
               </i>
             </div>
           </div>
+          <button
+            aria-label="Edit"
+            class="Button Button--tiny Button--tinySquare Button--transparent EditableChipInput-editButton"
+            data-test="DesignSystem-EditableChipInput--EditButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="Button-icon"
+              data-test="DesignSystem-Button--Icon-Wrapper"
+            >
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Button--Icon"
+                style="font-size: 14px; width: 14px;"
+              >
+                edit
+              </i>
+            </div>
+          </button>
         </div>
       </div>
     </div>
@@ -490,11 +585,10 @@ exports[`EditableChipInput component
  1`] = `
 <DocumentFragment>
   <div
-    aria-label="Click to edit. Current chips: Chip1, Chip2"
+    aria-label="Current chips: Chip1, Chip2"
     class="EditableChipInput"
     data-test="DesignSystem-EditableChipInput"
-    role="button"
-    tabindex="0"
+    role="group"
   >
     <div
       class="Editable"
@@ -575,6 +669,26 @@ exports[`EditableChipInput component
               </i>
             </div>
           </div>
+          <button
+            aria-label="Edit"
+            class="Button Button--tiny Button--tinySquare Button--transparent EditableChipInput-editButton"
+            data-test="DesignSystem-EditableChipInput--EditButton"
+            tabindex="0"
+            type="button"
+          >
+            <div
+              class="Button-icon"
+              data-test="DesignSystem-Button--Icon-Wrapper"
+            >
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Button--Icon"
+                style="font-size: 14px; width: 14px;"
+              >
+                edit
+              </i>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/css/src/components/editableChipInput.module.css
+++ b/css/src/components/editableChipInput.module.css
@@ -78,6 +78,11 @@
   padding-top: 0;
 }
 
+.EditableChipInput-editButton {
+  align-self: center;
+  margin-left: var(--spacing-10);
+}
+
 .EditableChipInput-actions {
   position: absolute;
   display: flex;


### PR DESCRIPTION
## Summary
- Replace `role="button"` on the outer div (which contained interactive chips) with `role="group"`
- Add a transparent icon `<Button>` with `aria-label="Edit"` inside the chip list for keyboard/AT users
- Remove `onClick`/`onKeyDown` from outer div when chips are present; the edit button handles activation

## Test plan
- [ ] All 29 EditableChipInput tests pass
- [ ] axe no-violations check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)