### PR TITLE
fix(grid): make header scroll region focusable

### DIFF
--- a/core/components/organisms/grid/GridHead.tsx
+++ b/core/components/organisms/grid/GridHead.tsx
@@ -101,7 +101,8 @@ export const GridHead = (props: GridHeadProps) => {
   };
 
   return (
-    <div className={styles['Grid-head']} role="rowgroup" data-test="DesignSystem-GridHead-wrapper">
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- Grid-head is horizontally scrollable.
+    <div className={styles['Grid-head']} role="rowgroup" tabIndex={0} data-test="DesignSystem-GridHead-wrapper">
       <div className={RowClass} role={hasColumns ? 'row' : undefined}>
         {renderSchema(leftPinnedSchema, !!leftPinnedSchema.length, 'left')}
         {renderSchema(unpinnedSchema, !leftPinnedSchema.length && !!unpinnedSchema.length)}

--- a/core/components/organisms/grid/__tests__/Grid.test.tsx
+++ b/core/components/organisms/grid/__tests__/Grid.test.tsx
@@ -67,6 +67,10 @@ describe('renders Grid with showHead true and false', () => {
     const { queryByTestId } = render(<Grid showHead={true} />);
     expect(queryByTestId('DesignSystem-GridHead-wrapper')).toBeInTheDocument();
   });
+  it('renders Grid head as a focusable scroll region', () => {
+    const { getByTestId } = render(<Grid showHead={true} />);
+    expect(getByTestId('DesignSystem-GridHead-wrapper')).toHaveAttribute('tabIndex', '0');
+  });
   it('renders Grid with showHead false', () => {
     const { queryByTestId } = render(<Grid showHead={false} />);
     expect(queryByTestId('DesignSystem-GridHead-wrapper')).not.toBeInTheDocument();


### PR DESCRIPTION
Summary: add tabIndex=0 to Grid-head so the horizontally scrollable header is always keyboard focusable; add a focused regression assertion; update Grid snapshots for the new header attribute. Test plan: npx jest core/components/organisms/grid/__tests__/Grid.test.tsx --runInBand -u; npx eslint --ext .tsx,.ts,.js,.jsx core/components/organisms/grid/GridHead.tsx core/components/organisms/grid/__tests__/Grid.test.tsx