### PR TITLE
feat(Table): responsive header toolbar and automatic column unpinning

### DIFF
--- a/core/components/organisms/grid/Cell.tsx
+++ b/core/components/organisms/grid/Cell.tsx
@@ -109,7 +109,7 @@ const HeaderCell = (props: HeaderCellProps) => {
     if (typeof parsed === 'number' && !isNaN(parsed)) estimatedWidth = Math.max(estimatedWidth, parsed);
   }
 
-  // If the column is already pinned, its width is already subtracted from mainRemainder, 
+  // If the column is already pinned, its width is already subtracted from mainRemainder,
   // so we don't need to charge for it again when checking if it can be pinned to the other side.
   const widthCost = pinned ? 0 : estimatedWidth;
 

--- a/core/components/organisms/grid/Cell.tsx
+++ b/core/components/organisms/grid/Cell.tsx
@@ -202,6 +202,7 @@ const HeaderCell = (props: HeaderCellProps) => {
       const schemaMin = typeof schema.minWidth === 'number' ? schema.minWidth : undefined;
       const effectiveMinWidth = schemaMin || getCellSize(schema.cellType || 'DEFAULT').minWidth || 96;
       updateColumnSchema(name, { width: Math.max(maxWidth, effectiveMinWidth) });
+      onResizeEnd?.();
     }
   };
 
@@ -323,6 +324,7 @@ const HeaderCell = (props: HeaderCellProps) => {
               const schemaMin = typeof schema.minWidth === 'number' ? schema.minWidth : undefined;
               const effectiveMinWidth = schemaMin || getCellSize(schema.cellType || 'DEFAULT').minWidth || 96;
               updateColumnSchema(name, { width: Math.max(currentWidth + delta, effectiveMinWidth) });
+              onResizeEnd?.();
             } else if (event.key === 'Enter') {
               event.preventDefault();
               autoFitColumn();

--- a/core/components/organisms/grid/Cell.tsx
+++ b/core/components/organisms/grid/Cell.tsx
@@ -63,6 +63,7 @@ const HeaderCell = (props: HeaderCellProps) => {
     mainRemainder,
     withCheckbox,
     ref: gridRef,
+    onResizeEnd,
   } = context;
 
   const {
@@ -309,7 +310,7 @@ const HeaderCell = (props: HeaderCellProps) => {
         <span
           className={styles['Grid-cellResize']}
           onMouseDown={() => {
-            resizeCol({ updateColumnSchema }, name, el.current);
+            resizeCol({ updateColumnSchema, onResizeEnd }, name, el.current);
             setIsDragged(false);
           }}
           onDoubleClick={autoFitColumn}

--- a/core/components/organisms/grid/Cell.tsx
+++ b/core/components/organisms/grid/Cell.tsx
@@ -6,6 +6,7 @@ import { DropdownProps, GridCellProps } from '@/index.type';
 import { isSpaceKey } from '@/accessibility/utils';
 import { resizeCol, hasSchema } from './utility';
 import { getCellSize, getWidth } from './columnUtility';
+import { AUTO_REPIN_BUFFER, AUTO_UNPIN_MAIN_REMAINDER_MAX } from './autoUnpinPinnedLayout';
 import { GridHeadProps } from './GridHead';
 import GridContext from './GridContext';
 import { FilterSelect } from '../table/FilterSelect';
@@ -59,6 +60,9 @@ const HeaderCell = (props: HeaderCellProps) => {
     headCellTooltip,
     showFilters,
     schema: schemaProp,
+    mainRemainder,
+    withCheckbox,
+    ref: gridRef,
   } = context;
 
   const {
@@ -93,13 +97,33 @@ const HeaderCell = (props: HeaderCellProps) => {
 
   const el = React.createRef<HTMLDivElement>();
 
+  let estimatedWidth = 176;
+  if (schema.width) {
+    const w = getWidth({ ref: gridRef, withCheckbox }, schema.width);
+    const parsed = typeof w === 'string' ? parseInt(w, 10) : w;
+    if (typeof parsed === 'number' && !isNaN(parsed)) estimatedWidth = parsed;
+  } else if (schema.minWidth) {
+    const mw = getWidth({ ref: gridRef, withCheckbox }, schema.minWidth);
+    const parsed = typeof mw === 'string' ? parseInt(mw, 10) : mw;
+    if (typeof parsed === 'number' && !isNaN(parsed)) estimatedWidth = Math.max(estimatedWidth, parsed);
+  }
+
+  // If the column is already pinned, its width is already subtracted from mainRemainder, 
+  // so we don't need to charge for it again when checking if it can be pinned to the other side.
+  const widthCost = pinned ? 0 : estimatedWidth;
+
+  const canPin =
+    mainRemainder === null ||
+    mainRemainder === undefined ||
+    mainRemainder >= AUTO_UNPIN_MAIN_REMAINDER_MAX + widthCost + AUTO_REPIN_BUFFER;
+
   const sortOptions: DropdownProps['options'] = [
     { label: 'Sort Ascending', value: 'sortAsc', icon: 'arrow_upward' },
     { label: 'Sort Descending', value: 'sortDesc', icon: 'arrow_downward' },
   ];
   const pinOptions: DropdownProps['options'] = [
-    { label: 'Pin Left', value: 'pinLeft', icon: 'skip_previous' },
-    { label: 'Pin Right', value: 'pinRight', icon: 'skip_next' },
+    { label: 'Pin Left', value: 'pinLeft', icon: 'skip_previous', disabled: !canPin },
+    { label: 'Pin Right', value: 'pinRight', icon: 'skip_next', disabled: !canPin },
   ];
   const unpinOption = { label: 'Unpin', value: 'unpin', icon: 'replay' };
   if (pinned === 'left') pinOptions[0] = unpinOption;
@@ -254,7 +278,7 @@ const HeaderCell = (props: HeaderCellProps) => {
           ) : (
             <div>
               <Dropdown
-                key={`${name}-${sorted}-${pinned}`}
+                key={`${name}-${sorted}-${pinned}-${canPin}`}
                 menu={true}
                 optionType="WITH_ICON"
                 triggerOptions={{

--- a/core/components/organisms/grid/Grid.tsx
+++ b/core/components/organisms/grid/Grid.tsx
@@ -3,7 +3,15 @@ import { DropdownProps, CheckboxProps, GridCellProps } from '@/index.type';
 import { GridHead } from './GridHead';
 import { GridBody } from './GridBody';
 import { HeaderCellRendererProps } from './Cell';
-import { sortColumn, pinColumn, hideColumn, moveToIndex, getSchema, isScrollAtTop } from './utility';
+import { sortColumn, pinColumn, hideColumn, moveToIndex, getSchema, isScrollAtTop, getWidth } from './utility';
+import {
+  AUTO_UNPIN_MAIN_REMAINDER_MAX,
+  AUTO_REPIN_BUFFER,
+  AutoUnpinStackEntry,
+  getNextAutoUnpinTarget,
+  pinnedLayoutSignature,
+  pruneAutoUnpinStack,
+} from './autoUnpinPinnedLayout';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { NestedRowProps } from './GridNestedRow';
 import classNames from 'classnames';
@@ -416,6 +424,7 @@ export interface GridState {
   init: boolean;
   prevPageInfo: PageInfo;
   isSortingListUpdated: boolean;
+  mainRemainder: number | null;
 }
 
 export class Grid extends React.Component<GridProps, GridState> {
@@ -424,6 +433,9 @@ export class Grid extends React.Component<GridProps, GridState> {
   gridId: string = uidGenerator();
   isHeadSyncing = false;
   isBodySyncing = false;
+  private autoUnpinStackRef: { current: AutoUnpinStackEntry[] } = { current: [] };
+  private autoUnpinResizeObserver: ResizeObserver | null = null;
+  private autoUnpinRafId: number | null = null;
 
   constructor(props: GridProps) {
     super(props);
@@ -434,6 +446,7 @@ export class Grid extends React.Component<GridProps, GridState> {
       init: false,
       prevPageInfo: pageInfo,
       isSortingListUpdated: false,
+      mainRemainder: null,
     };
   }
 
@@ -451,10 +464,12 @@ export class Grid extends React.Component<GridProps, GridState> {
 
   forceRerender() {
     this.forceUpdate();
+    this.scheduleAutoUnpinLayoutCheck();
   }
 
   componentWillUnmount() {
     this.removeScrollListeners();
+    this.teardownAutoUnpinObserver();
     window.removeEventListener('resize', this.forceRerender.bind(this));
   }
 
@@ -462,16 +477,30 @@ export class Grid extends React.Component<GridProps, GridState> {
     if (prevState.init !== this.state.init) {
       this.addScrollListeners();
       this.adjustPaddingRight();
+      if (this.state.init) {
+        this.setupAutoUnpinObserver();
+      }
     }
 
     if (prevProps.page !== this.props.page || prevProps.error !== this.props.error) {
       this.removeScrollListeners();
       this.addScrollListeners();
       this.adjustPaddingRight();
+      if (this.state.init) {
+        this.setupAutoUnpinObserver();
+      }
     }
 
     if (prevProps.data !== this.props.data) {
       this.adjustPaddingRight();
+    }
+
+    if (
+      this.state.init &&
+      (prevProps.loading !== this.props.loading ||
+        pinnedLayoutSignature(prevProps.schema) !== pinnedLayoutSignature(this.props.schema))
+    ) {
+      this.scheduleAutoUnpinLayoutCheck();
     }
   }
 
@@ -663,6 +692,141 @@ export class Grid extends React.Component<GridProps, GridState> {
     });
   };
 
+  getScrollContainer(): HTMLElement | null {
+    if (!this.gridRef) return null;
+    if (this.props.enableRowVirtualization) {
+      return this.gridRef.querySelector('.VS-container') as HTMLElement | null;
+    }
+    return this.gridRef.querySelector(`.${styles['Grid-body']}`) as HTMLElement | null;
+  }
+
+  getPinMeasurementElements(): { left: HTMLElement | null; right: HTMLElement | null } {
+    if (!this.gridRef) {
+      return { left: null, right: null };
+    }
+    if (this.props.showHead) {
+      const head = this.gridRef.querySelector(`.${styles['Grid-head']}`) as HTMLElement | null;
+      if (head) {
+        return {
+          left: head.querySelector(`.${styles['Grid-cellGroup--pinned-left']}`) as HTMLElement | null,
+          right: head.querySelector(`.${styles['Grid-cellGroup--pinned-right']}`) as HTMLElement | null,
+        };
+      }
+    }
+    const body = this.getScrollContainer();
+    if (!body) {
+      return { left: null, right: null };
+    }
+    const firstRowWrapper = body.querySelector(`.${styles['Grid-rowWrapper']}`) as HTMLElement | null;
+    if (!firstRowWrapper) {
+      return { left: null, right: null };
+    }
+    return {
+      left: firstRowWrapper.querySelector(`.${styles['Grid-cellGroup--pinned-left']}`) as HTMLElement | null,
+      right: firstRowWrapper.querySelector(`.${styles['Grid-cellGroup--pinned-right']}`) as HTMLElement | null,
+    };
+  }
+
+  measureMainRemainder(): number | null {
+    const scrollEl = this.getScrollContainer();
+    
+    if (!scrollEl) return null;
+    const { left, right } = this.getPinMeasurementElements();
+    const leftW = left?.getBoundingClientRect().width ?? 0;
+    const rightW = right?.getBoundingClientRect().width ?? 0;
+
+    return scrollEl.clientWidth - leftW - rightW;
+  }
+
+  scheduleAutoUnpinLayoutCheck(): void {
+    if (this.autoUnpinRafId !== null) return;
+    this.autoUnpinRafId = window.requestAnimationFrame(() => {
+      this.autoUnpinRafId = null;
+      this.runAutoUnpinLayoutCheck();
+    });
+  }
+
+  runAutoUnpinLayoutCheck(): void {
+    const { updateSchema, loading, error, schema, loaderSchema } = this.props;
+    if (!updateSchema || loading || error || !this.gridRef || !this.state.init) return;
+
+    const effectiveSchema = getSchema(schema, loading, loaderSchema);
+    const columnLike = effectiveSchema.map((s) => ({
+      name: s.name,
+      hidden: s.hidden,
+      pinned: s.pinned === 'left' || s.pinned === 'right' ? s.pinned : undefined,
+    }));
+
+    this.autoUnpinStackRef.current = pruneAutoUnpinStack(this.autoUnpinStackRef.current, columnLike);
+
+    const remainder = this.measureMainRemainder();
+
+    if (remainder === null) return;
+
+    if (this.state.mainRemainder !== remainder) {
+      this.setState({ mainRemainder: remainder });
+    }
+
+    if (this.autoUnpinStackRef.current.length > 0) {
+      const stack = this.autoUnpinStackRef.current;
+      const last = stack[stack.length - 1];
+      const col = effectiveSchema.find((s) => s.name === last.name);
+
+      let estimatedWidth = 176;
+      if (col) {
+        if (col.width) {
+          const w = getWidth({ ref: this.gridRef, withCheckbox: this.props.withCheckbox }, col.width);
+          const parsed = typeof w === 'string' ? parseInt(w, 10) : w;
+          if (typeof parsed === 'number' && !isNaN(parsed)) estimatedWidth = parsed;
+        } else if (col.minWidth) {
+          const mw = getWidth({ ref: this.gridRef, withCheckbox: this.props.withCheckbox }, col.minWidth);
+          const parsed = typeof mw === 'string' ? parseInt(mw, 10) : mw;
+          if (typeof parsed === 'number' && !isNaN(parsed)) estimatedWidth = Math.max(estimatedWidth, parsed);
+        }
+      }
+
+      const dynamicRepinThreshold = AUTO_UNPIN_MAIN_REMAINDER_MAX + estimatedWidth + AUTO_REPIN_BUFFER;
+
+      if (remainder >= dynamicRepinThreshold) {
+        this.autoUnpinStackRef.current = stack.slice(0, -1);
+        this.updateColumnSchema(last.name, { pinned: last.side });
+        return;
+      }
+    }
+
+    if (remainder < AUTO_UNPIN_MAIN_REMAINDER_MAX) {
+      const target = getNextAutoUnpinTarget(columnLike);
+      if (!target) return;
+      const col = effectiveSchema.find((s) => s.name === target.name);
+      if (!col || !(col.pinned === 'left' || col.pinned === 'right')) return;
+      this.updateColumnSchema(target.name, { pinned: undefined });
+      this.autoUnpinStackRef.current = [...this.autoUnpinStackRef.current, { name: target.name, side: target.side }];
+    }
+  }
+
+  setupAutoUnpinObserver(): void {
+    this.teardownAutoUnpinObserver();
+    const el = this.getScrollContainer();
+    if (!el || typeof ResizeObserver === 'undefined') {
+      this.scheduleAutoUnpinLayoutCheck();
+      return;
+    }
+    this.autoUnpinResizeObserver = new ResizeObserver(() => {
+      this.scheduleAutoUnpinLayoutCheck();
+    });
+    this.autoUnpinResizeObserver.observe(el);
+    this.scheduleAutoUnpinLayoutCheck();
+  }
+
+  teardownAutoUnpinObserver(): void {
+    this.autoUnpinResizeObserver?.disconnect();
+    this.autoUnpinResizeObserver = null;
+    if (this.autoUnpinRafId !== null) {
+      window.cancelAnimationFrame(this.autoUnpinRafId);
+      this.autoUnpinRafId = null;
+    }
+  }
+
   render() {
     const baseProps = extractBaseProps(this.props);
 
@@ -719,6 +883,7 @@ export class Grid extends React.Component<GridProps, GridState> {
               gridId: this.gridId,
               isSortingListUpdated: this.state.isSortingListUpdated,
               updateIsSortingListUpdated: this.updateIsSortingListUpdated.bind(this),
+              mainRemainder: this.state.mainRemainder,
             }}
           >
             {showHead && (

--- a/core/components/organisms/grid/Grid.tsx
+++ b/core/components/organisms/grid/Grid.tsx
@@ -498,7 +498,8 @@ export class Grid extends React.Component<GridProps, GridState> {
     if (
       this.state.init &&
       (prevProps.loading !== this.props.loading ||
-        pinnedLayoutSignature(prevProps.schema) !== pinnedLayoutSignature(this.props.schema))
+        pinnedLayoutSignature(prevProps.schema) !== pinnedLayoutSignature(this.props.schema) ||
+        prevProps.withCheckbox !== this.props.withCheckbox)
     ) {
       this.scheduleAutoUnpinLayoutCheck();
     }

--- a/core/components/organisms/grid/Grid.tsx
+++ b/core/components/organisms/grid/Grid.tsx
@@ -434,7 +434,7 @@ export class Grid extends React.Component<GridProps, GridState> {
   isHeadSyncing = false;
   isBodySyncing = false;
   private autoUnpinStackRef: { current: AutoUnpinStackEntry[] } = { current: [] };
-  private autoUnpinResizeObserver: ResizeObserver | null = null;
+  private autoUnpinResizeObserver: any = null;
   private autoUnpinRafId: number | null = null;
 
   constructor(props: GridProps) {
@@ -729,7 +729,7 @@ export class Grid extends React.Component<GridProps, GridState> {
 
   measureMainRemainder(): number | null {
     const scrollEl = this.getScrollContainer();
-    
+
     if (!scrollEl) return null;
     const { left, right } = this.getPinMeasurementElements();
     const leftW = left?.getBoundingClientRect().width ?? 0;
@@ -785,7 +785,16 @@ export class Grid extends React.Component<GridProps, GridState> {
         }
       }
 
-      const dynamicRepinThreshold = AUTO_UNPIN_MAIN_REMAINDER_MAX + estimatedWidth + AUTO_REPIN_BUFFER;
+      let checkboxWidth = 0;
+      if (this.props.withCheckbox && last.side === 'left') {
+        const hasLeftPinned = effectiveSchema.some((s) => s.pinned === 'left' && !s.hidden);
+        if (!hasLeftPinned) {
+          const checkboxCell = this.gridRef?.querySelector(`.${styles['Grid-cell--checkbox']}`);
+          checkboxWidth = checkboxCell?.clientWidth || 28;
+        }
+      }
+
+      const dynamicRepinThreshold = AUTO_UNPIN_MAIN_REMAINDER_MAX + estimatedWidth + checkboxWidth + AUTO_REPIN_BUFFER;
 
       if (remainder >= dynamicRepinThreshold) {
         this.autoUnpinStackRef.current = stack.slice(0, -1);
@@ -807,11 +816,11 @@ export class Grid extends React.Component<GridProps, GridState> {
   setupAutoUnpinObserver(): void {
     this.teardownAutoUnpinObserver();
     const el = this.getScrollContainer();
-    if (!el || typeof ResizeObserver === 'undefined') {
+    if (!el || typeof (window as any).ResizeObserver === 'undefined') {
       this.scheduleAutoUnpinLayoutCheck();
       return;
     }
-    this.autoUnpinResizeObserver = new ResizeObserver(() => {
+    this.autoUnpinResizeObserver = new (window as any).ResizeObserver(() => {
       this.scheduleAutoUnpinLayoutCheck();
     });
     this.autoUnpinResizeObserver.observe(el);

--- a/core/components/organisms/grid/Grid.tsx
+++ b/core/components/organisms/grid/Grid.tsx
@@ -499,7 +499,10 @@ export class Grid extends React.Component<GridProps, GridState> {
       this.state.init &&
       (prevProps.loading !== this.props.loading ||
         pinnedLayoutSignature(prevProps.schema) !== pinnedLayoutSignature(this.props.schema) ||
-        prevProps.withCheckbox !== this.props.withCheckbox)
+        prevProps.withCheckbox !== this.props.withCheckbox ||
+        // When showHead is false, pin widths are measured from the first body row.
+        // A data change can add/remove those DOM nodes, so re-check layout.
+        (!this.props.showHead && prevProps.data !== this.props.data))
     ) {
       this.scheduleAutoUnpinLayoutCheck();
     }

--- a/core/components/organisms/grid/Grid.tsx
+++ b/core/components/organisms/grid/Grid.tsx
@@ -884,6 +884,7 @@ export class Grid extends React.Component<GridProps, GridState> {
               isSortingListUpdated: this.state.isSortingListUpdated,
               updateIsSortingListUpdated: this.updateIsSortingListUpdated.bind(this),
               mainRemainder: this.state.mainRemainder,
+              onResizeEnd: this.scheduleAutoUnpinLayoutCheck.bind(this),
             }}
           >
             {showHead && (

--- a/core/components/organisms/grid/GridContext.ts
+++ b/core/components/organisms/grid/GridContext.ts
@@ -8,6 +8,7 @@ type ContextProps = GridProps & {
   gridId: string;
   isSortingListUpdated: boolean;
   updateIsSortingListUpdated: () => void;
+  mainRemainder?: number | null;
 };
 const context = React.createContext<ContextProps>({
   ...defaultProps,

--- a/core/components/organisms/grid/GridContext.ts
+++ b/core/components/organisms/grid/GridContext.ts
@@ -9,6 +9,7 @@ type ContextProps = GridProps & {
   isSortingListUpdated: boolean;
   updateIsSortingListUpdated: () => void;
   mainRemainder?: number | null;
+  onResizeEnd?: () => void;
 };
 const context = React.createContext<ContextProps>({
   ...defaultProps,

--- a/core/components/organisms/grid/__tests__/autoUnpinPinnedLayout.test.ts
+++ b/core/components/organisms/grid/__tests__/autoUnpinPinnedLayout.test.ts
@@ -1,0 +1,62 @@
+import { getNextAutoUnpinTarget, pinnedLayoutSignature, pruneAutoUnpinStack } from '../autoUnpinPinnedLayout';
+
+describe('autoUnpinPinnedLayout', () => {
+  describe('getNextAutoUnpinTarget', () => {
+    it('returns the right-most left-pinned column first', () => {
+      const columns = [
+        { name: 'a', pinned: 'left' as const },
+        { name: 'b', pinned: 'left' as const },
+        { name: 'c', pinned: 'left' as const },
+      ];
+      expect(getNextAutoUnpinTarget(columns)).toEqual({ name: 'c', side: 'left' });
+    });
+
+    it('returns the inner-most right-pinned column when no left pins', () => {
+      const columns = [
+        { name: 'x', pinned: 'right' as const },
+        { name: 'y', pinned: 'right' as const },
+      ];
+      expect(getNextAutoUnpinTarget(columns)).toEqual({ name: 'x', side: 'right' });
+    });
+
+    it('ignores hidden columns', () => {
+      const columns = [
+        { name: 'a', pinned: 'left' as const, hidden: true },
+        { name: 'b', pinned: 'left' as const },
+      ];
+      expect(getNextAutoUnpinTarget(columns)).toEqual({ name: 'b', side: 'left' });
+    });
+
+    it('returns null when nothing is pinned', () => {
+      expect(getNextAutoUnpinTarget([{ name: 'a' }])).toBeNull();
+    });
+  });
+
+  describe('pruneAutoUnpinStack', () => {
+    it('removes entries when the column was re-pinned to the saved side', () => {
+      const stack = [{ name: 'a', side: 'left' as const }];
+      const columns = [{ name: 'a', pinned: 'left' as const }];
+      expect(pruneAutoUnpinStack(stack, columns)).toEqual([]);
+    });
+
+    it('keeps entries that are still unpinned', () => {
+      const stack = [{ name: 'a', side: 'left' as const }];
+      const columns = [{ name: 'a' }];
+      expect(pruneAutoUnpinStack(stack, columns)).toEqual(stack);
+    });
+
+    it('removes entries if the column becomes hidden', () => {
+      const stack = [{ name: 'a', side: 'left' as const }];
+      const columns = [{ name: 'a', hidden: true }];
+      expect(pruneAutoUnpinStack(stack, columns)).toEqual([]);
+    });
+  });
+
+  describe('pinnedLayoutSignature', () => {
+    it('changes when pin sides change', () => {
+      const a = [{ name: 'x', pinned: 'left' as const }];
+      const b = [{ name: 'x', pinned: 'right' as const }];
+      expect(pinnedLayoutSignature(a)).not.toEqual(pinnedLayoutSignature(b));
+    });
+  });
+});

--- a/core/components/organisms/grid/autoUnpinPinnedLayout.ts
+++ b/core/components/organisms/grid/autoUnpinPinnedLayout.ts
@@ -1,0 +1,60 @@
+/**
+ * When the unpinned "main" region of the grid is narrower than AUTO_UNPIN_MAIN_REMAINDER_MAX,
+ * the Grid may auto-unpin columns (one per layout pass). 
+ * When checking if a column should be repinned, it requires the unpin threshold PLUS the column width
+ * PLUS this buffer, to prevent layout oscillation.
+ */
+export const AUTO_UNPIN_MAIN_REMAINDER_MAX = 320;
+export const AUTO_REPIN_BUFFER = 20;
+
+export type PinnedSide = 'left' | 'right';
+
+export type AutoUnpinStackEntry = {
+  name: string;
+  side: PinnedSide;
+};
+
+type ColumnLike = {
+  name: string;
+  hidden?: boolean;
+  pinned?: PinnedSide;
+};
+
+/**
+ * Prefer unpinning the inner-most left pin (last in order), then the inner-most right pin (first in order).
+ */
+export function getNextAutoUnpinTarget(columns: ColumnLike[]): AutoUnpinStackEntry | null {
+  const visible = columns.filter((s) => !s.hidden);
+  const leftPinned = visible.filter((s) => s.pinned === 'left');
+  if (leftPinned.length) {
+    return { name: leftPinned[leftPinned.length - 1].name, side: 'left' };
+  }
+  const rightPinned = visible.filter((s) => s.pinned === 'right');
+  if (rightPinned.length) {
+    return { name: rightPinned[0].name, side: 'right' };
+  }
+  return null;
+}
+
+/**
+ * Drop stack entries that no longer represent "we auto-unpinned this and should restore".
+ */
+/** Stable string for comparing pin layout across schema reference changes. */
+export function pinnedLayoutSignature(columns: ColumnLike[]): string {
+  return columns
+    .filter((s) => !s.hidden)
+    .map((s) => `${s.name}:${s.pinned === 'left' || s.pinned === 'right' ? s.pinned : ''}`)
+    .join('|');
+}
+
+export function pruneAutoUnpinStack(stack: AutoUnpinStackEntry[], columns: ColumnLike[]): AutoUnpinStackEntry[] {
+  const names = new Set(columns.map((s) => s.name));
+  return stack.filter((entry) => {
+    if (!names.has(entry.name)) return false;
+    const col = columns.find((s) => s.name === entry.name)!;
+    if (col.hidden) return false;
+    if (col.pinned === entry.side) return false;
+    if (col.pinned && col.pinned !== entry.side) return false;
+    return !col.pinned;
+  });
+}

--- a/core/components/organisms/grid/autoUnpinPinnedLayout.ts
+++ b/core/components/organisms/grid/autoUnpinPinnedLayout.ts
@@ -1,6 +1,6 @@
 /**
  * When the unpinned "main" region of the grid is narrower than AUTO_UNPIN_MAIN_REMAINDER_MAX,
- * the Grid may auto-unpin columns (one per layout pass). 
+ * the Grid may auto-unpin columns (one per layout pass).
  * When checking if a column should be repinned, it requires the unpin threshold PLUS the column width
  * PLUS this buffer, to prevent layout oscillation.
  */
@@ -17,7 +17,7 @@ export type AutoUnpinStackEntry = {
 type ColumnLike = {
   name: string;
   hidden?: boolean;
-  pinned?: PinnedSide;
+  pinned?: PinnedSide | 'unpin';
 };
 
 /**

--- a/core/components/organisms/grid/columnUtility.tsx
+++ b/core/components/organisms/grid/columnUtility.tsx
@@ -46,10 +46,12 @@ export const resizeCol: resizeColFn = ({ updateColumnSchema, onResizeEnd }, name
   }
 
   window.addEventListener('mousemove', resizable);
-  window.addEventListener('mouseup', () => {
+  function handleMouseUp() {
     window.removeEventListener('mousemove', resizable);
+    window.removeEventListener('mouseup', handleMouseUp);
     if (onResizeEnd) onResizeEnd();
-  });
+  }
+  window.addEventListener('mouseup', handleMouseUp);
 };
 
 export const sortColumn: sortColumnFn = ({ sortingList, updateSortingList }, name, type) => {

--- a/core/components/organisms/grid/columnUtility.tsx
+++ b/core/components/organisms/grid/columnUtility.tsx
@@ -11,7 +11,7 @@ import {
 import styles from '@css/components/grid.module.css';
 
 type resizeColFn = (
-  gridInfo: { updateColumnSchema: updateColumnSchemaFunction },
+  gridInfo: { updateColumnSchema: updateColumnSchemaFunction; onResizeEnd?: () => void },
   name: ColumnSchema['name'],
   el: GridRef
 ) => void;
@@ -34,7 +34,7 @@ type hideColumnFn = (
   value: boolean
 ) => void;
 
-export const resizeCol: resizeColFn = ({ updateColumnSchema }, name, el) => {
+export const resizeCol: resizeColFn = ({ updateColumnSchema, onResizeEnd }, name, el) => {
   const elX = el?.getBoundingClientRect().x;
   function resizable(ev: MouseEvent) {
     ev.preventDefault();
@@ -48,6 +48,7 @@ export const resizeCol: resizeColFn = ({ updateColumnSchema }, name, el) => {
   window.addEventListener('mousemove', resizable);
   window.addEventListener('mouseup', () => {
     window.removeEventListener('mousemove', resizable);
+    if (onResizeEnd) onResizeEnd();
   });
 };
 

--- a/core/components/organisms/table/Header.tsx
+++ b/core/components/organisms/table/Header.tsx
@@ -259,50 +259,53 @@ export const Header = (props: HeaderProps) => {
   return (
     <div className={gridStyles['Header']}>
       <div className={gridStyles['Header-content']}>
-        <div className="d-flex w-100">
-          {withSearch && (
-            <div className={gridStyles['Header-search']}>
-              <Input
-                data-test="DesignSystem-Table-Header--withSearch"
-                name="GridHeader-search"
-                icon="search"
-                placeholder={searchPlaceholder}
-                onChange={onSearchChange}
-                value={searchTerm}
-                onClear={() => updateSearchTerm && updateSearchTerm('')}
-                disabled={loading && !hasSchema(schema)}
-                autoComplete="off"
-              />
-            </div>
-          )}
-          {showFilters && filterSchema.length > 0 && (
-            <div className={gridStyles['Header-dropdown']}>
-              <div className={gridStyles['Header-filters']}>
-                {filterSchema.map((s) => {
-                  const { name, displayName, filters, filterType, filterOptions } = s;
+        <div className={gridStyles['Header-toolbar']}>
+          {(withSearch || (showFilters && filterSchema.length > 0)) && (
+            <div className={gridStyles['Header-searchFilters']}>
+              {withSearch && (
+                <div className={gridStyles['Header-search']}>
+                  <Input
+                    data-test="DesignSystem-Table-Header--withSearch"
+                    name="GridHeader-search"
+                    icon="search"
+                    placeholder={searchPlaceholder}
+                    onChange={onSearchChange}
+                    value={searchTerm}
+                    onClear={() => updateSearchTerm && updateSearchTerm('')}
+                    disabled={loading && !hasSchema(schema)}
+                    autoComplete="off"
+                  />
+                </div>
+              )}
+              {showFilters && filterSchema.length > 0 && (
+                <>
+                  {filterSchema.map((s) => {
+                    const { name, displayName, filters, filterType, filterOptions } = s;
 
-                  const selectFilters = filters
-                    ? filters.map((f) => ({
-                        label: f.label,
-                        value: f.value,
-                        id: f.value,
-                      }))
-                    : [];
+                    const selectFilters = filters
+                      ? filters.map((f) => ({
+                          label: f.label,
+                          value: f.value,
+                          id: f.value,
+                        }))
+                      : [];
 
-                  return (
-                    <FilterSelect
-                      key={name}
-                      name={name}
-                      displayName={displayName}
-                      filters={selectFilters}
-                      filterList={filterList}
-                      filterType={filterType}
-                      filterOptions={filterOptions}
-                      onChange={onFilterChange}
-                    />
-                  );
-                })}
-              </div>
+                    return (
+                      <FilterSelect
+                        key={name}
+                        name={name}
+                        displayName={displayName}
+                        filters={selectFilters}
+                        filterList={filterList}
+                        filterType={filterType}
+                        filterOptions={filterOptions}
+                        onChange={onFilterChange}
+                        className="my-0"
+                      />
+                    );
+                  })}
+                </>
+              )}
             </div>
           )}
           {children && <div className={gridStyles['Header-actions']}>{children}</div>}

--- a/core/components/organisms/table/Header.tsx
+++ b/core/components/organisms/table/Header.tsx
@@ -256,64 +256,69 @@ export const Header = (props: HeaderProps) => {
   const headerClasses = classNames(gridStyles['Header-content'], gridStyles['Header-content--bottom']);
   const tableDividerClasses = classNames(tableStyles['Table-Header--Divider'], 'mx-4');
 
+  const hasToolbarContent =
+    withSearch || (showFilters && filterSchema.length > 0) || !!children || !!globalActionRenderer;
+
   return (
     <div className={gridStyles['Header']}>
-      <div className={gridStyles['Header-content']}>
-        <div className={gridStyles['Header-toolbar']}>
-          {(withSearch || (showFilters && filterSchema.length > 0)) && (
-            <div className={gridStyles['Header-searchFilters']}>
-              {withSearch && (
-                <div className={gridStyles['Header-search']}>
-                  <Input
-                    data-test="DesignSystem-Table-Header--withSearch"
-                    name="GridHeader-search"
-                    icon="search"
-                    placeholder={searchPlaceholder}
-                    onChange={onSearchChange}
-                    value={searchTerm}
-                    onClear={() => updateSearchTerm && updateSearchTerm('')}
-                    disabled={loading && !hasSchema(schema)}
-                    autoComplete="off"
-                  />
-                </div>
-              )}
-              {showFilters && filterSchema.length > 0 && (
-                <>
-                  {filterSchema.map((s) => {
-                    const { name, displayName, filters, filterType, filterOptions } = s;
+      {hasToolbarContent && (
+        <div className={gridStyles['Header-content']}>
+          <div className={gridStyles['Header-toolbar']}>
+            {(withSearch || (showFilters && filterSchema.length > 0)) && (
+              <div className={gridStyles['Header-searchFilters']}>
+                {withSearch && (
+                  <div className={gridStyles['Header-search']}>
+                    <Input
+                      data-test="DesignSystem-Table-Header--withSearch"
+                      name="GridHeader-search"
+                      icon="search"
+                      placeholder={searchPlaceholder}
+                      onChange={onSearchChange}
+                      value={searchTerm}
+                      onClear={() => updateSearchTerm && updateSearchTerm('')}
+                      disabled={loading && !hasSchema(schema)}
+                      autoComplete="off"
+                    />
+                  </div>
+                )}
+                {showFilters && filterSchema.length > 0 && (
+                  <>
+                    {filterSchema.map((s) => {
+                      const { name, displayName, filters, filterType, filterOptions } = s;
 
-                    const selectFilters = filters
-                      ? filters.map((f) => ({
-                          label: f.label,
-                          value: f.value,
-                          id: f.value,
-                        }))
-                      : [];
+                      const selectFilters = filters
+                        ? filters.map((f) => ({
+                            label: f.label,
+                            value: f.value,
+                            id: f.value,
+                          }))
+                        : [];
 
-                    return (
-                      <FilterSelect
-                        key={name}
-                        name={name}
-                        displayName={displayName}
-                        filters={selectFilters}
-                        filterList={filterList}
-                        filterType={filterType}
-                        filterOptions={filterOptions}
-                        onChange={onFilterChange}
-                        className="my-0"
-                      />
-                    );
-                  })}
-                </>
-              )}
-            </div>
+                      return (
+                        <FilterSelect
+                          key={name}
+                          name={name}
+                          displayName={displayName}
+                          filters={selectFilters}
+                          filterList={filterList}
+                          filterType={filterType}
+                          filterOptions={filterOptions}
+                          onChange={onFilterChange}
+                          className="my-0"
+                        />
+                      );
+                    })}
+                  </>
+                )}
+              </div>
+            )}
+            {children && <div className={gridStyles['Header-actions']}>{children}</div>}
+          </div>
+          {globalActionRenderer && (
+            <div className={gridStyles['Header-global-actions']}>{globalActionRenderer(displayData)}</div>
           )}
-          {children && <div className={gridStyles['Header-actions']}>{children}</div>}
         </div>
-        {globalActionRenderer && (
-          <div className={gridStyles['Header-global-actions']}>{globalActionRenderer(displayData)}</div>
-        )}
-      </div>
+      )}
       <div className={headerClasses}>
         <div className={gridStyles['Header-label']}>
           {!showHead && withCheckbox && !loading && (

--- a/core/components/organisms/table/__stories__/responsiveness/Responsiveness.story.jsx
+++ b/core/components/organisms/table/__stories__/responsiveness/Responsiveness.story.jsx
@@ -23,7 +23,7 @@ const buildLoaderSchema = (isNarrow, showWideFilters) => {
   const tierOnly = showWideFilters ? [{ name: 'tier', displayName: 'Tier', width: isNarrow ? 96 : 120 }] : [];
   return [
     { name: 'id', displayName: 'ID', width: isNarrow ? 48 : 72 },
-    { name: 'member', displayName: 'Member', width: isNarrow ? 200 : 260 },
+    { name: 'member', displayName: 'Member', width: isNarrow ? 200 : 260, pinned: 'left' },
     { name: 'email', displayName: 'Email', width: isNarrow ? 240 : 300 },
     ...laneOnly,
     { name: 'department', displayName: 'Department', width: isNarrow ? 176 : 200 },
@@ -148,6 +148,7 @@ const buildViewportSchema = (isNarrow, showWideFilters) => {
       minWidth: isNarrow ? 188 : 228,
       maxWidth: isNarrow ? cap : 320,
       sorting: true,
+      pinned: 'left',
       cellType: 'AVATAR_WITH_TEXT',
       translate: (row) => ({
         title: `${row.firstName} ${row.lastName}`,
@@ -486,7 +487,7 @@ const customCode = `
     var tierOnly = showWide ? [{ name: 'tier', displayName: 'Tier', width: narrow ? 96 : 120 }] : [];
     return [
       { name: 'id', displayName: 'ID', width: narrow ? 48 : 72 },
-      { name: 'member', displayName: 'Member', width: narrow ? 200 : 260 },
+      { name: 'member', displayName: 'Member', width: narrow ? 200 : 260, pinned: 'left' },
       { name: 'email', displayName: 'Email', width: narrow ? 240 : 300 },
     ].concat(laneOnly).concat([
       { name: 'department', displayName: 'Department', width: narrow ? 176 : 200 },
@@ -590,6 +591,7 @@ const customCode = `
         minWidth: narrow ? 188 : 228,
         maxWidth: narrow ? cap : 320,
         sorting: true,
+        pinned: 'left',
         cellType: 'AVATAR_WITH_TEXT',
         translate: function (row) {
           return {

--- a/core/components/organisms/table/__stories__/responsiveness/Responsiveness.story.jsx
+++ b/core/components/organisms/table/__stories__/responsiveness/Responsiveness.story.jsx
@@ -1,0 +1,943 @@
+import * as React from 'react';
+import { Button, Card, Chip, Flex, Menu, Table, Text } from '@/index';
+import { AsyncTable, SyncTable } from '../_common_/types';
+import { mockUsersData } from '../_common_/mockUsersData';
+import { action } from '@/utils/action';
+
+const DEPARTMENTS = ['Clinical Ops', 'Population Health', 'Quality', 'Revenue'];
+const PROGRAMS = ['ACO', 'MSSP', 'PCF', 'BPCI'];
+const SITES = ['Boston', 'Austin', 'Denver', 'Seattle'];
+const PRIORITIES = ['P1', 'P2', 'P3', 'P4'];
+
+/** When the table is 320px wide, no column max should exceed this (leaves room for scroll/chrome). */
+const COLUMN_CAP_NARROW = 300;
+const COLUMN_CAP_WIDE = 560;
+
+/** Wide filter popovers (400px min) on short-named edge columns; middle column uses 320px min when wide mode is on. */
+const WIDE_FILTER_OPTIONS = { minWidth: '400px', maxWidth: '480px' };
+const MIDDLE_WIDE_FILTER_OPTIONS = { minWidth: '320px', maxWidth: '400px' };
+
+const buildLoaderSchema = (isNarrow, showWideFilters) => {
+  const laneOnly = showWideFilters ? [{ name: 'lane', displayName: 'Lane', width: isNarrow ? 96 : 120 }] : [];
+  const bandOnly = showWideFilters ? [{ name: 'band', displayName: 'Band', width: isNarrow ? 88 : 112 }] : [];
+  const tierOnly = showWideFilters ? [{ name: 'tier', displayName: 'Tier', width: isNarrow ? 96 : 120 }] : [];
+  return [
+    { name: 'id', displayName: 'ID', width: isNarrow ? 48 : 72 },
+    { name: 'member', displayName: 'Member', width: isNarrow ? 200 : 260 },
+    { name: 'email', displayName: 'Email', width: isNarrow ? 240 : 300 },
+    ...laneOnly,
+    { name: 'department', displayName: 'Department', width: isNarrow ? 176 : 200 },
+    { name: 'program', displayName: 'Program', width: isNarrow ? 88 : 104 },
+    { name: 'site', displayName: 'Site', width: isNarrow ? 96 : 104 },
+    { name: 'priority', displayName: 'Priority', width: isNarrow ? 64 : 72 },
+    ...bandOnly,
+    { name: 'role', displayName: 'Role', width: isNarrow ? 120 : 148 },
+    { name: 'status', displayName: 'Status', width: isNarrow ? 108 : 124 },
+    { name: 'region', displayName: 'Coverage region', width: isNarrow ? COLUMN_CAP_NARROW : 400 },
+    ...tierOnly,
+    { name: 'actions', displayName: '', width: isNarrow ? 48 : 56 },
+  ];
+};
+
+const responsivenessRows = mockUsersData.slice(0, 12).map((u, i) => ({
+  ...u,
+  region:
+    i % 2 === 0
+      ? 'Northeast–Mid-Atlantic Integrated Care Network — remote monitoring & transitional care (corridor 4-B)'
+      : 'Southwest Rural Primary Care Collaborative — FQHC outreach & field nursing (Region VII)',
+  department: DEPARTMENTS[i % DEPARTMENTS.length],
+  program: PROGRAMS[i % PROGRAMS.length],
+  site: SITES[i % SITES.length],
+  priority: PRIORITIES[i % PRIORITIES.length],
+  lane: i % 2 === 0 ? 'North' : 'South',
+  tier: i % 2 === 0 ? 'Gold' : 'Silver',
+  band: i % 2 === 0 ? 'A' : 'B',
+}));
+
+const statusAppearance = {
+  Active: 'success',
+  Inactive: 'default',
+};
+
+const buildViewportSchema = (isNarrow, showWideFilters) => {
+  const cap = isNarrow ? COLUMN_CAP_NARROW : COLUMN_CAP_WIDE;
+  const filterMax = isNarrow ? 260 : 320;
+  const laneColumn = showWideFilters
+    ? [
+        {
+          name: 'lane',
+          displayName: 'Lane',
+          width: isNarrow ? 96 : 120,
+          minWidth: isNarrow ? 88 : 100,
+          maxWidth: isNarrow ? cap : 200,
+          sorting: true,
+          filters: [
+            { label: 'North', value: 'North' },
+            { label: 'South', value: 'South' },
+          ],
+          filterOptions: WIDE_FILTER_OPTIONS,
+          onFilterChange: (row, filters) => {
+            for (let i = 0; i < filters.length; i += 1) {
+              if (row.lane === filters[i]) return true;
+            }
+            return false;
+          },
+        },
+      ]
+    : [];
+  const tierColumn = showWideFilters
+    ? [
+        {
+          name: 'tier',
+          displayName: 'Tier',
+          width: isNarrow ? 96 : 120,
+          minWidth: isNarrow ? 88 : 100,
+          maxWidth: isNarrow ? cap : 200,
+          sorting: true,
+          filters: [
+            { label: 'Gold', value: 'Gold' },
+            { label: 'Silver', value: 'Silver' },
+          ],
+          filterOptions: WIDE_FILTER_OPTIONS,
+          onFilterChange: (row, filters) => {
+            for (let i = 0; i < filters.length; i += 1) {
+              if (row.tier === filters[i]) return true;
+            }
+            return false;
+          },
+        },
+      ]
+    : [];
+  const bandColumn = showWideFilters
+    ? [
+        {
+          name: 'band',
+          displayName: 'Band',
+          width: isNarrow ? 88 : 112,
+          minWidth: isNarrow ? 80 : 96,
+          maxWidth: isNarrow ? cap : 200,
+          sorting: true,
+          filters: [
+            { label: 'A', value: 'A' },
+            { label: 'B', value: 'B' },
+          ],
+          filterOptions: MIDDLE_WIDE_FILTER_OPTIONS,
+          onFilterChange: (row, filters) => {
+            for (let i = 0; i < filters.length; i += 1) {
+              if (row.band === filters[i]) return true;
+            }
+            return false;
+          },
+        },
+      ]
+    : [];
+  return [
+    {
+      name: 'id',
+      displayName: 'ID',
+      width: isNarrow ? 48 : 72,
+      minWidth: isNarrow ? 44 : 64,
+      maxWidth: isNarrow ? 56 : 88,
+      sorting: true,
+      pinned: 'left',
+    },
+    {
+      name: 'member',
+      displayName: 'Member',
+      width: isNarrow ? 200 : 260,
+      minWidth: isNarrow ? 188 : 228,
+      maxWidth: isNarrow ? cap : 320,
+      sorting: true,
+      cellType: 'AVATAR_WITH_TEXT',
+      translate: (row) => ({
+        title: `${row.firstName} ${row.lastName}`,
+        firstName: row.firstName,
+        lastName: row.lastName,
+      }),
+    },
+    {
+      name: 'email',
+      displayName: 'Email',
+      width: isNarrow ? 240 : 300,
+      minWidth: isNarrow ? 220 : 260,
+      maxWidth: isNarrow ? cap : 400,
+      sorting: true,
+      tooltip: true,
+    },
+    ...laneColumn,
+    {
+      name: 'department',
+      displayName: 'Department',
+      width: isNarrow ? 176 : 200,
+      minWidth: isNarrow ? 160 : 176,
+      maxWidth: isNarrow ? cap : 360,
+      sorting: true,
+      filters: DEPARTMENTS.map((label) => ({ label, value: label })),
+      filterOptions: {
+        minWidth: 160,
+        maxWidth: filterMax,
+        maxVisibleSelection: 4,
+      },
+      onFilterChange: (row, filters) => {
+        for (let i = 0; i < filters.length; i += 1) {
+          if (row.department === filters[i]) return true;
+        }
+        return false;
+      },
+    },
+    {
+      name: 'program',
+      displayName: 'Program',
+      width: isNarrow ? 88 : 104,
+      minWidth: isNarrow ? 80 : 88,
+      maxWidth: isNarrow ? 120 : 160,
+      sorting: true,
+      filters: PROGRAMS.map((label) => ({ label, value: label })),
+      filterOptions: {
+        minWidth: 120,
+        maxWidth: filterMax,
+        selectionType: 'singleSelect',
+      },
+      onFilterChange: (row, filters) => {
+        for (let i = 0; i < filters.length; i += 1) {
+          if (row.program === filters[i]) return true;
+        }
+        return false;
+      },
+    },
+    {
+      name: 'site',
+      displayName: 'Site',
+      width: isNarrow ? 96 : 104,
+      minWidth: isNarrow ? 88 : 92,
+      maxWidth: isNarrow ? 128 : 168,
+      sorting: true,
+      filters: SITES.map((label) => ({ label, value: label })),
+      filterOptions: {
+        minWidth: 120,
+        maxWidth: filterMax,
+        maxVisibleSelection: 4,
+      },
+      onFilterChange: (row, filters) => {
+        for (let i = 0; i < filters.length; i += 1) {
+          if (row.site === filters[i]) return true;
+        }
+        return false;
+      },
+    },
+    {
+      name: 'priority',
+      displayName: 'Priority',
+      width: isNarrow ? 64 : 72,
+      minWidth: isNarrow ? 56 : 64,
+      maxWidth: isNarrow ? 96 : 120,
+      sorting: true,
+      filters: PRIORITIES.map((label) => ({ label, value: label })),
+      filterOptions: {
+        minWidth: 100,
+        maxWidth: filterMax,
+        selectionType: 'singleSelect',
+      },
+      onFilterChange: (row, filters) => {
+        for (let i = 0; i < filters.length; i += 1) {
+          if (row.priority === filters[i]) return true;
+        }
+        return false;
+      },
+    },
+    ...bandColumn,
+    {
+      name: 'role',
+      displayName: 'Role',
+      width: isNarrow ? 120 : 148,
+      minWidth: isNarrow ? 108 : 120,
+      maxWidth: isNarrow ? cap : 280,
+      sorting: true,
+      filters: [
+        { label: 'Admin', value: 'Admin' },
+        { label: 'User', value: 'User' },
+      ],
+      filterOptions: {
+        minWidth: 160,
+        maxWidth: filterMax,
+        maxVisibleSelection: 4,
+      },
+      onFilterChange: (row, filters) => {
+        for (let i = 0; i < filters.length; i += 1) {
+          if (row.role === filters[i]) return true;
+        }
+        return false;
+      },
+    },
+    {
+      name: 'status',
+      displayName: 'Status',
+      width: isNarrow ? 108 : 124,
+      minWidth: isNarrow ? 96 : 104,
+      maxWidth: isNarrow ? cap : 200,
+      cellType: 'STATUS_HINT',
+      sorting: true,
+      filters: [
+        { label: 'Active', value: 'Active' },
+        { label: 'Inactive', value: 'Inactive' },
+      ],
+      filterOptions: {
+        minWidth: 140,
+        maxWidth: filterMax,
+        selectionType: 'singleSelect',
+      },
+      onFilterChange: (row, filters) => {
+        for (let i = 0; i < filters.length; i += 1) {
+          if (row.status === filters[i]) return true;
+        }
+        return false;
+      },
+      translate: (row) => {
+        const status = row.status;
+        const appearance = statusAppearance[status] || 'default';
+        return {
+          title: status,
+          statusAppearance: appearance,
+        };
+      },
+    },
+    {
+      name: 'region',
+      displayName: 'Coverage region',
+      width: isNarrow ? COLUMN_CAP_NARROW : 400,
+      minWidth: isNarrow ? 260 : 320,
+      maxWidth: isNarrow ? COLUMN_CAP_NARROW : COLUMN_CAP_WIDE,
+      sorting: true,
+      tooltip: true,
+    },
+    ...tierColumn,
+    {
+      name: 'actions',
+      displayName: '',
+      width: isNarrow ? 48 : 56,
+      minWidth: isNarrow ? 44 : 52,
+      maxWidth: isNarrow ? 56 : 64,
+      sorting: false,
+      pinned: 'right',
+      cellRenderer: () => (
+        <div className="d-flex align-items-center justify-content-end">
+          <Menu trigger={<Menu.Trigger appearance="transparent" />}>
+            <Menu.List>
+              <Menu.Item>
+                <Text>View…</Text>
+              </Menu.Item>
+              <Menu.Item>
+                <Text>Assign…</Text>
+              </Menu.Item>
+            </Menu.List>
+          </Menu>
+        </div>
+      ),
+    },
+  ];
+};
+
+export const responsiveness = () => {
+  const [viewportPreset, setViewportPreset] = React.useState('320');
+  const [showWideFilters, setShowWideFilters] = React.useState(false);
+  const [showCreateNew, setShowCreateNew] = React.useState(false);
+
+  const isNarrowSchema = viewportPreset === '320';
+
+  const schema = React.useMemo(
+    () => buildViewportSchema(isNarrowSchema, showWideFilters),
+    [isNarrowSchema, showWideFilters]
+  );
+  const loaderSchema = React.useMemo(
+    () => buildLoaderSchema(isNarrowSchema, showWideFilters),
+    [isNarrowSchema, showWideFilters]
+  );
+
+  const selectionActionRenderer = () => (
+    <div className="d-flex align-items-center">
+      <Button size="tiny" className="mr-4">
+        Delete
+      </Button>
+      <Button size="tiny">Export</Button>
+    </div>
+  );
+
+  const globalActionRenderer = showCreateNew
+    ? () => (
+        <Button type="button" onClick={() => action('Create new')()}>
+          Create new
+        </Button>
+      )
+    : undefined;
+
+  return (
+    <div>
+      <Flex direction="row" wrap="wrap" gap="spacing-40" className="mb-6 align-items-center">
+        <Chip
+          type="selection"
+          name="viewport320"
+          label="320 view"
+          selected={viewportPreset === '320'}
+          aria-label="Constrain table to 320px width (narrow column layout)"
+          onClick={() => setViewportPreset((p) => (p === '320' ? 'full' : '320'))}
+        />
+        <Chip
+          type="selection"
+          name="viewport640"
+          label="640 view"
+          selected={viewportPreset === '640'}
+          aria-label="Constrain table to 640px width (unselects 320 view)"
+          onClick={() => setViewportPreset((p) => (p === '640' ? 'full' : '640'))}
+        />
+        <Chip
+          type="selection"
+          name="wideFilters"
+          label="Wide filters"
+          selected={showWideFilters}
+          aria-label="Toggle 400px wide filter popovers on Lane and Tier columns"
+          onClick={() => setShowWideFilters((v) => !v)}
+        />
+        <Chip
+          type="selection"
+          name="createNew"
+          label="Create new"
+          selected={showCreateNew}
+          aria-label="Toggle Create new header action"
+          onClick={() => setShowCreateNew((v) => !v)}
+        />
+      </Flex>
+      <div
+        style={{
+          width: viewportPreset === '320' ? 320 : viewportPreset === '640' ? 640 : '100%',
+          maxWidth: '100%',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          boxSizing: 'border-box',
+        }}
+      >
+        <Card className="overflow-hidden vh-75">
+          <Table
+            aria-label="Responsive roster table with filters and pinned columns"
+            loaderSchema={loaderSchema}
+            data={responsivenessRows}
+            schema={schema}
+            type="data"
+            size="compressed"
+            separator={false}
+            showMenu={true}
+            draggable={true}
+            withHeader={true}
+            headerOptions={{
+              withSearch: true,
+              searchPlaceholder: 'Search by name, email, or role…',
+              dynamicColumn: true,
+              allowSelectAll: true,
+              globalActionRenderer,
+              selectionActionRenderer,
+            }}
+            filterPosition="HEADER"
+            multipleSorting={true}
+            sortingList={[]}
+            withCheckbox={true}
+            uniqueColumnName="id"
+            withPagination={true}
+            paginationType="jump"
+            pageSize={5}
+            pageJumpDebounceDuration={750}
+            searchDebounceDuration={500}
+            filterList={{}}
+            onSearch={(currData, searchTerm) => {
+              const t = searchTerm.toLowerCase();
+              return currData.filter(
+                (d) =>
+                  d.firstName.toLowerCase().indexOf(t) !== -1 ||
+                  d.lastName.toLowerCase().indexOf(t) !== -1 ||
+                  d.email.toLowerCase().indexOf(t) !== -1 ||
+                  d.role.toLowerCase().indexOf(t) !== -1
+              );
+            }}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+const customCode = `
+() => {
+  var NARROW_COL_CAP = 300;
+  var WIDE_COL_CAP = 560;
+  var WIDE_FILTER_OPTIONS_LIVE = { minWidth: '400px', maxWidth: '480px' };
+  var WIDE_MID_FILTER_OPTIONS_LIVE = { minWidth: '320px', maxWidth: '400px' };
+  var data = ${JSON.stringify(responsivenessRows)};
+  var departmentFilters = ${JSON.stringify(DEPARTMENTS.map((label) => ({ label, value: label })))};
+  var programFilters = ${JSON.stringify(PROGRAMS.map((label) => ({ label, value: label })))};
+  var siteFilters = ${JSON.stringify(SITES.map((label) => ({ label, value: label })))};
+  var priorityFilters = ${JSON.stringify(PRIORITIES.map((label) => ({ label, value: label })))};
+
+  var statusAppearance = {
+    Active: 'success',
+    Inactive: 'default',
+  };
+
+  function buildLoaderSchemaLive(narrow, showWide) {
+    var laneOnly = showWide ? [{ name: 'lane', displayName: 'Lane', width: narrow ? 96 : 120 }] : [];
+    var bandOnly = showWide ? [{ name: 'band', displayName: 'Band', width: narrow ? 88 : 112 }] : [];
+    var tierOnly = showWide ? [{ name: 'tier', displayName: 'Tier', width: narrow ? 96 : 120 }] : [];
+    return [
+      { name: 'id', displayName: 'ID', width: narrow ? 48 : 72 },
+      { name: 'member', displayName: 'Member', width: narrow ? 200 : 260 },
+      { name: 'email', displayName: 'Email', width: narrow ? 240 : 300 },
+    ].concat(laneOnly).concat([
+      { name: 'department', displayName: 'Department', width: narrow ? 176 : 200 },
+      { name: 'program', displayName: 'Program', width: narrow ? 88 : 104 },
+      { name: 'site', displayName: 'Site', width: narrow ? 96 : 104 },
+      { name: 'priority', displayName: 'Priority', width: narrow ? 64 : 72 },
+    ]).concat(bandOnly).concat([
+      { name: 'role', displayName: 'Role', width: narrow ? 120 : 148 },
+      { name: 'status', displayName: 'Status', width: narrow ? 108 : 124 },
+      { name: 'region', displayName: 'Coverage region', width: narrow ? NARROW_COL_CAP : 400 },
+    ]).concat(tierOnly).concat([{ name: 'actions', displayName: '', width: narrow ? 48 : 56 }]);
+  }
+
+  function buildViewportSchemaLive(narrow, showWide) {
+    var cap = narrow ? NARROW_COL_CAP : WIDE_COL_CAP;
+    var filterMax = narrow ? 260 : 320;
+    var laneColumn = showWide
+      ? [
+          {
+            name: 'lane',
+            displayName: 'Lane',
+            width: narrow ? 96 : 120,
+            minWidth: narrow ? 88 : 100,
+            maxWidth: narrow ? cap : 200,
+            sorting: true,
+            filters: [
+              { label: 'North', value: 'North' },
+              { label: 'South', value: 'South' },
+            ],
+            filterOptions: WIDE_FILTER_OPTIONS_LIVE,
+            onFilterChange: function (row, filters) {
+              for (var ln = 0; ln < filters.length; ln += 1) {
+                if (row.lane === filters[ln]) return true;
+              }
+              return false;
+            },
+          },
+        ]
+      : [];
+    var tierColumn = showWide
+      ? [
+          {
+            name: 'tier',
+            displayName: 'Tier',
+            width: narrow ? 96 : 120,
+            minWidth: narrow ? 88 : 100,
+            maxWidth: narrow ? cap : 200,
+            sorting: true,
+            filters: [
+              { label: 'Gold', value: 'Gold' },
+              { label: 'Silver', value: 'Silver' },
+            ],
+            filterOptions: WIDE_FILTER_OPTIONS_LIVE,
+            onFilterChange: function (row, filters) {
+              for (var tn = 0; tn < filters.length; tn += 1) {
+                if (row.tier === filters[tn]) return true;
+              }
+              return false;
+            },
+          },
+        ]
+      : [];
+    var bandColumn = showWide
+      ? [
+          {
+            name: 'band',
+            displayName: 'Band',
+            width: narrow ? 88 : 112,
+            minWidth: narrow ? 80 : 96,
+            maxWidth: narrow ? cap : 200,
+            sorting: true,
+            filters: [
+              { label: 'A', value: 'A' },
+              { label: 'B', value: 'B' },
+            ],
+            filterOptions: WIDE_MID_FILTER_OPTIONS_LIVE,
+            onFilterChange: function (row, filters) {
+              for (var bn = 0; bn < filters.length; bn += 1) {
+                if (row.band === filters[bn]) return true;
+              }
+              return false;
+            },
+          },
+        ]
+      : [];
+    return []
+      .concat([
+      {
+        name: 'id',
+        displayName: 'ID',
+        width: narrow ? 48 : 72,
+        minWidth: narrow ? 44 : 64,
+        maxWidth: narrow ? 56 : 88,
+        sorting: true,
+        pinned: 'left',
+      },
+      {
+        name: 'member',
+        displayName: 'Member',
+        width: narrow ? 200 : 260,
+        minWidth: narrow ? 188 : 228,
+        maxWidth: narrow ? cap : 320,
+        sorting: true,
+        cellType: 'AVATAR_WITH_TEXT',
+        translate: function (row) {
+          return {
+            title: row.firstName + ' ' + row.lastName,
+            firstName: row.firstName,
+            lastName: row.lastName,
+          };
+        },
+      },
+      {
+        name: 'email',
+        displayName: 'Email',
+        width: narrow ? 240 : 300,
+        minWidth: narrow ? 220 : 260,
+        maxWidth: narrow ? cap : 400,
+        sorting: true,
+        tooltip: true,
+      },
+    ])
+      .concat(laneColumn)
+      .concat([
+      {
+        name: 'department',
+        displayName: 'Department',
+        width: narrow ? 176 : 200,
+        minWidth: narrow ? 160 : 176,
+        maxWidth: narrow ? cap : 360,
+        sorting: true,
+        filters: departmentFilters,
+        filterOptions: {
+          minWidth: 160,
+          maxWidth: filterMax,
+          maxVisibleSelection: 4,
+        },
+        onFilterChange: function (row, filters) {
+          for (var d = 0; d < filters.length; d += 1) {
+            if (row.department === filters[d]) return true;
+          }
+          return false;
+        },
+      },
+      {
+        name: 'program',
+        displayName: 'Program',
+        width: narrow ? 88 : 104,
+        minWidth: narrow ? 80 : 88,
+        maxWidth: narrow ? 120 : 160,
+        sorting: true,
+        filters: programFilters,
+        filterOptions: {
+          minWidth: 120,
+          maxWidth: filterMax,
+          selectionType: 'singleSelect',
+        },
+        onFilterChange: function (row, filters) {
+          for (var p = 0; p < filters.length; p += 1) {
+            if (row.program === filters[p]) return true;
+          }
+          return false;
+        },
+      },
+      {
+        name: 'site',
+        displayName: 'Site',
+        width: narrow ? 96 : 104,
+        minWidth: narrow ? 88 : 92,
+        maxWidth: narrow ? 128 : 168,
+        sorting: true,
+        filters: siteFilters,
+        filterOptions: {
+          minWidth: 120,
+          maxWidth: filterMax,
+          maxVisibleSelection: 4,
+        },
+        onFilterChange: function (row, filters) {
+          for (var s = 0; s < filters.length; s += 1) {
+            if (row.site === filters[s]) return true;
+          }
+          return false;
+        },
+      },
+      {
+        name: 'priority',
+        displayName: 'Priority',
+        width: narrow ? 64 : 72,
+        minWidth: narrow ? 56 : 64,
+        maxWidth: narrow ? 96 : 120,
+        sorting: true,
+        filters: priorityFilters,
+        filterOptions: {
+          minWidth: 100,
+          maxWidth: filterMax,
+          selectionType: 'singleSelect',
+        },
+        onFilterChange: function (row, filters) {
+          for (var r = 0; r < filters.length; r += 1) {
+            if (row.priority === filters[r]) return true;
+          }
+          return false;
+        },
+      },
+    ])
+      .concat(bandColumn)
+      .concat([
+      {
+        name: 'role',
+        displayName: 'Role',
+        width: narrow ? 120 : 148,
+        minWidth: narrow ? 108 : 120,
+        maxWidth: narrow ? cap : 280,
+        sorting: true,
+        filters: [
+          { label: 'Admin', value: 'Admin' },
+          { label: 'User', value: 'User' },
+        ],
+        filterOptions: {
+          minWidth: 160,
+          maxWidth: filterMax,
+          maxVisibleSelection: 4,
+        },
+        onFilterChange: function (row, filters) {
+          for (var i = 0; i < filters.length; i += 1) {
+            if (row.role === filters[i]) return true;
+          }
+          return false;
+        },
+      },
+      {
+        name: 'status',
+        displayName: 'Status',
+        width: narrow ? 108 : 124,
+        minWidth: narrow ? 96 : 104,
+        maxWidth: narrow ? cap : 200,
+        cellType: 'STATUS_HINT',
+        sorting: true,
+        filters: [
+          { label: 'Active', value: 'Active' },
+          { label: 'Inactive', value: 'Inactive' },
+        ],
+        filterOptions: {
+          minWidth: 140,
+          maxWidth: filterMax,
+          selectionType: 'singleSelect',
+        },
+        onFilterChange: function (row, filters) {
+          for (var j = 0; j < filters.length; j += 1) {
+            if (row.status === filters[j]) return true;
+          }
+          return false;
+        },
+        translate: function (row) {
+          var status = row.status;
+          var appearance = statusAppearance[status] || 'default';
+          return {
+            title: status,
+            statusAppearance: appearance,
+          };
+        },
+      },
+      {
+        name: 'region',
+        displayName: 'Coverage region',
+        width: narrow ? NARROW_COL_CAP : 400,
+        minWidth: narrow ? 260 : 320,
+        maxWidth: narrow ? NARROW_COL_CAP : WIDE_COL_CAP,
+        sorting: true,
+        tooltip: true,
+      },
+    ])
+      .concat(tierColumn)
+      .concat([
+      {
+        name: 'actions',
+        displayName: '',
+        width: narrow ? 48 : 56,
+        minWidth: narrow ? 44 : 52,
+        maxWidth: narrow ? 56 : 64,
+        sorting: false,
+        pinned: 'right',
+        cellRenderer: function () {
+          return (
+            <div className="d-flex align-items-center justify-content-end">
+              <Menu trigger={<Menu.Trigger appearance="transparent" />}>
+                <Menu.List>
+                  <Menu.Item>
+                    <Text>View…</Text>
+                  </Menu.Item>
+                  <Menu.Item>
+                    <Text>Assign…</Text>
+                  </Menu.Item>
+                </Menu.List>
+              </Menu>
+            </div>
+          );
+        },
+      },
+    ]);
+  }
+
+  const [viewportPreset, setViewportPreset] = React.useState('320');
+  const [showWideFilters, setShowWideFilters] = React.useState(false);
+  const [showCreateNew, setShowCreateNew] = React.useState(false);
+
+  var isNarrowSchema = viewportPreset === '320';
+
+  const loaderSchema = React.useMemo(function () {
+    return buildLoaderSchemaLive(isNarrowSchema, showWideFilters);
+  }, [isNarrowSchema, showWideFilters]);
+  const schema = React.useMemo(function () {
+    return buildViewportSchemaLive(isNarrowSchema, showWideFilters);
+  }, [isNarrowSchema, showWideFilters]);
+
+  const selectionActionRenderer = function () {
+    return (
+      <div className="d-flex align-items-center">
+        <Button size="tiny" className="mr-4">
+          Delete
+        </Button>
+        <Button size="tiny">Export</Button>
+      </div>
+    );
+  };
+
+  var globalActionRenderer = showCreateNew
+    ? function () {
+        return (
+          <Button type="button" onClick={function () { action('Create new')(); }}>
+            Create new
+          </Button>
+        );
+      }
+    : undefined;
+
+  return (
+    <div>
+      <Flex direction="row" wrap="wrap" gap="spacing-40" className="mb-6 align-items-center">
+        <Chip
+          type="selection"
+          name="viewport320"
+          label="320 view"
+          selected={viewportPreset === '320'}
+          aria-label="Constrain table to 320px width (narrow column layout)"
+          onClick={function () {
+            setViewportPreset(function (p) {
+              return p === '320' ? 'full' : '320';
+            });
+          }}
+        />
+        <Chip
+          type="selection"
+          name="viewport640"
+          label="640 view"
+          selected={viewportPreset === '640'}
+          aria-label="Constrain table to 640px width (unselects 320 view)"
+          onClick={function () {
+            setViewportPreset(function (p) {
+              return p === '640' ? 'full' : '640';
+            });
+          }}
+        />
+        <Chip
+          type="selection"
+          name="wideFilters"
+          label="Wide filters"
+          selected={showWideFilters}
+          aria-label="Toggle 400px wide filter popovers on Lane and Tier columns"
+          onClick={function () { setShowWideFilters(function (v) { return !v; }); }}
+        />
+        <Chip
+          type="selection"
+          name="createNew"
+          label="Create new"
+          selected={showCreateNew}
+          aria-label="Toggle Create new header action"
+          onClick={function () { setShowCreateNew(function (v) { return !v; }); }}
+        />
+      </Flex>
+      <div
+        style={{
+          width: viewportPreset === '320' ? 320 : viewportPreset === '640' ? 640 : '100%',
+          maxWidth: '100%',
+          marginLeft: 'auto',
+          marginRight: 'auto',
+          boxSizing: 'border-box',
+        }}
+      >
+        <Card className="overflow-hidden vh-75">
+          <Table
+            aria-label="Responsive roster table with filters and pinned columns"
+            loaderSchema={loaderSchema}
+            data={data}
+            schema={schema}
+            type="data"
+            size="compressed"
+            separator={false}
+            showMenu={true}
+            draggable={true}
+            withHeader={true}
+            headerOptions={{
+              withSearch: true,
+              searchPlaceholder: 'Search by name, email, or role…',
+              dynamicColumn: true,
+              allowSelectAll: true,
+              globalActionRenderer: globalActionRenderer,
+              selectionActionRenderer: selectionActionRenderer,
+            }}
+            filterPosition="HEADER"
+            multipleSorting={true}
+            sortingList={[]}
+            withCheckbox={true}
+            uniqueColumnName="id"
+            withPagination={true}
+            paginationType="jump"
+            pageSize={5}
+            pageJumpDebounceDuration={750}
+            searchDebounceDuration={500}
+            filterList={{}}
+            onSearch={function (currData, searchTerm) {
+              var t = searchTerm.toLowerCase();
+              return currData.filter(function (d) {
+                return (
+                  d.firstName.toLowerCase().indexOf(t) !== -1 ||
+                  d.lastName.toLowerCase().indexOf(t) !== -1 ||
+                  d.email.toLowerCase().indexOf(t) !== -1 ||
+                  d.role.toLowerCase().indexOf(t) !== -1
+                );
+              });
+            }}
+          />
+        </Card>
+      </div>
+    </div>
+  );
+};
+`;
+
+export default {
+  title: 'Components/Table/Responsiveness',
+  component: Table,
+  parameters: {
+    docs: {
+      docPage: {
+        customCode,
+        title: 'Table responsiveness',
+        props: {
+          components: { AsyncTable, SyncTable, Chip, Flex, Button, action },
+        },
+      },
+    },
+  },
+};

--- a/css/src/components/grid.module.css
+++ b/css/src/components/grid.module.css
@@ -415,16 +415,41 @@
 
 .Header-content {
   display: flex;
+  flex-wrap: wrap-reverse;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-40);
+  gap: var(--spacing-20) var(--spacing-60);
+}
+
+.Header-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--spacing-20) var(--spacing-30);
+  flex: 1 1 0%;
+}
+
+.Header-searchFilters {
+  display: flex;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  align-items: center;
+  column-gap: var(--spacing-20);
+  row-gap: var(--spacing-20);
 }
 
 .Header-content--bottom {
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-20) 0;
 }
 
 .Header-search {
   width: var(--spacing-640);
-  margin-bottom: var(--spacing-40);
+  max-width: 100%;
+  flex-shrink: 0;
+  min-width: 0;
 }
 
 .Header-label {
@@ -437,23 +462,9 @@
   margin-right: var(--spacing-20);
 }
 
-.Header-dropdown {
-  display: flex;
-  margin-left: var(--spacing-10);
-  margin-bottom: var(--spacing-40);
-}
-
-.Header-dropdown .Dropdown {
-  margin: 0 var(--spacing-10);
-}
-
 .Header-draggableDropdown .Dropdown-wrapper {
   max-height: 200px;
   overflow-y: auto;
-}
-
-.Header-filters {
-  display: flex;
 }
 
 .Header-sorting {
@@ -461,13 +472,16 @@
 }
 
 .Header-actions {
-  margin-bottom: var(--spacing-40);
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .Header-global-actions {
-  justify-content: flex-end;
+  display: flex;
+  flex: 0 0 auto;
   margin-left: auto;
-  margin-bottom: var(--spacing-40);
+  min-width: 0;
+  justify-content: flex-end;
 }
 
 /* Grid row */

--- a/css/src/components/grid.module.css
+++ b/css/src/components/grid.module.css
@@ -417,8 +417,12 @@
   display: flex;
   flex-wrap: wrap-reverse;
   justify-content: space-between;
-  margin-bottom: var(--spacing-40);
   gap: var(--spacing-20) var(--spacing-60);
+}
+
+/* Toolbar row only: space before summary/selection row. Do not apply to .Header-content--bottom. */
+.Header-content:not(.Header-content--bottom) {
+  margin-bottom: var(--spacing-40);
 }
 
 .Header-toolbar {

--- a/docs/src/pages/components/table/usage.mdx
+++ b/docs/src/pages/components/table/usage.mdx
@@ -296,9 +296,9 @@ The cursor changes to Pointing Hand when hovering on a header cell indicating th
 **Pinned column divider** is used to pin columns to the left so that they get fixed and do not scroll along with the rest of the columns. It is quite handy when the no. of columns is too many and all of them are not visible without scrolling. In that case, the pinning can help freeze the crucial columns in order to maintain the context.
 <Preview name='components-table-pinned-columns--pinned-columns' />
 
-##### Narrow Containers
+**Narrow Containers**
 
-When the container is too narrow, pinned columns can take so much width that scrollable columns are hidden. The grid measures the visible scroll area minus pinned regions; when the remaining width for unpinned columns drops below 320px, pins are cleared one column at a time (inner-most left pin first, then inner-most right). When that region widens past 380px, pins are restored in reverse order so layout does not oscillate at the threshold.
+When the container is narrow, pinned columns can take so much width that other columns get completely hidden. To ensure the table stays accessible at small widths, columns are unpinned one at a time until the scrolling region is at least 320px.
 
 <br/>
 
@@ -347,9 +347,11 @@ Use pagination over infinite scroll so that the user can navigate to an item’s
 
 To read about filters patterns visit [Table Filters](https://design.innovaccer.com/patterns/tableFilters/usage/)
 
-##### Responsiveness
+**Narrow containers**
 
-As the table gets smaller some Filters can overflow the container bringing in horizontal scroll. This causes accessibility issues by introducing horizontal and vertical scroll at the same time. To ensure tables stay accessible, when filters overflow they are wrapped to the next line as the width shrinks.
+When a table is narrow, a long list of filters can overflow and cause horizontal scrolling. To prevent accessibility issues from having both horizontal and vertical scrollbars, filters automatically wrap to the next line to fit the available space.
+
+If a filter has a custom width, ensure this width is removed when the table shrinks towards 320px so the filter fits within the container and is not clipped.
 <br />
 
 #### Data Alignment

--- a/docs/src/pages/components/table/usage.mdx
+++ b/docs/src/pages/components/table/usage.mdx
@@ -296,6 +296,12 @@ The cursor changes to Pointing Hand when hovering on a header cell indicating th
 **Pinned column divider** is used to pin columns to the left so that they get fixed and do not scroll along with the rest of the columns. It is quite handy when the no. of columns is too many and all of them are not visible without scrolling. In that case, the pinning can help freeze the crucial columns in order to maintain the context.
 <Preview name='components-table-pinned-columns--pinned-columns' />
 
+##### Narrow Containers
+
+When the container is too narrow, pinned columns can take so much width that scrollable columns are hidden. The grid measures the visible scroll area minus pinned regions; when the remaining width for unpinned columns drops below 320px, pins are cleared one column at a time (inner-most left pin first, then inner-most right). When that region widens past 380px, pins are restored in reverse order so layout does not oscillate at the threshold.
+
+<br/>
+
 #### Selection
 
 ##### Default Selection
@@ -339,8 +345,11 @@ Use pagination over infinite scroll so that the user can navigate to an item’s
 
 #### Filtering
 
-To read all about table filters visit [Table Filters](https://design.innovaccer.com/patterns/tableFilters/usage/)
+To read about filters patterns visit [Table Filters](https://design.innovaccer.com/patterns/tableFilters/usage/)
 
+##### Responsiveness
+
+As the table gets smaller some Filters can overflow the container bringing in horizontal scroll. This causes accessibility issues by introducing horizontal and vertical scroll at the same time. To ensure tables stay accessible, when filters overflow they are wrapped to the next line as the width shrinks.
 <br />
 
 #### Data Alignment

--- a/docs/src/pages/patterns/tableFilters/usage.mdx
+++ b/docs/src/pages/patterns/tableFilters/usage.mdx
@@ -63,6 +63,14 @@ In case the need arises to use more than 3 filters, an additional button- “+ M
 <br/>
 
 
+#### Responsiveness
+
+When quick filters are placed in the table header, they automatically wrap to the next line on narrow screens to prevent horizontal scrolling. If a filter has a custom width, ensure this width is removed when the table shrinks to 320px so the filter fits within the container and is not clipped.
+
+<br/>
+<br/>
+
+
 #### Applying Filters
 
 ##### Instant Application


### PR DESCRIPTION
## Summary
- Introduces responsive flex-wrapping for Table header toolbars so filters don't cause horizontal overflow on small screens.
- Adds an auto-unpinning mechanism for Grid/Table to prevent pinned columns from consuming the entire container width on narrow viewports.

## Changes
- **Responsive Header**: Modified `Header.tsx` and `grid.module.css` to use `flex-wrap` for the search and filter elements.
- **Auto-Unpinning**: Added logic to dynamically unpin columns if the remaining scrollable width drops below 320px, and repin them if it widens above 380px.
- **Pin Validation**: Updated `Cell.tsx` to disable pin options in the column dropdown if the column's width would exceed available space.
- **Documentation**: Updated Table `usage.mdx` with guidance on Filtering Responsiveness and Narrow Containers for pinned columns.
- **Tests & Stories**: Added `autoUnpinPinnedLayout.test.ts` and updated `Responsiveness.story.jsx` to cover the new behaviors.