### PR TITLE
fix(chip): avoid nested interactive default

### DIFF
--- a/core/components/atoms/_chip/__tests__/_chip.test.tsx
+++ b/core/components/atoms/_chip/__tests__/_chip.test.tsx
@@ -109,6 +109,52 @@ describe('Chip component with keyboard interaction', () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('does not render a non-actionable chip wrapper as a button', () => {
+    const { getByTestId } = render(<GenericChip name="Chip" label="Test Chip" />);
+
+    const chipWrapper = getByTestId('DesignSystem-GenericChip--Wrapper');
+
+    expect(chipWrapper).toHaveAttribute('tabIndex', '-1');
+    expect(chipWrapper).not.toHaveAttribute('role');
+  });
+
+  it('keeps removable chip wrapper out of tab order when only clear button is actionable', () => {
+    const { getByTestId } = render(<GenericChip name="Chip" label="Test Chip" clearButton={true} />);
+
+    const chipWrapper = getByTestId('DesignSystem-GenericChip--Wrapper');
+    const clearButton = getByTestId('DesignSystem-GenericChip--clearButton');
+
+    expect(chipWrapper).toHaveAttribute('tabIndex', '-1');
+    expect(chipWrapper).not.toHaveAttribute('role');
+    expect(clearButton).toHaveAttribute('tabIndex', '0');
+    expect(clearButton).toHaveAttribute('role', 'button');
+  });
+
+  it('keeps chip wrapper focusable when onClick is provided', () => {
+    const { getByTestId } = render(
+      <GenericChip name="Chip" label="Test Chip" clearButton={true} onClick={jest.fn()} />
+    );
+
+    const chipWrapper = getByTestId('DesignSystem-GenericChip--Wrapper');
+
+    expect(chipWrapper).toHaveAttribute('tabIndex', '0');
+    expect(chipWrapper).toHaveAttribute('role', 'button');
+  });
+
+  it('preserves keyboard activation for actionable chips with custom interactive roles', () => {
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <GenericChip name="Chip" label="Test Chip" type="selection" role="option" selected={true} onClick={onClick} />
+    );
+
+    const chipWrapper = getByTestId('DesignSystem-GenericChip--Wrapper');
+    fireEvent.keyDown(chipWrapper, { key: 'Enter', code: 'Enter' });
+
+    expect(chipWrapper).toHaveAttribute('role', 'option');
+    expect(chipWrapper).toHaveAttribute('aria-selected', 'true');
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('GenericChip component size prop functionality', () => {
@@ -185,6 +231,12 @@ describe('GenericChip component icon size functionality based on chip size', () 
 describe('GenericChip component a11y', () => {
   it('has no detectable a11y violations', async () => {
     const { container } = render(<GenericChip label="ChipLabel" name="Chip" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no detectable a11y violations when clear button is the only action', async () => {
+    const { container } = render(<GenericChip label="ChipLabel" name="Chip" clearButton={true} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/core/components/atoms/_chip/index.tsx
+++ b/core/components/atoms/_chip/index.tsx
@@ -166,7 +166,10 @@ export const GenericChip = (props: GenericChipProps) => {
     return labelText;
   };
 
-  const computedTabIndex = props.tabIndex !== undefined ? (disabled ? -1 : props.tabIndex) : disabled ? -1 : 0;
+  const hasWrapperAction = !!onClick;
+  const wrapperRole = props.role || (hasWrapperAction ? 'button' : undefined);
+  const computedTabIndex =
+    props.tabIndex !== undefined ? (disabled ? -1 : props.tabIndex) : disabled || !hasWrapperAction ? -1 : 0;
 
   const clearButtonAriaAttr = props.clearButtonAriaLabel ?? (typeof label === 'string' ? `Remove ${label}` : 'Remove');
 
@@ -179,10 +182,10 @@ export const GenericChip = (props: GenericChipProps) => {
   })();
 
   const getAriaProps = () => {
-    const effectiveRole = props.role || 'button';
+    const effectiveRole = wrapperRole;
     const ariaProps: React.HTMLAttributes<HTMLDivElement> = {};
 
-    if (type === 'selection') {
+    if (type === 'selection' && effectiveRole) {
       if (effectiveRole === 'button') {
         ariaProps['aria-pressed'] = selected;
       } else if (effectiveRole === 'checkbox' || effectiveRole === 'menuitemcheckbox') {
@@ -206,14 +209,14 @@ export const GenericChip = (props: GenericChipProps) => {
         tabIndex={computedTabIndex}
         style={wrapperStyle}
         data-test="DesignSystem-GenericChip--Wrapper"
-        role={props.role || 'button'}
+        role={wrapperRole}
         aria-label={computedAriaLabel}
         aria-labelledby={props['aria-labelledby']}
         {...getAriaProps()}
-        onKeyDown={onChipKeyDownHandler}
+        onKeyDown={hasWrapperAction ? onChipKeyDownHandler : undefined}
         {...baseProps}
         className={chipWrapperClass}
-        onClick={onClickHandler}
+        onClick={hasWrapperAction ? onClickHandler : undefined}
       >
         {icon && (
           <Icon

--- a/core/components/atoms/chip/Chip.tsx
+++ b/core/components/atoms/chip/Chip.tsx
@@ -145,7 +145,7 @@ export const Chip = (props: ChipProps) => {
       disabled={disabled}
       className={chipClass}
       onClose={onCloseHandler}
-      onClick={onClickHandler}
+      onClick={onClick ? onClickHandler : undefined}
       name={name}
       labelPrefix={labelPrefix}
       maxWidth={maxWidth}

--- a/core/components/atoms/chip/__tests__/Chip.test.tsx
+++ b/core/components/atoms/chip/__tests__/Chip.test.tsx
@@ -133,6 +133,27 @@ describe('Chip component', () => {
     expect(FunctionValue).toHaveBeenCalled();
   });
 
+  it('does not render a non-actionable chip wrapper as a button', () => {
+    const { getByTestId } = render(<Chip label="Chip" name="Chip" />);
+
+    const chipWrapper = getByTestId('DesignSystem-Chip--GenericChip');
+
+    expect(chipWrapper).toHaveAttribute('tabIndex', '-1');
+    expect(chipWrapper).not.toHaveAttribute('role');
+  });
+
+  it('keeps removable chip wrapper out of tab order without onClick', () => {
+    const { getByTestId } = render(<Chip label="Chip" name="Chip" onClose={FunctionValue} clearButton={true} />);
+
+    const chipWrapper = getByTestId('DesignSystem-Chip--GenericChip');
+    const clearButton = getByTestId('DesignSystem-GenericChip--clearButton');
+
+    expect(chipWrapper).toHaveAttribute('tabIndex', '-1');
+    expect(chipWrapper).not.toHaveAttribute('role');
+    expect(clearButton).toHaveAttribute('tabIndex', '0');
+    expect(clearButton).toHaveAttribute('role', 'button');
+  });
+
   it('renders chip component with prop: selected, disabled and type selection', () => {
     const { queryByTestId } = render(
       <Chip label="Chip" name="Chip" type="selection" disabled={true} selected={true} />
@@ -264,6 +285,12 @@ describe('Chip component size functionality', () => {
 describe('Chip component a11y', () => {
   it('has no detectable a11y violations', async () => {
     const { container } = render(<Chip label="Test" name="test" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('has no detectable a11y violations when clear button is the only action', async () => {
+    const { container } = render(<Chip label="Test" name="test" clearButton={true} />);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/core/components/atoms/chip/__tests__/__snapshots__/Chip.test.tsx.snap
+++ b/core/components/atoms/chip/__tests__/__snapshots__/Chip.test.tsx.snap
@@ -8,9 +8,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Action Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -24,9 +23,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Action Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -40,7 +38,6 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip-Action--disabled Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
       tabindex="-1"
     />
@@ -56,9 +53,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Input Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -72,9 +68,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Input Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -88,7 +83,6 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip-Input--disabled Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
       tabindex="-1"
     />
@@ -104,9 +98,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Selection Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -120,9 +113,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Selection Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -136,7 +128,6 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip-Selection--disabled Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
       tabindex="-1"
     />
@@ -152,9 +143,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Selection Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>
@@ -168,9 +158,8 @@ exports[`Chip component
     <div
       class="Chip-wrapper Chip Chip--Selection Chip-Selection--selected Chip-size--regular"
       data-test="DesignSystem-Chip--GenericChip"
-      role="button"
       style="max-width: var(--spacing-640);"
-      tabindex="0"
+      tabindex="-1"
     />
   </div>
 </body>


### PR DESCRIPTION
Summary: prevent removable Chip wrappers from becoming interactive when only the clear button is actionable; only pass Chip onClick to GenericChip when consumers provide it; add GenericChip and Chip axe regressions. Test plan: npx jest core/components/atoms/_chip/__tests__/_chip.test.tsx core/components/atoms/chip/__tests__/Chip.test.tsx --runInBand