### PR TITLE
fix(VerificationCodeInput): prevent shared aria-label from overwriting per-digit labels

### DIFF
--- a/core/components/molecules/verificationCodeInput/VerificationCodeInput.tsx
+++ b/core/components/molecules/verificationCodeInput/VerificationCodeInput.tsx
@@ -74,6 +74,7 @@ const VerificationCodeInput = (props: VerificationCodeInputProps) => {
     className,
     value,
     id,
+    'aria-label': groupAriaLabel,
     ...rest
   } = props;
 
@@ -232,8 +233,10 @@ const VerificationCodeInput = (props: VerificationCodeInputProps) => {
           data-id={index}
           ref={refs[index]}
           type={type}
-          aria-label={`Digit ${index + 1} of ${fields}`}
           {...rest}
+          aria-label={
+            groupAriaLabel ? `${groupAriaLabel}, digit ${index + 1} of ${fields}` : `Digit ${index + 1} of ${fields}`
+          }
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Extract `aria-label` from `...rest` so a consumer-supplied group label is no longer spread verbatim to every Input cell
- Synthesize per-cell labels: `"<group label>, digit N of M"` when group label provided, else `"Digit N of M"`

## Test plan
- [ ] All 50 VerificationCodeInput tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)