### PR TITLE
fix(datepicker): collapsible datepicker

### DIFF
--- a/core/components/organisms/calendar/PickerCustomContent.tsx
+++ b/core/components/organisms/calendar/PickerCustomContent.tsx
@@ -1,0 +1,368 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import Select from '@/components/organisms/select';
+import Button from '@/components/atoms/button';
+import { OptionType } from '@/common.type';
+import styles from '@css/components/pickerContent.module.css';
+
+let pickerCustomContentId = 0;
+
+export const hasRenderableChildren = (children: React.ReactNode): boolean => {
+  const childArray = React.Children.toArray(children);
+
+  return childArray.some((child) => {
+    if (child === null || child === undefined || typeof child === 'boolean') return false;
+    if (typeof child === 'string') return child.trim().length > 0;
+    if (typeof child === 'number') return true;
+
+    if (React.isValidElement(child) && child.type === React.Fragment) {
+      return hasRenderableChildren(child.props.children);
+    }
+
+    return true;
+  });
+};
+
+export interface PickerCustomContentProps {
+  children: React.ReactNode;
+  triggerLabel?: string;
+}
+
+interface PresetChipProps {
+  disabled?: boolean;
+  label?: React.ReactNode;
+  labelPrefix?: string;
+  name?: unknown;
+  onClick?: (name?: unknown) => void;
+  selected?: boolean;
+}
+
+interface PresetOption {
+  disabled?: boolean;
+  id: string;
+  onClick?: () => void;
+  option: OptionType;
+  selected?: boolean;
+}
+
+interface SplitContentResult {
+  content: React.ReactNode;
+  hasContent: boolean;
+}
+
+const getNodeText = (node: React.ReactNode): string => {
+  if (node === null || node === undefined || typeof node === 'boolean') return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+
+  if (Array.isArray(node)) {
+    return node.map(getNodeText).join(' ');
+  }
+
+  if (React.isValidElement<{ children?: React.ReactNode }>(node)) {
+    return getNodeText(node.props.children);
+  }
+
+  return '';
+};
+
+const isChipElement = (child: React.ReactElement): child is React.ReactElement<PresetChipProps> => {
+  const elementType = child.type as { displayName?: string; name?: string };
+  return elementType.displayName === 'Chip' || elementType.name === 'Chip';
+};
+
+const hasChildrenProp = (element: React.ReactElement<{ children?: React.ReactNode }>): boolean => {
+  return element.props.children !== undefined;
+};
+
+const shouldKeepEmptyElement = (element: React.ReactElement) => {
+  if (typeof element.type !== 'string') return !hasChildrenProp(element);
+
+  const elementType = element.type;
+  const props = element.props as Record<string, unknown>;
+  const selfRenderingElements = ['button', 'input', 'select', 'textarea', 'img', 'svg'];
+
+  return (
+    selfRenderingElements.includes(elementType) ||
+    Boolean(props.onClick || props.onKeyDown || props.role || props['aria-label'] || props.href)
+  );
+};
+
+const removePresetChips = (children: React.ReactNode): SplitContentResult => {
+  const splitNode = (node: React.ReactNode): SplitContentResult => {
+    if (node === null || node === undefined || typeof node === 'boolean') {
+      return { content: null, hasContent: false };
+    }
+
+    if (typeof node === 'string') {
+      return { content: node, hasContent: node.trim().length > 0 };
+    }
+
+    if (typeof node === 'number') {
+      return { content: node, hasContent: true };
+    }
+
+    if (!React.isValidElement(node)) {
+      return { content: node, hasContent: true };
+    }
+
+    if (isChipElement(node)) {
+      return { content: null, hasContent: false };
+    }
+
+    if (hasChildrenProp(node)) {
+      const splitChildren = removePresetChips(node.props.children);
+
+      if (!splitChildren.hasContent) {
+        if (node.type === React.Fragment || !shouldKeepEmptyElement(node)) {
+          return { content: null, hasContent: false };
+        }
+
+        return { content: node, hasContent: true };
+      }
+
+      return {
+        content: React.cloneElement(node, undefined, splitChildren.content),
+        hasContent: true,
+      };
+    }
+
+    return { content: node, hasContent: true };
+  };
+
+  const content: React.ReactNode[] = [];
+  let hasContent = false;
+
+  React.Children.forEach(children, (child) => {
+    const splitChild = splitNode(child);
+
+    if (splitChild.hasContent) {
+      content.push(splitChild.content);
+      hasContent = true;
+    }
+  });
+
+  return {
+    content: content.length === 1 ? content[0] : content,
+    hasContent,
+  };
+};
+
+const getPresetOptions = (children: React.ReactNode): PresetOption[] => {
+  const options: PresetOption[] = [];
+  let optionIndex = 0;
+
+  const walk = (node: React.ReactNode) => {
+    React.Children.forEach(node, (child) => {
+      if (!React.isValidElement(child)) return;
+
+      if (isChipElement(child)) {
+        const { disabled, label, labelPrefix, name, onClick, selected } = child.props;
+        const labelText = [labelPrefix, getNodeText(label)].filter(Boolean).join(' ').trim();
+
+        if (!labelText) return;
+
+        const value = `${typeof name === 'string' || typeof name === 'number' ? name : labelText}-${optionIndex}`;
+        const option = { label: labelText, value };
+
+        options.push({
+          disabled,
+          id: `preset-option-${optionIndex}`,
+          onClick: onClick ? () => onClick(name) : undefined,
+          option,
+          selected,
+        });
+        optionIndex += 1;
+        return;
+      }
+
+      if (hasChildrenProp(child)) {
+        walk(child.props.children);
+      }
+    });
+  };
+
+  walk(children);
+  return options;
+};
+
+export const PickerCustomContent = (props: PickerCustomContentProps) => {
+  const { children, triggerLabel = 'Presets' } = props;
+  const [open, setOpen] = React.useState(false);
+  const [selectedLabel, setSelectedLabel] = React.useState('');
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLButtonElement>(null);
+  const panelIdRef = React.useRef('');
+  const presetOptions = React.useMemo(() => getPresetOptions(children), [children]);
+  const selectedPreset = presetOptions.find((option) => option.selected);
+  const hasPresetOptions = presetOptions.length > 0;
+  const mobileCustomContent = React.useMemo(() => removePresetChips(children), [children]);
+
+  if (!panelIdRef.current) {
+    pickerCustomContentId += 1;
+    panelIdRef.current = `DesignSystem-PickerCustomContent-${pickerCustomContentId}`;
+  }
+
+  React.useEffect(() => {
+    if (!open) return undefined;
+
+    const onMouseDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    window.requestAnimationFrame(() => {
+      const panel = document.getElementById(panelIdRef.current);
+      const focusable = panel?.querySelector<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [role="button"]:not([aria-disabled="true"]), [tabindex]:not([tabindex="-1"])'
+      );
+      focusable?.focus({ preventScroll: true });
+    });
+  }, [open]);
+
+  const getInteractiveLabel = (target: HTMLElement) => {
+    const interactiveElement = target.closest<HTMLElement>(
+      '[data-test="DesignSystem-GenericChip--Wrapper"], button, [role="button"], [role="option"], [role="menuitem"]'
+    );
+
+    if (!interactiveElement || !rootRef.current?.contains(interactiveElement)) return undefined;
+
+    const label = interactiveElement.getAttribute('aria-label') || interactiveElement.textContent;
+    return label?.replace(/\s+/g, ' ').trim();
+  };
+
+  const closeAfterSelection = (target: HTMLElement) => {
+    window.setTimeout(() => {
+      const label = getInteractiveLabel(target);
+      if (!label) return;
+
+      if (label) setSelectedLabel(label);
+      setOpen(false);
+      triggerRef.current?.focus();
+    }, 0);
+  };
+
+  const onPanelClickCapture = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!open) return;
+
+    closeAfterSelection(event.target as HTMLElement);
+  };
+
+  const onPanelKeyDownCapture = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!open) return;
+
+    if (event.key === 'Enter') {
+      closeAfterSelection(event.target as HTMLElement);
+    }
+  };
+
+  const onPresetSelect = (option?: OptionType | OptionType[]) => {
+    if (!option || Array.isArray(option)) return;
+
+    const selectedOption = presetOptions.find((presetOption) => presetOption.option.value === option.value);
+    selectedOption?.onClick?.();
+  };
+
+  const panelClass = classNames(styles['PickerCustomContent-panel'], {
+    [styles['PickerCustomContent-panel--open']]: open,
+  });
+  const rootClass = classNames(styles['PickerCustomContent'], {
+    [styles['PickerCustomContent--withPresetSelect']]: hasPresetOptions,
+  });
+  const fallbackTriggerText = selectedLabel ? `${triggerLabel}: ${selectedLabel}` : triggerLabel;
+
+  return (
+    <div className={rootClass} ref={rootRef}>
+      {hasPresetOptions && (
+        <div className={styles['PickerCustomContent-presetSelect']}>
+          <Select
+            key={selectedPreset ? String(selectedPreset.option.value) : 'empty'}
+            width="100%"
+            maxHeight={256}
+            onSelect={onPresetSelect}
+            value={selectedPreset?.option}
+            triggerOptions={{
+              icon: 'calendar_today',
+              placeholder: triggerLabel,
+              withClearButton: false,
+              'aria-label': triggerLabel,
+            }}
+          >
+            <Select.List aria-label={`${triggerLabel} options`} size="compressed">
+              {presetOptions.map((presetOption) => (
+                <Select.Option
+                  key={presetOption.id}
+                  option={presetOption.option}
+                  disabled={presetOption.disabled}
+                  data-test="DesignSystem-PickerCustomContent--PresetOption"
+                >
+                  {presetOption.option.label}
+                </Select.Option>
+              ))}
+            </Select.List>
+          </Select>
+        </div>
+      )}
+      {hasPresetOptions && mobileCustomContent.hasContent && (
+        <div
+          className={styles['PickerCustomContent-mobileCustomContent']}
+          role="group"
+          aria-label={`${triggerLabel} custom content`}
+          data-test="DesignSystem-PickerCustomContent--MobileCustomContent"
+        >
+          {mobileCustomContent.content}
+        </div>
+      )}
+      {!hasPresetOptions && (
+        <div className={styles['PickerCustomContent-trigger']}>
+          <Button
+            ref={triggerRef}
+            expanded={true}
+            icon={open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+            iconAlign="right"
+            className={styles['PickerCustomContent-triggerButton']}
+            aria-expanded={open}
+            aria-controls={panelIdRef.current}
+            aria-haspopup="dialog"
+            onClick={() => setOpen((currentOpen) => !currentOpen)}
+            data-test="DesignSystem-PickerCustomContent--Trigger"
+          >
+            {fallbackTriggerText}
+          </Button>
+        </div>
+      )}
+      <div
+        id={panelIdRef.current}
+        className={panelClass}
+        role="group"
+        aria-label={triggerLabel}
+        onClickCapture={onPanelClickCapture}
+        onKeyDownCapture={onPanelKeyDownCapture}
+        data-test="DesignSystem-PickerCustomContent--Panel"
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default PickerCustomContent;

--- a/core/components/organisms/calendar/__tests__/PickerCustomContent.test.tsx
+++ b/core/components/organisms/calendar/__tests__/PickerCustomContent.test.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { fireEvent, render, waitFor, within } from '@testing-library/react';
+import Chip from '@/components/atoms/chip';
+import PickerCustomContent, { hasRenderableChildren } from '../PickerCustomContent';
+
+const PresetLayout = ({ children }: { children: React.ReactNode }) => <section>{children}</section>;
+
+describe('PickerCustomContent', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  it('opens and closes non-preset custom picker content from the mobile trigger', async () => {
+    const onClick = jest.fn();
+    const { getByTestId, getByText } = render(
+      <PickerCustomContent>
+        <button type="button" onClick={onClick}>
+          Today
+        </button>
+      </PickerCustomContent>
+    );
+
+    const trigger = getByTestId('DesignSystem-PickerCustomContent--Trigger');
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(getByText('Today'));
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(trigger).toHaveTextContent('Presets: Today');
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps non-preset custom content accessible when preset chips exist', () => {
+    const { getByTestId } = render(
+      <PickerCustomContent>
+        <div>
+          <button type="button">Reset</button>
+          <div>
+            <Chip label="This week" clearButton={false} type="selection" name="currWeek" />
+          </div>
+        </div>
+      </PickerCustomContent>
+    );
+
+    const mobileCustomContent = getByTestId('DesignSystem-PickerCustomContent--MobileCustomContent');
+
+    expect(within(mobileCustomContent).getByText('Reset')).toBeInTheDocument();
+    expect(within(mobileCustomContent).queryByText('This week')).toBeNull();
+  });
+
+  it('keeps non-preset content inside custom wrappers while removing wrapped preset chips', () => {
+    const { getByTestId } = render(
+      <PickerCustomContent>
+        <PresetLayout>
+          <button type="button">Reset</button>
+          <Chip label="Wrapped preset" clearButton={false} type="selection" name="wrappedPreset" />
+        </PresetLayout>
+      </PickerCustomContent>
+    );
+
+    const mobileCustomContent = getByTestId('DesignSystem-PickerCustomContent--MobileCustomContent');
+
+    expect(within(mobileCustomContent).getByText('Reset')).toBeInTheDocument();
+    expect(within(mobileCustomContent).queryByText('Wrapped preset')).toBeNull();
+  });
+
+  it('does not close custom content on Space keydown before native button activation', async () => {
+    const onClick = jest.fn();
+    const { getByTestId, getByText } = render(
+      <PickerCustomContent>
+        <button type="button" onClick={onClick}>
+          Apply
+        </button>
+      </PickerCustomContent>
+    );
+
+    const trigger = getByTestId('DesignSystem-PickerCustomContent--Trigger');
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(getByText('Apply'), { key: ' ' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(getByText('Apply'));
+
+    await waitFor(() => {
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders preset chips as Select options in the collapsed control', async () => {
+    const onClick = jest.fn();
+    const { findAllByTestId, getByTestId, queryByTestId } = render(
+      <PickerCustomContent>
+        <div>
+          <Chip label="This week" clearButton={false} type="selection" name="currWeek" onClick={onClick} />
+        </div>
+      </PickerCustomContent>
+    );
+
+    expect(queryByTestId('DesignSystem-PickerCustomContent--Trigger')).toBeNull();
+    expect(queryByTestId('DesignSystem-PickerCustomContent--MobileCustomContent')).toBeNull();
+
+    fireEvent.click(getByTestId('DesignSystem-Select-trigger'));
+    const presetOptions = await findAllByTestId('DesignSystem-PickerCustomContent--PresetOption');
+
+    fireEvent.click(presetOptions[0]);
+
+    expect(onClick).toHaveBeenCalledWith('currWeek');
+  });
+
+  it('renders preset chips wrapped by custom components as Select options', async () => {
+    const onClick = jest.fn();
+    const { findAllByTestId, getByTestId, queryByTestId } = render(
+      <PickerCustomContent>
+        <PresetLayout>
+          <Chip label="Wrapped preset" clearButton={false} type="selection" name="wrappedPreset" onClick={onClick} />
+        </PresetLayout>
+      </PickerCustomContent>
+    );
+
+    expect(queryByTestId('DesignSystem-PickerCustomContent--Trigger')).toBeNull();
+    expect(queryByTestId('DesignSystem-PickerCustomContent--MobileCustomContent')).toBeNull();
+
+    fireEvent.click(getByTestId('DesignSystem-Select-trigger'));
+    const presetOptions = await findAllByTestId('DesignSystem-PickerCustomContent--PresetOption');
+
+    fireEvent.click(presetOptions[0]);
+
+    expect(onClick).toHaveBeenCalledWith('wrappedPreset');
+  });
+
+  it('detects empty fragments as non-renderable children', () => {
+    expect(hasRenderableChildren(<></>)).toBe(false);
+    expect(hasRenderableChildren(<div />)).toBe(true);
+  });
+});

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -8,6 +8,8 @@ import { convertToDate, translateToString, compareDate, getDateInfo } from '../c
 import { Trigger } from './Trigger';
 import config from '../calendar/config';
 import classNames from 'classnames';
+import PickerCustomContent, { hasRenderableChildren } from '../calendar/PickerCustomContent';
+import pickerContentStyles from '@css/components/pickerContent.module.css';
 
 export type DatePickerProps = SharedProps & {
   /**
@@ -283,19 +285,27 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
       'pt-3': size === 'large' && view === 'year',
     });
 
+    const hasCustomContent = hasRenderableChildren(children);
+    const pickerBodyClass = classNames('d-flex', {
+      [pickerContentStyles['PickerContentLayout']]: hasCustomContent,
+    });
+    const calendar = (
+      <Calendar
+        {...rest}
+        size={size}
+        date={currDate}
+        view={view}
+        disabledBefore={dateDisabledBefore}
+        disabledAfter={dateDisabledAfter}
+        onDateChange={this.onDateChangeHandler}
+      />
+    );
+
     return (
       <div>
-        <div className="d-flex">
-          {children}
-          <Calendar
-            {...rest}
-            size={size}
-            date={currDate}
-            view={view}
-            disabledBefore={dateDisabledBefore}
-            disabledAfter={dateDisabledAfter}
-            onDateChange={this.onDateChangeHandler}
-          />
+        <div className={pickerBodyClass}>
+          {hasCustomContent ? <PickerCustomContent>{children}</PickerCustomContent> : children}
+          {hasCustomContent ? <div className={pickerContentStyles['PickerCalendar']}>{calendar}</div> : calendar}
         </div>
         {showTodayDate && (
           <div className={todayChipClass} data-test="DesignSystem-Select--TodaysDate-wrapper">

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -18,6 +18,8 @@ import {
   getCurrentYear,
   getCurrentMonth,
 } from './utilities';
+import PickerCustomContent, { hasRenderableChildren } from '../calendar/PickerCustomContent';
+import pickerContentStyles from '@css/components/pickerContent.module.css';
 
 export type InputOptions = Omit<InputMaskProps, 'mask' | 'value' | 'onChange' | 'onBlur' | 'onClick' | 'onClear'> & {
   label?: string;
@@ -414,10 +416,12 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     } = this.props;
 
     const { open } = this.state;
+    const hasCustomContent = hasRenderableChildren(children);
 
     const RangePickerClass = classNames({
       [styles['DateRangePicker']]: true,
       [styles[`DateRangePicker--${contentAlign}`]]: contentAlign,
+      [pickerContentStyles['PickerContentLayout']]: hasCustomContent,
     });
 
     if (withInput) {
@@ -465,8 +469,12 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           open={open}
           onToggle={this.onToggleHandler}
         >
-          {children}
-          {this.renderCalendar()}
+          {hasCustomContent ? <PickerCustomContent>{children}</PickerCustomContent> : children}
+          {hasCustomContent ? (
+            <div className={pickerContentStyles['PickerCalendar']}>{this.renderCalendar()}</div>
+          ) : (
+            this.renderCalendar()
+          )}
         </Popover>
       );
     }

--- a/css/src/components/dateRangePicker.module.css
+++ b/css/src/components/dateRangePicker.module.css
@@ -23,6 +23,11 @@
 }
 
 @media (max-width: 576px) {
+  .DateRangePicker--left,
+  .DateRangePicker--right {
+    flex-direction: column;
+  }
+
   .DateRangePicker-input {
     padding: 0;
   }

--- a/css/src/components/pickerContent.module.css
+++ b/css/src/components/pickerContent.module.css
@@ -1,0 +1,92 @@
+.PickerContentLayout {
+  display: flex;
+  align-items: stretch;
+}
+
+.PickerCalendar {
+  min-width: 0;
+}
+
+.PickerCustomContent {
+  display: flex;
+  align-items: stretch;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.PickerCustomContent-presetSelect,
+.PickerCustomContent-trigger {
+  display: none;
+  width: calc(100% - var(--spacing-60));
+  margin: var(--spacing-30) var(--spacing-30) 0;
+}
+
+.PickerCustomContent-mobileCustomContent {
+  display: none;
+}
+
+.PickerCustomContent-panel {
+  display: flex;
+  align-items: stretch;
+}
+
+.PickerCustomContent-triggerButton {
+  justify-content: space-between;
+}
+
+@media (max-width: 576px) {
+  .PickerContentLayout {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .PickerCalendar {
+    width: 100%;
+  }
+
+  .PickerCustomContent {
+    display: block;
+    width: 100%;
+    z-index: 1;
+  }
+
+  .PickerCustomContent-presetSelect,
+  .PickerCustomContent-trigger {
+    display: block;
+  }
+
+  .PickerCustomContent-mobileCustomContent {
+    display: block;
+    width: calc(100% - var(--spacing-60));
+    margin: var(--spacing-20) var(--spacing-30) 0;
+  }
+
+  .PickerCustomContent--withPresetSelect .PickerCustomContent-panel {
+    display: none;
+  }
+
+  .PickerCustomContent-panel {
+    display: none;
+    position: absolute;
+    top: calc(100% + var(--spacing-10));
+    left: var(--spacing-30);
+    right: var(--spacing-30);
+    max-height: min(var(--spacing-640), 50vh);
+    overflow: auto;
+    flex-direction: column;
+    align-items: stretch;
+    padding: var(--spacing-10);
+    border-radius: var(--border-radius-10);
+    background: var(--white);
+    box-shadow: var(--shadow-l);
+    z-index: 500;
+  }
+
+  .PickerCustomContent-panel--open {
+    display: block;
+  }
+
+  .PickerCustomContent-panel [data-test='DesignSystem-Divider'] {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- Collapse DatePicker/DateRangePicker custom preset content under 576px so calendars keep their usable width.
- Render recognized preset Chips as Select options in the collapsed mobile control, while preserving arbitrary custom content with a DS Button-triggered popover fallback.
- Add focused coverage for preset-to-Select behavior and non-preset custom content fallback.
