### PR TITLE
fix(TimePicker): set 320px default width, 256px min-width, and wrap options text

### DIFF
--- a/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -68,7 +68,6 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
-      aria-label="Button"
       class="Button Button--regular Button--alert Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -109,6 +108,7 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-pressed="true"
       class="Button Button--regular Button--alert Button--iconAlign-left"
       data-test="DesignSystem-Button"
       tabindex="0"
@@ -191,7 +191,6 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
-      aria-label="Button"
       class="Button Button--regular Button--basic Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -315,7 +314,6 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
-      aria-label="Button"
       class="Button Button--regular Button--primary Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -356,6 +354,7 @@ exports[`Button component
 <body>
   <div>
     <button
+      aria-pressed="true"
       class="Button Button--regular Button--primary Button--iconAlign-left"
       data-test="DesignSystem-Button"
       tabindex="0"
@@ -438,7 +437,6 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
-      aria-label="Button"
       class="Button Button--regular Button--transparent Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""

--- a/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/core/components/atoms/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--alert Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -108,7 +109,6 @@ exports[`Button component
 <body>
   <div>
     <button
-      aria-pressed="true"
       class="Button Button--regular Button--alert Button--iconAlign-left"
       data-test="DesignSystem-Button"
       tabindex="0"
@@ -191,6 +191,7 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--basic Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -314,6 +315,7 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--primary Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""
@@ -354,7 +356,6 @@ exports[`Button component
 <body>
   <div>
     <button
-      aria-pressed="true"
       class="Button Button--regular Button--primary Button--iconAlign-left"
       data-test="DesignSystem-Button"
       tabindex="0"
@@ -437,6 +438,7 @@ exports[`Button component
   <div>
     <button
       aria-busy="true"
+      aria-label="Button"
       class="Button Button--regular Button--transparent Button--iconAlign-left"
       data-test="DesignSystem-Button"
       disabled=""

--- a/core/components/molecules/sidesheet/Sidesheet.tsx
+++ b/core/components/molecules/sidesheet/Sidesheet.tsx
@@ -411,8 +411,8 @@ class Sidesheet extends React.Component<SidesheetProps, SidesheetState> {
                 <Button
                   icon="close"
                   appearance="transparent"
-                  data-test="DesignSystem-Sidesheet--CloseButton"
                   aria-label="Close"
+                  data-test="DesignSystem-Sidesheet--CloseButton"
                   largeIcon={true}
                   onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
                     if (onClose) onClose(event, 'IconClick');

--- a/core/components/organisms/timePicker/TimePickerWithSearch.tsx
+++ b/core/components/organisms/timePicker/TimePickerWithSearch.tsx
@@ -5,6 +5,7 @@ import { getScrollIndex } from './utility/searchUtils';
 import { OptionSchema } from '@/components/atoms/dropdown/option';
 import { scrollToOptionIndex } from '@/components/atoms/dropdown/utility';
 import { getDropdownOptionList, isFormat12Hour, convert24To12HourFormat } from './utility/timePickerUtility';
+import timePickerStyles from '@css/components/timePicker.module.css';
 
 type fetchOptionsFunction = (searchTerm: string) => Promise<{
   count: number;
@@ -203,6 +204,8 @@ export const TimePickerWithSearch = (props: TimePickerDropdownProps) => {
       error={error}
       aria-label={ariaLabel}
       optionsAriaLabel={optionsAriaLabel}
+      className={timePickerStyles['TimePicker-trigger']}
+      truncateOption={false}
     />
   );
 };

--- a/core/components/organisms/timePicker/TimePickerWithSearch.tsx
+++ b/core/components/organisms/timePicker/TimePickerWithSearch.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import { Dropdown } from '@/index';
 import { BaseProps } from '@/utils/types';
 import { getScrollIndex } from './utility/searchUtils';
@@ -114,6 +115,7 @@ export const TimePickerWithSearch = (props: TimePickerDropdownProps) => {
     disabledSlotList,
     fetchTimeOptions,
     error,
+    className,
     'aria-label': ariaLabel,
     optionsAriaLabel,
   } = props;
@@ -204,7 +206,7 @@ export const TimePickerWithSearch = (props: TimePickerDropdownProps) => {
       error={error}
       aria-label={ariaLabel}
       optionsAriaLabel={optionsAriaLabel}
-      className={timePickerStyles['TimePicker-trigger']}
+      className={classNames(timePickerStyles['TimePicker-trigger'], className)}
       truncateOption={false}
     />
   );

--- a/core/components/organisms/timePicker/__stories__/TimeIntervals.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/TimeIntervals.story.jsx
@@ -6,7 +6,7 @@ import { TimePickerWithSearch } from '../TimePickerWithSearch';
 export const TimeIntervals = () => {
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format (1 hour Interval)</Label>
         <TimePicker
           withSearch={true}
@@ -17,7 +17,7 @@ export const TimeIntervals = () => {
         />
       </div>
 
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format (1 hour Interval)</Label>
         <TimePicker
           timeFormat="24-Hour"
@@ -36,7 +36,7 @@ const customCode = `() => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format (1 hour Interval)</Label>
         <TimePicker
           withSearch={true}
@@ -47,7 +47,7 @@ const customCode = `() => {
         />
       </div>
 
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format (1 hour Interval)</Label>
         <TimePicker
           timeFormat="24-Hour"

--- a/core/components/organisms/timePicker/__stories__/disabledOption.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/disabledOption.story.jsx
@@ -6,7 +6,7 @@ import { TimePickerWithSearch } from '../TimePickerWithSearch';
 export const disabledOption = () => {
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format</Label>
         <TimePicker
           withSearch={true}
@@ -17,7 +17,7 @@ export const disabledOption = () => {
         />
       </div>
 
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format</Label>
         <TimePicker
           timeFormat="24-Hour"
@@ -36,7 +36,7 @@ const customCode = `() => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format</Label>
         <TimePicker
           withSearch={true}
@@ -47,7 +47,7 @@ const customCode = `() => {
         />
       </div>
 
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format</Label>
         <TimePicker
           timeFormat="24-Hour"

--- a/core/components/organisms/timePicker/__stories__/fromTo.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/fromTo.story.jsx
@@ -12,7 +12,7 @@ export const FromTo = () => {
 
   return (
     <div className="d-flex">
-      <div className="w-25 mr-5">
+      <div className="mr-5">
         <Label withInput={true}>From</Label>
         <TimePicker
           withSearch={true}
@@ -25,7 +25,7 @@ export const FromTo = () => {
         />
       </div>
 
-      <div className="w-25">
+      <div>
         <Label withInput={true}>To</Label>
         <TimePicker
           withSearch={true}
@@ -51,7 +51,7 @@ const customCode = `() => {
 
   return (
     <div className="d-flex">
-      <div className="w-25 mr-5">
+      <div className="mr-5">
         <Label withInput={true}>From</Label>
         <TimePicker
           withSearch={true}
@@ -64,7 +64,7 @@ const customCode = `() => {
         />
       </div>
 
-      <div className="w-25">
+      <div>
         <Label withInput={true}>To</Label>
         <TimePicker
           withSearch={true}

--- a/core/components/organisms/timePicker/__stories__/showDuration.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/showDuration.story.jsx
@@ -6,7 +6,7 @@ import { TimePickerWithSearch } from '../TimePickerWithSearch';
 export const timeDuration = () => {
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format</Label>
         <TimePicker
           startTime="05:00"
@@ -18,7 +18,7 @@ export const timeDuration = () => {
         />
       </div>
 
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format</Label>
         <TimePicker
           startTime="05:00"
@@ -38,7 +38,7 @@ const customCode = `() => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format</Label>
         <TimePicker
           startTime="05:00"
@@ -50,7 +50,7 @@ const customCode = `() => {
         />
       </div>
 
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format</Label>
         <TimePicker
           startTime="05:00"

--- a/core/components/organisms/timePicker/__stories__/withDatePicker.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/withDatePicker.story.jsx
@@ -17,7 +17,7 @@ export const withDatePicker = () => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>Date</Label>
         <DatePicker
           aria-label="Visit date"
@@ -30,7 +30,7 @@ export const withDatePicker = () => {
           }}
         />
       </div>
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>Time</Label>
         <TimePicker withSearch={true} open={open} aria-label="Appointment time" optionsAriaLabel="Time options" />
       </div>
@@ -53,7 +53,7 @@ const customCode = `() => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>Date</Label>
         <DatePicker
           aria-label="Visit date"
@@ -66,7 +66,7 @@ const customCode = `() => {
           }}
         />
       </div>
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>Time</Label>
         <TimePicker withSearch={true} open={open} aria-label="Appointment time" optionsAriaLabel="Time options" />
       </div>

--- a/core/components/organisms/timePicker/__stories__/withSearch.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/withSearch.story.jsx
@@ -11,7 +11,7 @@ export const withSearch = () => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format</Label>
         <TimePicker
           withSearch={true}
@@ -24,7 +24,7 @@ export const withSearch = () => {
           optionsAriaLabel="12 hour time options"
         />
       </div>
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format</Label>
         <TimePicker
           withSearch={true}
@@ -50,7 +50,7 @@ const customCode = `() => {
 
   return (
     <Row>
-      <div className="w-25">
+      <div>
         <Label>12 Hour Format</Label>
         <TimePicker 
           withSearch={true} 
@@ -63,7 +63,7 @@ const customCode = `() => {
           optionsAriaLabel="12 hour time options"
         />
       </div>
-      <div className="w-25 ml-7">
+      <div className="ml-7">
         <Label>24 Hour Format</Label>
         <TimePicker
           withSearch={true}

--- a/core/components/organisms/timePicker/__stories__/withSearchErrorState.story.jsx
+++ b/core/components/organisms/timePicker/__stories__/withSearchErrorState.story.jsx
@@ -10,7 +10,7 @@ export const withSearchErrorState = () => {
   };
 
   return (
-    <div className="w-25">
+    <div>
       <Label>Time</Label>
       <TimePicker
         withSearch={true}
@@ -35,7 +35,7 @@ const customCode = `() => {
   };
 
   return (
-    <div className="w-25">
+    <div>
       <Label>Time</Label>
       <TimePicker
         withSearch={true}

--- a/core/components/organisms/timePicker/__tests__/__snapshots__/TimePickerWithSearch.test.tsx.snap
+++ b/core/components/organisms/timePicker/__tests__/__snapshots__/TimePickerWithSearch.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -51,7 +51,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -96,7 +96,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -141,7 +141,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -186,7 +186,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -231,7 +231,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -276,7 +276,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       
@@ -321,7 +321,7 @@ exports[`TimePicker component snapshots renders snapshot for all props
 <body>
   <div>
     <div
-      class="Dropdown"
+      class="Dropdown TimePicker-trigger"
       role="presentation"
     >
       

--- a/css/src/components/timePicker.module.css
+++ b/css/src/components/timePicker.module.css
@@ -1,0 +1,4 @@
+.TimePicker-trigger {
+  width: calc(var(--spacing-40) * 20);
+  min-width: calc(var(--spacing-40) * 16);
+}


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

feat(TimePicker): set 320px default width, 256px min-width, and wrap options text

- Add css/src/components/timePicker.module.css with width (320px) and
  min-width (256px) using CSS variable calc expressions
- Apply TimePicker-trigger class to the Dropdown wrapper in
  TimePickerWithSearch so the trigger has a fixed initial size instead
  of filling its container
- Set truncateOption={false} on the Dropdown so option labels wrap
  instead of truncating
- Remove w-25 width constraints from all TimePicker stories to prevent
  triggers from overflowing their containers now that a fixed width is set


### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
