### PR TITLE
fix(PageHeader): responsive layout

### DIFF
--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -119,6 +119,26 @@ export const PageHeader = (props: PageHeaderProps) => {
       const actionsEl = row.querySelector<HTMLElement>('[data-group="actions"]');
       if (!titleEl) return;
 
+      // Measure title-heading and status/meta separately. Only the heading
+      // truncates past TITLE_CAP — status/meta wraps, so capping the combined
+      // group would under-report when meta is long and miss real overflow.
+      // Setting width:max-content on each child is required because, as
+      // block-level children of titleEl, they otherwise stretch to titleEl's
+      // own width rather than reporting their natural content widths.
+      const measureTitleDesired = () => {
+        const titleTextEl = titleEl.querySelector<HTMLElement>('[data-test="DesignSystem-PageHeader--Title"]');
+        const statusEl = titleEl.querySelector<HTMLElement>('[data-test="DesignSystem-PageHeader--Status"]');
+        const prevTitleW = titleTextEl?.style.width;
+        const prevStatusW = statusEl?.style.width;
+        if (titleTextEl) titleTextEl.style.width = 'max-content';
+        if (statusEl) statusEl.style.width = 'max-content';
+        const titleW = titleTextEl ? Math.min(titleTextEl.offsetWidth, TITLE_CAP) : 0;
+        const statusW = statusEl?.offsetWidth ?? 0;
+        if (titleTextEl && prevTitleW !== undefined) titleTextEl.style.width = prevTitleW;
+        if (statusEl && prevStatusW !== undefined) statusEl.style.width = prevStatusW;
+        return Math.max(titleW, statusW);
+      };
+
       // Strip stacked classes before measuring so we read natural layout widths.
       // Also temporarily restore the grid (withCenter) if not in full mode —
       // grid is only applied in full mode now (center-wrapped uses flex), but we
@@ -142,7 +162,7 @@ export const PageHeader = (props: PageHeaderProps) => {
         const prevCols = row.style.gridTemplateColumns;
         row.style.gridTemplateColumns = 'max-content max-content max-content';
 
-        const titleDesired = Math.min(titleEl.offsetWidth, TITLE_CAP);
+        const titleDesired = measureTitleDesired();
         const centerDesired = centerEl?.offsetWidth ?? 0;
         const actionsDesired = actionsEl?.offsetWidth ?? 0;
 
@@ -178,7 +198,7 @@ export const PageHeader = (props: PageHeaderProps) => {
         row.style.display = 'grid';
         row.style.gridTemplateColumns = actionsEl ? 'max-content max-content' : 'max-content';
 
-        const titleDesired = Math.min(titleEl.offsetWidth, TITLE_CAP);
+        const titleDesired = measureTitleDesired();
         const actionsDesired = actionsEl?.offsetWidth ?? 0;
 
         row.style.display = prevDisplay;

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -119,14 +119,20 @@ export const PageHeader = (props: PageHeaderProps) => {
       const actionsEl = row.querySelector<HTMLElement>('[data-group="actions"]');
       if (!titleEl) return;
 
-      // Strip stacked/wrapped classes to restore base layout before measuring —
-      // center-wrapped switches to flex (gridTemplateColumns becomes a no-op),
-      // all-stacked sets title to 100% width (offsetWidth would return rowWidth).
-      const cwClass = styles['PageHeader-row--centerWrapped'];
+      // Strip stacked classes before measuring so we read natural layout widths.
+      // Also temporarily restore the grid (withCenter) if not in full mode —
+      // grid is only applied in full mode now (center-wrapped uses flex), but we
+      // need it for the max-content column trick to work accurately.
+      const withCenterClass = styles['PageHeader-row--withCenter'];
       const asClass = styles['PageHeader-row--allStacked'];
-      const hadCW = row.classList.contains(cwClass);
+      const ghostClass = styles['PageHeader-group--center--ghost'];
       const hadAS = row.classList.contains(asClass);
-      row.classList.remove(cwClass, asClass);
+      const hadWithCenter = row.classList.contains(withCenterClass);
+      const hadGhost = centerEl?.classList.contains(ghostClass) ?? false;
+
+      row.classList.remove(asClass);
+      if (!hadWithCenter && hasCenterNav) row.classList.add(withCenterClass);
+      if (hadGhost && centerEl) centerEl.classList.remove(ghostClass);
 
       const rowWidth = row.offsetWidth;
 
@@ -141,7 +147,8 @@ export const PageHeader = (props: PageHeaderProps) => {
         const actionsDesired = actionsEl?.offsetWidth ?? 0;
 
         row.style.gridTemplateColumns = prevCols;
-        if (hadCW) row.classList.add(cwClass);
+        if (hadGhost && centerEl) centerEl.classList.add(ghostClass);
+        if (!hadWithCenter) row.classList.remove(withCenterClass);
         if (hadAS) row.classList.add(asClass);
 
         // Grid gives equal 1fr to title and actions columns. Check each half
@@ -160,17 +167,22 @@ export const PageHeader = (props: PageHeaderProps) => {
         }
       } else {
         // Bottom nav (consumer-set) or no nav — only check if actions fit on the
-        // title row. Row is flex here, so use width:max-content on each element.
-        const prevTitleW = titleEl.style.width;
-        const prevActionsW = actionsEl ? actionsEl.style.width : '';
-        titleEl.style.width = 'max-content';
-        if (actionsEl) actionsEl.style.width = 'max-content';
+        // title row. Temporarily reshape the row into a max-content grid so each
+        // element reports its natural width. Flex won't do here: flex-grow stretches
+        // the title past content, and once title+actions exceed rowWidth flex-wrap
+        // fires mid-measurement (title takes full row, actions onto next line),
+        // inflating offsetWidth so the sum spuriously exceeds rowWidth → false stack.
+        // The grid trick mirrors the hasCenterNav branch above.
+        const prevDisplay = row.style.display;
+        const prevCols = row.style.gridTemplateColumns;
+        row.style.display = 'grid';
+        row.style.gridTemplateColumns = actionsEl ? 'max-content max-content' : 'max-content';
 
         const titleDesired = Math.min(titleEl.offsetWidth, TITLE_CAP);
         const actionsDesired = actionsEl?.offsetWidth ?? 0;
 
-        titleEl.style.width = prevTitleW;
-        if (actionsEl) actionsEl.style.width = prevActionsW;
+        row.style.display = prevDisplay;
+        row.style.gridTemplateColumns = prevCols;
         if (hadAS) row.classList.add(asClass);
 
         if (actionsEl && titleDesired + actionsDesired > rowWidth) {
@@ -189,12 +201,18 @@ export const PageHeader = (props: PageHeaderProps) => {
   }, [hasCenterNav, navigation, stepper, actions]);
 
   const rowClasses = classNames(styles['PageHeader-row'], {
-    [styles['PageHeader-row--withCenter']]: hasCenterNav,
-    [styles['PageHeader-row--centerWrapped']]: hasCenterNav && stackedMode === 'center-wrapped',
+    // Grid only in full mode — center-wrapped uses flex so title/actions share naturally
+    [styles['PageHeader-row--withCenter']]: hasCenterNav && stackedMode === 'full',
     [styles['PageHeader-row--allStacked']]: stackedMode === 'all-stacked',
   });
 
-  const centerNavProps = { navigationPosition, navigation, stepper };
+  // When center nav is auto-moved to bottom, keep it ghost in the row for measurement
+  // (position:absolute, visibility:hidden) so recovery detection still works.
+  const centerNavGhost = hasCenterNav && stackedMode !== 'full';
+  const centerNavProps = { navigationPosition, navigation, stepper, ghost: centerNavGhost };
+
+  // Nav renders in PageHeader-bottom if: consumer set bottom, or collision moved it there
+  const showNavInBottom = !!(navigation || stepper) && (navigationPosition === 'bottom' || centerNavGhost);
 
   return (
     <div data-test="DesignSystem-PageHeader">
@@ -218,9 +236,9 @@ export const PageHeader = (props: PageHeaderProps) => {
           </div>
         </div>
 
-        {(tabs || (navigationPosition === 'bottom' && (navigation || stepper))) && (
+        {(tabs || showNavInBottom) && (
           <div className={classNames('pl-3', styles['PageHeader-bottom'])}>
-            {navigationPosition === 'bottom' && <Nav navigation={navigation} stepper={stepper} />}
+            {showNavInBottom && <Nav navigation={navigation} stepper={stepper} />}
             {tabs && <div data-test="DesignSystem-PageHeader--Tabs">{tabs}</div>}
           </div>
         )}

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -127,10 +127,12 @@ export const PageHeader = (props: PageHeaderProps) => {
           </div>
         </div>
 
-        <div className={classNames('pl-3', styles['PageHeader-bottom'])}>
-          {navigationPosition === 'bottom' && <Nav navigation={navigation} stepper={stepper} />}
-          {tabs && <div data-test="DesignSystem-PageHeader--Tabs">{tabs}</div>}
-        </div>
+        {(tabs || navigationPosition === 'bottom') && (
+          <div className={classNames('pl-3', styles['PageHeader-bottom'])}>
+            {navigationPosition === 'bottom' && <Nav navigation={navigation} stepper={stepper} />}
+            {tabs && <div data-test="DesignSystem-PageHeader--Tabs">{tabs}</div>}
+          </div>
+        )}
       </div>
       {separator && <Divider appearance="header" />}
     </div>

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useRef, useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { Divider } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
@@ -64,6 +65,8 @@ export interface PageHeaderProps extends BaseProps {
   'aria-label'?: string;
 }
 
+type StackedMode = 'full' | 'center-wrapped' | 'all-stacked';
+
 export const PageHeader = (props: PageHeaderProps) => {
   const {
     title,
@@ -99,8 +102,65 @@ export const PageHeader = (props: PageHeaderProps) => {
 
   const classes = classNames(styles.PageHeader);
 
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [stackedMode, setStackedMode] = useState<StackedMode>('full');
+
+  useEffect(() => {
+    if (!hasCenterNav) {
+      setStackedMode('full');
+      return;
+    }
+
+    const row = rowRef.current;
+    if (!row) return;
+
+    const measure = () => {
+      const titleEl = row.querySelector<HTMLElement>('[data-group="title"]');
+      const centerEl = row.querySelector<HTMLElement>('[data-group="center"]');
+      const actionsEl = row.querySelector<HTMLElement>('[data-group="actions"]');
+      if (!titleEl) return;
+
+      // Strip stacked classes so elements return to natural grid positions for measurement
+      const cwClass = styles['PageHeader-row--centerWrapped'];
+      const asClass = styles['PageHeader-row--allStacked'];
+      const hadCW = row.classList.contains(cwClass);
+      const hadAS = row.classList.contains(asClass);
+      row.classList.remove(cwClass, asClass);
+
+      const titleRect = titleEl.getBoundingClientRect();
+      const actionsRect = actionsEl?.getBoundingClientRect();
+      const centerRect = centerEl?.getBoundingClientRect();
+
+      // Restore immediately before any paint
+      if (hadCW) row.classList.add(cwClass);
+      if (hadAS) row.classList.add(asClass);
+
+      const titleActionsCollide = !!actionsRect && titleRect.right > actionsRect.left;
+      const centerCollidesLeft = !!centerRect && centerRect.left < titleRect.right;
+      const centerCollidesRight = !!centerRect && !!actionsRect && centerRect.right > actionsRect.left;
+
+      if (titleActionsCollide) {
+        setStackedMode('all-stacked');
+      } else if (centerCollidesLeft || centerCollidesRight) {
+        setStackedMode('center-wrapped');
+      } else {
+        setStackedMode('full');
+      }
+    };
+
+    if (!window.ResizeObserver) return;
+
+    const observer = new window.ResizeObserver(measure);
+    observer.observe(row);
+    measure();
+
+    return () => observer.disconnect();
+  }, [hasCenterNav]);
+
   const rowClasses = classNames(styles['PageHeader-row'], {
     [styles['PageHeader-row--withCenter']]: hasCenterNav,
+    [styles['PageHeader-row--centerWrapped']]: hasCenterNav && stackedMode === 'center-wrapped',
+    [styles['PageHeader-row--allStacked']]: stackedMode === 'all-stacked',
   });
 
   const centerNavProps = { navigationPosition, navigation, stepper };
@@ -116,8 +176,8 @@ export const PageHeader = (props: PageHeaderProps) => {
         <div className="d-flex pl-6">
           <BackButton button={button} />
           <div className={classes}>
-            <div className={rowClasses}>
-              <div className={styles['PageHeader-group--title']}>
+            <div className={rowClasses} ref={rowRef}>
+              <div className={styles['PageHeader-group--title']} data-group="title">
                 <Title badge={badge} title={title} />
                 <Status status={status} meta={meta} />
               </div>

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -105,14 +105,13 @@ export const PageHeader = (props: PageHeaderProps) => {
   const rowRef = useRef<HTMLDivElement>(null);
   const [stackedMode, setStackedMode] = useState<StackedMode>('full');
 
-  useEffect(() => {
-    if (!hasCenterNav) {
-      setStackedMode('full');
-      return;
-    }
+  // Title is capped at 320px — beyond this it truncates with ellipsis so extra
+  // width doesn't buy anything meaningful for layout decisions.
+  const TITLE_CAP = 320;
 
+  useEffect(() => {
     const row = rowRef.current;
-    if (!row) return;
+    if (!row || !window.ResizeObserver) return;
 
     const measure = () => {
       const titleEl = row.querySelector<HTMLElement>('[data-group="title"]');
@@ -120,45 +119,67 @@ export const PageHeader = (props: PageHeaderProps) => {
       const actionsEl = row.querySelector<HTMLElement>('[data-group="actions"]');
       if (!titleEl) return;
 
-      // Strip stacked classes so elements return to natural grid positions for measurement
+      // Strip stacked/wrapped classes to restore base layout before measuring —
+      // center-wrapped switches to flex (gridTemplateColumns becomes a no-op),
+      // all-stacked sets title to 100% width (offsetWidth would return rowWidth).
       const cwClass = styles['PageHeader-row--centerWrapped'];
       const asClass = styles['PageHeader-row--allStacked'];
       const hadCW = row.classList.contains(cwClass);
       const hadAS = row.classList.contains(asClass);
       row.classList.remove(cwClass, asClass);
 
-      // Disable internal flex-wrap on actions so its bounding rect reflects natural unwrapped width.
-      // Without this, actions wraps silently inside its grid column and getBoundingClientRect never
-      // exceeds the column boundary, so overflow goes undetected.
-      if (actionsEl) actionsEl.style.flexWrap = 'nowrap';
+      const rowWidth = row.offsetWidth;
 
-      const rowRect = row.getBoundingClientRect();
-      const titleRect = titleEl.getBoundingClientRect();
-      const actionsRect = actionsEl?.getBoundingClientRect();
-      const centerRect = centerEl?.getBoundingClientRect();
+      if (hasCenterNav) {
+        // Grid layout — switch all columns to max-content so each element reports
+        // its natural unconstrained width (1fr columns otherwise clamp offsetWidth).
+        const prevCols = row.style.gridTemplateColumns;
+        row.style.gridTemplateColumns = 'max-content max-content max-content';
 
-      if (actionsEl) actionsEl.style.flexWrap = '';
+        const titleDesired = Math.min(titleEl.offsetWidth, TITLE_CAP);
+        const centerDesired = centerEl?.offsetWidth ?? 0;
+        const actionsDesired = actionsEl?.offsetWidth ?? 0;
 
-      // Restore immediately before any paint
-      if (hadCW) row.classList.add(cwClass);
-      if (hadAS) row.classList.add(asClass);
+        row.style.gridTemplateColumns = prevCols;
+        if (hadCW) row.classList.add(cwClass);
+        if (hadAS) row.classList.add(asClass);
 
-      const titleActionsCollide = !!actionsRect && titleRect.right > actionsRect.left;
-      // Actions wider than its grid column spills beyond the row boundary
-      const actionsOverflow = !!actionsRect && actionsRect.right > rowRect.right + 1;
-      const centerCollidesLeft = !!centerRect && centerRect.left < titleRect.right;
-      const centerCollidesRight = !!centerRect && !!actionsRect && centerRect.right > actionsRect.left;
+        // Grid gives equal 1fr to title and actions columns. Check each half
+        // independently: title must fit the left half, actions the right half.
+        const halfWidth = rowWidth / 2;
+        const leftOverflows = titleDesired + centerDesired / 2 > halfWidth;
+        const rightOverflows = actionsDesired + centerDesired / 2 > halfWidth;
+        const actionsWrap = titleDesired + actionsDesired > rowWidth;
 
-      if (titleActionsCollide) {
-        setStackedMode('all-stacked');
-      } else if (centerCollidesLeft || centerCollidesRight || actionsOverflow) {
-        setStackedMode('center-wrapped');
+        if (actionsWrap) {
+          setStackedMode('all-stacked');
+        } else if (leftOverflows || rightOverflows) {
+          setStackedMode('center-wrapped');
+        } else {
+          setStackedMode('full');
+        }
       } else {
-        setStackedMode('full');
+        // Bottom nav (consumer-set) or no nav — only check if actions fit on the
+        // title row. Row is flex here, so use width:max-content on each element.
+        const prevTitleW = titleEl.style.width;
+        const prevActionsW = actionsEl ? actionsEl.style.width : '';
+        titleEl.style.width = 'max-content';
+        if (actionsEl) actionsEl.style.width = 'max-content';
+
+        const titleDesired = Math.min(titleEl.offsetWidth, TITLE_CAP);
+        const actionsDesired = actionsEl?.offsetWidth ?? 0;
+
+        titleEl.style.width = prevTitleW;
+        if (actionsEl) actionsEl.style.width = prevActionsW;
+        if (hadAS) row.classList.add(asClass);
+
+        if (actionsEl && titleDesired + actionsDesired > rowWidth) {
+          setStackedMode('all-stacked');
+        } else {
+          setStackedMode('full');
+        }
       }
     };
-
-    if (!window.ResizeObserver) return;
 
     const observer = new window.ResizeObserver(measure);
     observer.observe(row);

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -127,7 +127,7 @@ export const PageHeader = (props: PageHeaderProps) => {
           </div>
         </div>
 
-        {(tabs || navigationPosition === 'bottom') && (
+        {(tabs || (navigationPosition === 'bottom' && (navigation || stepper))) && (
           <div className={classNames('pl-3', styles['PageHeader-bottom'])}>
             {navigationPosition === 'bottom' && <Nav navigation={navigation} stepper={stepper} />}
             {tabs && <div data-test="DesignSystem-PageHeader--Tabs">{tabs}</div>}

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -127,21 +127,31 @@ export const PageHeader = (props: PageHeaderProps) => {
       const hadAS = row.classList.contains(asClass);
       row.classList.remove(cwClass, asClass);
 
+      // Disable internal flex-wrap on actions so its bounding rect reflects natural unwrapped width.
+      // Without this, actions wraps silently inside its grid column and getBoundingClientRect never
+      // exceeds the column boundary, so overflow goes undetected.
+      if (actionsEl) actionsEl.style.flexWrap = 'nowrap';
+
+      const rowRect = row.getBoundingClientRect();
       const titleRect = titleEl.getBoundingClientRect();
       const actionsRect = actionsEl?.getBoundingClientRect();
       const centerRect = centerEl?.getBoundingClientRect();
+
+      if (actionsEl) actionsEl.style.flexWrap = '';
 
       // Restore immediately before any paint
       if (hadCW) row.classList.add(cwClass);
       if (hadAS) row.classList.add(asClass);
 
       const titleActionsCollide = !!actionsRect && titleRect.right > actionsRect.left;
+      // Actions wider than its grid column spills beyond the row boundary
+      const actionsOverflow = !!actionsRect && actionsRect.right > rowRect.right + 1;
       const centerCollidesLeft = !!centerRect && centerRect.left < titleRect.right;
       const centerCollidesRight = !!centerRect && !!actionsRect && centerRect.right > actionsRect.left;
 
       if (titleActionsCollide) {
         setStackedMode('all-stacked');
-      } else if (centerCollidesLeft || centerCollidesRight) {
+      } else if (centerCollidesLeft || centerCollidesRight || actionsOverflow) {
         setStackedMode('center-wrapped');
       } else {
         setStackedMode('full');
@@ -155,7 +165,7 @@ export const PageHeader = (props: PageHeaderProps) => {
     measure();
 
     return () => observer.disconnect();
-  }, [hasCenterNav]);
+  }, [hasCenterNav, navigation, stepper, actions]);
 
   const rowClasses = classNames(styles['PageHeader-row'], {
     [styles['PageHeader-row--withCenter']]: hasCenterNav,

--- a/core/components/organisms/pageHeader/PageHeader.tsx
+++ b/core/components/organisms/pageHeader/PageHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { Row, Column, Divider } from '@/index';
+import { Divider } from '@/index';
 import { BaseProps, extractBaseProps } from '@/utils/types';
 import { BackButton, Title, CenterNav, Nav, Action, Status } from './utils';
 import styles from '@css/components/pageHeader.module.css';
@@ -83,33 +83,27 @@ export const PageHeader = (props: PageHeaderProps) => {
   } = props;
   const baseProps = extractBaseProps(props);
 
+  const isLevel1 = !!(breadcrumbs || button);
+
   const wrapperClasses = classNames(
     {
       [styles['PageHeader-wrapper']]: true,
       [styles['PageHeader-wrapper--withTabs']]: tabs,
+      [styles['PageHeader-wrapper--level1']]: isLevel1,
+      [styles['PageHeader-wrapper--withActions']]: !!actions,
     },
     className
   );
 
+  const hasCenterNav = !!(navigation || stepper) && navigationPosition === 'center';
+
   const classes = classNames(styles.PageHeader);
 
-  const colSize = (navigation || stepper) && navigationPosition === 'center' ? '4' : actions ? '8' : '12';
+  const rowClasses = classNames(styles['PageHeader-row'], {
+    [styles['PageHeader-row--withCenter']]: hasCenterNav,
+  });
 
-  const centerNavProps = {
-    colSize,
-    breadcrumbs,
-    navigationPosition,
-    navigation,
-    stepper,
-  };
-
-  const statusProps = {
-    status,
-    meta,
-    navigationPosition,
-    navigation,
-    tabs,
-  };
+  const centerNavProps = { navigationPosition, navigation, stepper };
 
   return (
     <div data-test="DesignSystem-PageHeader">
@@ -122,18 +116,18 @@ export const PageHeader = (props: PageHeaderProps) => {
         <div className="d-flex pl-6">
           <BackButton button={button} />
           <div className={classes}>
-            <Row className="w-100">
-              <Column size={colSize} sizeXL={colSize} sizeM={colSize}>
+            <div className={rowClasses}>
+              <div className={styles['PageHeader-group--title']}>
                 <Title badge={badge} title={title} />
-              </Column>
+                <Status status={status} meta={meta} />
+              </div>
               <CenterNav {...centerNavProps} />
               <Action actions={actions} navigation={navigation} stepper={stepper} />
-            </Row>
-            <Status {...statusProps} />
+            </div>
           </div>
         </div>
 
-        <div className="pl-3">
+        <div className={classNames('pl-3', styles['PageHeader-bottom'])}>
           {navigationPosition === 'bottom' && <Nav navigation={navigation} stepper={stepper} />}
           {tabs && <div data-test="DesignSystem-PageHeader--Tabs">{tabs}</div>}
         </div>

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -17,6 +17,7 @@ export const Responsiveness = () => {
   const [viewportPreset, setViewportPreset] = React.useState('full');
   const [showActions, setShowActions] = React.useState(true);
   const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
+  const [showBadge, setShowBadge] = React.useState(true);
 
   const navigationData = [
     { name: 'overview', label: 'Overview' },
@@ -113,6 +114,14 @@ export const Responsiveness = () => {
           aria-label="Toggle breadcrumb (level 1)"
           onClick={() => setShowBreadcrumb((v) => !v)}
         />
+        <Chip
+          type="selection"
+          name="showBadge"
+          label="Badge"
+          selected={showBadge}
+          aria-label="Toggle badge beside title"
+          onClick={() => setShowBadge((v) => !v)}
+        />
       </Flex>
 
       <div style={containerStyle} className="bg-secondary-lightest">
@@ -122,7 +131,7 @@ export const Responsiveness = () => {
           navigation={navigation}
           actions={actions}
           breadcrumbs={breadcrumbs}
-          badge={<Badge appearance="secondary">Draft</Badge>}
+          badge={showBadge ? <Badge appearance="secondary">Draft</Badge> : undefined}
           status={<StatusHint appearance="info">Ongoing</StatusHint>}
           separator={false}
           aria-label="Pac follow-up page header"
@@ -136,6 +145,7 @@ const customCode = `() => {
   const [viewportPreset, setViewportPreset] = React.useState('full');
   const [showActions, setShowActions] = React.useState(true);
   const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
+  const [showBadge, setShowBadge] = React.useState(true);
 
   const navigationData = [
     { name: 'overview', label: 'Overview' },
@@ -199,6 +209,8 @@ const customCode = `() => {
           aria-label="Toggle action buttons" onClick={() => setShowActions((v) => !v)} />
         <Chip type="selection" name="showBreadcrumb" label="Breadcrumb" selected={showBreadcrumb}
           aria-label="Toggle breadcrumb (level 1)" onClick={() => setShowBreadcrumb((v) => !v)} />
+        <Chip type="selection" name="showBadge" label="Badge" selected={showBadge}
+          aria-label="Toggle badge beside title" onClick={() => setShowBadge((v) => !v)} />
       </Flex>
 
       <div style={containerStyle} className="bg-secondary-lightest">
@@ -208,7 +220,7 @@ const customCode = `() => {
           navigation={navigation}
           actions={actions}
           breadcrumbs={breadcrumbs}
-          badge={<Badge appearance="secondary">Draft</Badge>}
+          badge={showBadge ? <Badge appearance="secondary">Draft</Badge> : undefined}
           status={<StatusHint appearance="info">Ongoing</StatusHint>}
           separator={false}
           aria-label="Pac follow-up page header"

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -15,7 +15,6 @@ import { action } from '@/utils/action';
 
 export const Responsiveness = () => {
   const [viewportPreset, setViewportPreset] = React.useState('full');
-  const [navPosition, setNavPosition] = React.useState('center');
   const [showActions, setShowActions] = React.useState(true);
   const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
 
@@ -100,22 +99,6 @@ export const Responsiveness = () => {
         />
         <Chip
           type="selection"
-          name="centerNav"
-          label="Center nav"
-          selected={navPosition === 'center'}
-          aria-label="Use center navigation position"
-          onClick={() => setNavPosition('center')}
-        />
-        <Chip
-          type="selection"
-          name="bottomNav"
-          label="Bottom nav"
-          selected={navPosition === 'bottom'}
-          aria-label="Use bottom navigation position"
-          onClick={() => setNavPosition('bottom')}
-        />
-        <Chip
-          type="selection"
           name="showActions"
           label="Actions"
           selected={showActions}
@@ -135,7 +118,7 @@ export const Responsiveness = () => {
       <div style={containerStyle} className="bg-secondary-lightest">
         <PageHeader
           title="Pac Follow-Up Protocol"
-          navigationPosition={navPosition}
+          navigationPosition="center"
           navigation={navigation}
           actions={actions}
           breadcrumbs={breadcrumbs}
@@ -151,7 +134,6 @@ export const Responsiveness = () => {
 
 const customCode = `() => {
   const [viewportPreset, setViewportPreset] = React.useState('full');
-  const [navPosition, setNavPosition] = React.useState('center');
   const [showActions, setShowActions] = React.useState(true);
   const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
 
@@ -213,10 +195,6 @@ const customCode = `() => {
           aria-label="Constrain header to 320px width" onClick={() => togglePreset('320')} />
         <Chip type="selection" name="viewport640" label="640px" selected={viewportPreset === '640'}
           aria-label="Constrain header to 640px width" onClick={() => togglePreset('640')} />
-        <Chip type="selection" name="centerNav" label="Center nav" selected={navPosition === 'center'}
-          aria-label="Use center navigation position" onClick={() => setNavPosition('center')} />
-        <Chip type="selection" name="bottomNav" label="Bottom nav" selected={navPosition === 'bottom'}
-          aria-label="Use bottom navigation position" onClick={() => setNavPosition('bottom')} />
         <Chip type="selection" name="showActions" label="Actions" selected={showActions}
           aria-label="Toggle action buttons" onClick={() => setShowActions((v) => !v)} />
         <Chip type="selection" name="showBreadcrumb" label="Breadcrumb" selected={showBreadcrumb}
@@ -226,7 +204,7 @@ const customCode = `() => {
       <div style={containerStyle} className="bg-secondary-lightest">
         <PageHeader
           title="Pac Follow-Up Protocol"
-          navigationPosition={navPosition}
+          navigationPosition="center"
           navigation={navigation}
           actions={actions}
           breadcrumbs={breadcrumbs}

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -42,6 +42,10 @@ export const Responsiveness = () => {
   const [showButton, setShowButton] = React.useState(false);
   const [showBadge, setShowBadge] = React.useState(true);
 
+  const prevActionCount = React.useRef(MIN_ACTIONS);
+  const prevNavCount = React.useRef(MIN_NAV);
+  const prevTitleWordCount = React.useRef(3);
+
   const avatarList = [
     { firstName: 'John', lastName: 'Doe', appearance: 'accent2' },
     { firstName: 'Jane', lastName: 'Smith', appearance: 'accent3' },
@@ -180,7 +184,14 @@ export const Responsiveness = () => {
             label="Max"
             selected={actionCount >= MAX_ACTIONS}
             aria-label="Set actions to max or remove one"
-            onClick={() => setActionCount((c) => (c >= MAX_ACTIONS ? MAX_ACTIONS - 1 : MAX_ACTIONS))}
+            onClick={() => {
+              if (actionCount >= MAX_ACTIONS) {
+                setActionCount(prevActionCount.current);
+              } else {
+                prevActionCount.current = actionCount;
+                setActionCount(MAX_ACTIONS);
+              }
+            }}
           />
         </Flex>
 
@@ -214,7 +225,14 @@ export const Responsiveness = () => {
             label="Max"
             selected={navCount >= MAX_NAV}
             aria-label="Set nav to max or remove one"
-            onClick={() => setNavCount((c) => (c >= MAX_NAV ? MAX_NAV - 1 : MAX_NAV))}
+            onClick={() => {
+              if (navCount >= MAX_NAV) {
+                setNavCount(prevNavCount.current);
+              } else {
+                prevNavCount.current = navCount;
+                setNavCount(MAX_NAV);
+              }
+            }}
           />
         </Flex>
 
@@ -243,7 +261,14 @@ export const Responsiveness = () => {
             label="Max"
             selected={titleWordCount >= MAX_TITLE}
             aria-label="Set title to max length or shorten by one word"
-            onClick={() => setTitleWordCount((c) => (c >= MAX_TITLE ? MAX_TITLE - 1 : MAX_TITLE))}
+            onClick={() => {
+              if (titleWordCount >= MAX_TITLE) {
+                setTitleWordCount(prevTitleWordCount.current);
+              } else {
+                prevTitleWordCount.current = titleWordCount;
+                setTitleWordCount(MAX_TITLE);
+              }
+            }}
           />
           <Chip
             type="selection"
@@ -316,6 +341,10 @@ const customCode = `() => {
   const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
   const [showButton, setShowButton] = React.useState(false);
   const [showBadge, setShowBadge] = React.useState(true);
+
+  const prevActionCount = React.useRef(MIN_ACTIONS);
+  const prevNavCount = React.useRef(MIN_NAV);
+  const prevTitleWordCount = React.useRef(3);
 
   const avatarList = [
     { firstName: 'John', lastName: 'Doe', appearance: 'accent2' },
@@ -393,8 +422,8 @@ const customCode = `() => {
           <Button icon="add" size="tiny" aria-label="Add one action"
             disabled={actionCount >= MAX_ACTIONS} onClick={() => setActionCount((c) => Math.min(MAX_ACTIONS, c + 1))} />
           <Chip type="selection" name="actionsMax" label="Max" selected={actionCount >= MAX_ACTIONS}
-            aria-label="Set actions to max or remove one"
-            onClick={() => setActionCount((c) => (c >= MAX_ACTIONS ? MAX_ACTIONS - 1 : MAX_ACTIONS))} />
+            aria-label="Set actions to max or restore previous"
+            onClick={() => { if (actionCount >= MAX_ACTIONS) { setActionCount(prevActionCount.current); } else { prevActionCount.current = actionCount; setActionCount(MAX_ACTIONS); } }} />
         </Flex>
 
         <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
@@ -405,8 +434,8 @@ const customCode = `() => {
           <Button icon="add" size="tiny" aria-label="Add one nav item"
             disabled={navCount >= MAX_NAV} onClick={() => setNavCount((c) => Math.min(MAX_NAV, c + 1))} />
           <Chip type="selection" name="navMax" label="Max" selected={navCount >= MAX_NAV}
-            aria-label="Set nav to max or remove one"
-            onClick={() => setNavCount((c) => (c >= MAX_NAV ? MAX_NAV - 1 : MAX_NAV))} />
+            aria-label="Set nav to max or restore previous"
+            onClick={() => { if (navCount >= MAX_NAV) { setNavCount(prevNavCount.current); } else { prevNavCount.current = navCount; setNavCount(MAX_NAV); } }} />
         </Flex>
 
         <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
@@ -416,8 +445,8 @@ const customCode = `() => {
           <Button icon="add" size="tiny" aria-label="Lengthen title by one word"
             disabled={titleWordCount >= MAX_TITLE} onClick={() => setTitleWordCount((c) => Math.min(MAX_TITLE, c + 1))} />
           <Chip type="selection" name="titleMax" label="Max" selected={titleWordCount >= MAX_TITLE}
-            aria-label="Set title to max length or shorten by one word"
-            onClick={() => setTitleWordCount((c) => (c >= MAX_TITLE ? MAX_TITLE - 1 : MAX_TITLE))} />
+            aria-label="Set title to max or restore previous"
+            onClick={() => { if (titleWordCount >= MAX_TITLE) { setTitleWordCount(prevTitleWordCount.current); } else { prevTitleWordCount.current = titleWordCount; setTitleWordCount(MAX_TITLE); } }} />
           <Chip type="selection" name="showBreadcrumb" label="Breadcrumb" selected={showBreadcrumb}
             aria-label="Toggle breadcrumb (level 1)" onClick={() => setShowBreadcrumb((v) => !v)} />
           <Chip type="selection" name="showButton" label="Back button" selected={showButton}

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -1,209 +1,153 @@
 import * as React from 'react';
-import { Breadcrumbs, Text, StatusHint, HorizontalNav, AvatarGroup, PageHeader, Dropdown } from '@/index';
+import {
+  Breadcrumbs,
+  Text,
+  StatusHint,
+  HorizontalNav,
+  AvatarGroup,
+  PageHeader,
+  Button,
+  Chip,
+  Flex,
+  Badge,
+} from '@/index';
 import { action } from '@/utils/action';
 
 export const Responsiveness = () => {
+  const [viewportPreset, setViewportPreset] = React.useState('full');
+  const [navPosition, setNavPosition] = React.useState('center');
+  const [showActions, setShowActions] = React.useState(true);
+  const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
+
   const navigationData = [
-    {
-      name: 'menu_1',
-      label: 'Interventions',
-    },
-    {
-      name: 'menu_2',
-      label: 'No Linked Activites',
-    },
+    { name: 'overview', label: 'Overview' },
+    { name: 'interventions', label: 'Interventions' },
+    { name: 'activities', label: 'Activities' },
+    { name: 'documents', label: 'Documents' },
   ];
 
-  const list = [
-    {
-      firstName: 'John',
-      lastName: 'Doe',
-      appearance: 'accent2',
-    },
-    {
-      firstName: 'Steven',
-      lastName: 'Packton',
-      appearance: 'accent3',
-    },
+  const avatarList = [
+    { firstName: 'John', lastName: 'Doe', appearance: 'accent2' },
+    { firstName: 'Jane', lastName: 'Smith', appearance: 'accent3' },
   ];
 
-  const options = [
-    {
-      icon: 'print',
-      label: 'Edit',
-      value: 'Edit',
-    },
-    {
-      icon: 'assignment_turned_in',
-      label: 'Complete',
-      value: 'Complete',
-    },
-  ];
-
-  const [active, setActive] = React.useState({
-    name: 'menu_1',
-  });
-
-  const onClickHandler = (menu) => {
-    setActive(menu);
-  };
-
-  const actions = (
-    <div className="d-flex justify-content-end align-items-center">
-      <Text appearance="subtle" className="mr-4">
-        Updated 1 day ago
-      </Text>
-      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={list} />
-      <div>
-        <Dropdown menu={true} optionType="WITH_ICON" icon="more_horiz" options={options} align="left" />
-      </div>
-    </div>
-  );
-
-  const breadcrumbs = (
-    <Breadcrumbs
-      list={[
-        {
-          label: 'Care potential',
-          link: '/Care potential',
-        },
-      ]}
-      onClick={(link) => action(`on-click: ${link}`)}
-    />
-  );
-
-  const status = <StatusHint appearance="info">Ongoing</StatusHint>;
+  const [active, setActive] = React.useState({ name: 'overview' });
 
   const navigation = (
     <HorizontalNav
       menus={navigationData}
-      onClick={onClickHandler}
       active={active}
-      aria-label="Follow-up protocol navigation"
+      onClick={(menu) => {
+        setActive(menu);
+        action(`nav-click: ${menu.name}`)();
+      }}
+      aria-label="Protocol navigation"
     />
   );
 
+  const actions = showActions ? (
+    <div className="d-flex align-items-center justify-content-end">
+      <Text appearance="subtle" className="mr-4">
+        Updated 1 day ago
+      </Text>
+      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={avatarList} />
+      <Button className="mr-4" onClick={action('edit')}>
+        Edit
+      </Button>
+      <Button appearance="primary" onClick={action('save')}>
+        Save
+      </Button>
+    </div>
+  ) : undefined;
+
+  const breadcrumbs = showBreadcrumb ? (
+    <Breadcrumbs
+      list={[{ label: 'Care potential', link: '/care-potential' }]}
+      onClick={(link) => action(`breadcrumb: ${link}`)()}
+    />
+  ) : undefined;
+
+  const containerStyle = {
+    width: viewportPreset === '320' ? 320 : viewportPreset === '640' ? 640 : '100%',
+    maxWidth: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    boxSizing: 'border-box',
+  };
+
+  function togglePreset(preset) {
+    setViewportPreset((p) => (p === preset ? 'full' : preset));
+  }
+
   return (
-    <div className="w-100 bg-secondary-lightest">
-      <PageHeader
-        navigationPosition="bottom"
-        title="Pac Follow-Up Protocol"
-        separator={false}
-        navigation={navigation}
-        actions={actions}
-        breadcrumbs={breadcrumbs}
-        status={status}
-        aria-label="Pac follow-up page"
-      />
+    <div>
+      <Flex direction="row" wrap="wrap" gap="spacing-40" className="mb-6 align-items-center">
+        <Chip
+          type="selection"
+          name="viewport320"
+          label="320px"
+          selected={viewportPreset === '320'}
+          aria-label="Constrain header to 320px width"
+          onClick={() => togglePreset('320')}
+        />
+        <Chip
+          type="selection"
+          name="viewport640"
+          label="640px"
+          selected={viewportPreset === '640'}
+          aria-label="Constrain header to 640px width"
+          onClick={() => togglePreset('640')}
+        />
+        <Chip
+          type="selection"
+          name="centerNav"
+          label="Center nav"
+          selected={navPosition === 'center'}
+          aria-label="Use center navigation position"
+          onClick={() => setNavPosition('center')}
+        />
+        <Chip
+          type="selection"
+          name="bottomNav"
+          label="Bottom nav"
+          selected={navPosition === 'bottom'}
+          aria-label="Use bottom navigation position"
+          onClick={() => setNavPosition('bottom')}
+        />
+        <Chip
+          type="selection"
+          name="showActions"
+          label="Actions"
+          selected={showActions}
+          aria-label="Toggle action buttons"
+          onClick={() => setShowActions((v) => !v)}
+        />
+        <Chip
+          type="selection"
+          name="showBreadcrumb"
+          label="Breadcrumb"
+          selected={showBreadcrumb}
+          aria-label="Toggle breadcrumb (level 1)"
+          onClick={() => setShowBreadcrumb((v) => !v)}
+        />
+      </Flex>
+
+      <div style={containerStyle} className="bg-secondary-lightest">
+        <PageHeader
+          title="Pac Follow-Up Protocol"
+          navigationPosition={navPosition}
+          navigation={navigation}
+          actions={actions}
+          breadcrumbs={breadcrumbs}
+          badge={<Badge appearance="secondary">Draft</Badge>}
+          status={<StatusHint appearance="info">Ongoing</StatusHint>}
+          separator={false}
+          aria-label="Pac follow-up page header"
+        />
+      </div>
     </div>
   );
 };
-
-const customCode = `() => {
-  const navigationData = [
-    {
-      name: 'menu_1',
-      label: 'Interventions',
-    },
-    {
-      name: 'menu_2',
-      label: 'No Linked Activites'
-    }
-  ];
-
-  const list = [
-    {
-      firstName: 'John',
-      lastName: 'Doe',
-      appearance: 'accent2',
-    },
-    {
-      firstName: 'Steven',
-      lastName: 'Packton',
-      appearance: 'accent3',
-    }
-  ];
-
-  const options = [
-    {
-      icon: 'print',
-      label: 'Edit',
-      value: 'Edit',
-    },
-    {
-      icon: 'assignment_turned_in',
-      label: 'Complete',
-      value: 'Complete',
-    },
-  ];
-
-  const [active, setActive] = React.useState({
-    name: 'menu_1'
-  });
-
-  const onClickHandler = (menu) => {
-    setActive(menu);
-  };
-
-  const actions = (
-    <div className="d-flex justify-content-end align-items-center">
-    <Text appearance="subtle" className="mr-4">Updated 1 day ago</Text>
-    <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={list}/>
-    <div>
-        <Menu trigger={<Menu.Trigger />}>
-          <Menu.List>
-            <Menu.Item className="d-flex align-items-center">
-              <Icon name="print" className="mr-4 my-2" />
-              <Text>Edit</Text>
-            </Menu.Item>
-            <Menu.Item className="d-flex align-items-center">
-              <Icon name="assignment_turned_in" className="mr-4 my-2" />
-              <Text>Complete</Text>
-            </Menu.Item>
-          </Menu.List>
-      </Menu>
-    </div>
-    </div>
-  );
-
-  const breadcrumbs = (
-    <Breadcrumbs
-      list={[{
-        label: 'Care potential',
-        link: '/Care potential'
-      }]}
-      onClick={link => console.log(\`on-click: \${link}\`)}
-    />
-  );
-
-  const status = (
-    <StatusHint appearance="info">Ongoing</StatusHint>
-  );
-
-  const navigation = (
-    <HorizontalNav 
-      menus={navigationData}
-      onClick={onClickHandler}
-      active={active}
-      aria-label="Follow-up protocol navigation"
-    />
-  );
-
-  return (
-    <div className="bg-secondary-lightest">
-      <PageHeader
-        navigationPosition="bottom"
-        title="Pac Follow-Up Protocol"
-        separator={false}
-        navigation={navigation}
-        actions={actions}
-        breadcrumbs={breadcrumbs}
-        status={status}
-        aria-label="Pac follow-up page"
-      />
-    </div>
-  );
-}`;
 
 export default {
   title: 'Components/PageHeader/Responsiveness',
@@ -211,7 +155,7 @@ export default {
   parameters: {
     docs: {
       docPage: {
-        customCode,
+        title: 'Responsiveness',
       },
     },
   },

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -90,7 +90,7 @@ export const Responsiveness = () => {
 
   const actions =
     actionCount > 0 ? (
-      <div className="d-flex align-items-center justify-content-end">
+      <div className="d-flex flex-wrap align-items-center justify-content-end">
         {extraActionElements.slice(MAX_ACTIONS - actionCount)}
         <Button appearance="primary" onClick={action('save')} key="save">
           Save
@@ -371,7 +371,7 @@ const customCode = `() => {
   ];
 
   const actions = actionCount > 0 ? (
-    <div className="d-flex align-items-center justify-content-end">
+    <div className="d-flex flex-wrap align-items-center justify-content-end">
       {extraActionElements.slice(MAX_ACTIONS - actionCount)}
       <Button appearance="primary" key="save">Save</Button>
     </div>

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -149,13 +149,104 @@ export const Responsiveness = () => {
   );
 };
 
+const customCode = `() => {
+  const [viewportPreset, setViewportPreset] = React.useState('full');
+  const [navPosition, setNavPosition] = React.useState('center');
+  const [showActions, setShowActions] = React.useState(true);
+  const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
+
+  const navigationData = [
+    { name: 'overview', label: 'Overview' },
+    { name: 'interventions', label: 'Interventions' },
+    { name: 'activities', label: 'Activities' },
+    { name: 'documents', label: 'Documents' },
+  ];
+
+  const avatarList = [
+    { firstName: 'John', lastName: 'Doe', appearance: 'accent2' },
+    { firstName: 'Jane', lastName: 'Smith', appearance: 'accent3' },
+  ];
+
+  const [active, setActive] = React.useState({ name: 'overview' });
+
+  const navigation = (
+    <HorizontalNav
+      menus={navigationData}
+      active={active}
+      onClick={(menu) => setActive(menu)}
+      aria-label="Protocol navigation"
+    />
+  );
+
+  const actions = showActions ? (
+    <div className="d-flex align-items-center justify-content-end">
+      <Text appearance="subtle" className="mr-4">Updated 1 day ago</Text>
+      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={avatarList} />
+      <Button className="mr-4">Edit</Button>
+      <Button appearance="primary">Save</Button>
+    </div>
+  ) : undefined;
+
+  const breadcrumbs = showBreadcrumb ? (
+    <Breadcrumbs
+      list={[{ label: 'Care potential', link: '/care-potential' }]}
+      onClick={(link) => console.log(\`breadcrumb: \${link}\`)}
+    />
+  ) : undefined;
+
+  const containerStyle = {
+    width: viewportPreset === '320' ? 320 : viewportPreset === '640' ? 640 : '100%',
+    maxWidth: '100%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    boxSizing: 'border-box',
+  };
+
+  function togglePreset(preset) {
+    setViewportPreset((p) => (p === preset ? 'full' : preset));
+  }
+
+  return (
+    <div>
+      <Flex direction="row" wrap="wrap" gap="spacing-40" className="mb-6 align-items-center">
+        <Chip type="selection" name="viewport320" label="320px" selected={viewportPreset === '320'}
+          aria-label="Constrain header to 320px width" onClick={() => togglePreset('320')} />
+        <Chip type="selection" name="viewport640" label="640px" selected={viewportPreset === '640'}
+          aria-label="Constrain header to 640px width" onClick={() => togglePreset('640')} />
+        <Chip type="selection" name="centerNav" label="Center nav" selected={navPosition === 'center'}
+          aria-label="Use center navigation position" onClick={() => setNavPosition('center')} />
+        <Chip type="selection" name="bottomNav" label="Bottom nav" selected={navPosition === 'bottom'}
+          aria-label="Use bottom navigation position" onClick={() => setNavPosition('bottom')} />
+        <Chip type="selection" name="showActions" label="Actions" selected={showActions}
+          aria-label="Toggle action buttons" onClick={() => setShowActions((v) => !v)} />
+        <Chip type="selection" name="showBreadcrumb" label="Breadcrumb" selected={showBreadcrumb}
+          aria-label="Toggle breadcrumb (level 1)" onClick={() => setShowBreadcrumb((v) => !v)} />
+      </Flex>
+
+      <div style={containerStyle} className="bg-secondary-lightest">
+        <PageHeader
+          title="Pac Follow-Up Protocol"
+          navigationPosition={navPosition}
+          navigation={navigation}
+          actions={actions}
+          breadcrumbs={breadcrumbs}
+          badge={<Badge appearance="secondary">Draft</Badge>}
+          status={<StatusHint appearance="info">Ongoing</StatusHint>}
+          separator={false}
+          aria-label="Pac follow-up page header"
+        />
+      </div>
+    </div>
+  );
+}`;
+
 export default {
   title: 'Components/PageHeader/Responsiveness',
   component: PageHeader,
   parameters: {
     docs: {
       docPage: {
-        title: 'Responsiveness',
+        customCode,
       },
     },
   },

--- a/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/Responsiveness.story.jsx
@@ -13,18 +13,34 @@ import {
 } from '@/index';
 import { action } from '@/utils/action';
 
+const ALL_TITLE_WORDS = ['Pac', 'Follow-Up', 'Protocol', 'for', 'Advanced', 'Cardiac', 'Care', 'Management'];
+const MIN_TITLE = 1;
+const MAX_TITLE = ALL_TITLE_WORDS.length;
+
+const ALL_NAV_DATA = [
+  { name: 'overview', label: 'Overview' },
+  { name: 'interventions', label: 'Interventions' },
+  { name: 'activities', label: 'Activities' },
+  { name: 'documents', label: 'Documents' },
+  { name: 'reports', label: 'Reports' },
+  { name: 'settings', label: 'Settings' },
+  { name: 'analytics', label: 'Analytics' },
+];
+const MIN_NAV = 2;
+const MAX_NAV = ALL_NAV_DATA.length;
+
+// Save is always present; these are the optional extras ordered left-to-right
+const MIN_ACTIONS = 1; // menu button is always the minimum when actions are on
+const MAX_ACTIONS = 5; // 5 optional items on top of Save
+
 export const Responsiveness = () => {
   const [viewportPreset, setViewportPreset] = React.useState('full');
-  const [showActions, setShowActions] = React.useState(true);
+  const [titleWordCount, setTitleWordCount] = React.useState(3);
+  const [actionCount, setActionCount] = React.useState(MIN_ACTIONS);
+  const [navCount, setNavCount] = React.useState(MIN_NAV);
   const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
+  const [showButton, setShowButton] = React.useState(false);
   const [showBadge, setShowBadge] = React.useState(true);
-
-  const navigationData = [
-    { name: 'overview', label: 'Overview' },
-    { name: 'interventions', label: 'Interventions' },
-    { name: 'activities', label: 'Activities' },
-    { name: 'documents', label: 'Documents' },
-  ];
 
   const avatarList = [
     { firstName: 'John', lastName: 'Doe', appearance: 'accent2' },
@@ -33,32 +49,50 @@ export const Responsiveness = () => {
 
   const [active, setActive] = React.useState({ name: 'overview' });
 
-  const navigation = (
-    <HorizontalNav
-      menus={navigationData}
-      active={active}
-      onClick={(menu) => {
-        setActive(menu);
-        action(`nav-click: ${menu.name}`)();
-      }}
-      aria-label="Protocol navigation"
-    />
-  );
+  const navigation =
+    navCount > 0 ? (
+      <HorizontalNav
+        menus={ALL_NAV_DATA.slice(0, navCount)}
+        active={active}
+        onClick={(menu) => {
+          setActive(menu);
+          action(`nav-click: ${menu.name}`)();
+        }}
+        aria-label="Protocol navigation"
+      />
+    ) : undefined;
 
-  const actions = showActions ? (
-    <div className="d-flex align-items-center justify-content-end">
-      <Text appearance="subtle" className="mr-4">
-        Updated 1 day ago
-      </Text>
-      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={avatarList} />
-      <Button className="mr-4" onClick={action('edit')}>
-        Edit
-      </Button>
-      <Button appearance="primary" onClick={action('save')}>
-        Save
-      </Button>
-    </div>
-  ) : undefined;
+  // Optional action items ordered left-to-right; Save is always rendered separately
+  const extraActionElements = [
+    <Text appearance="subtle" className="mr-4" key="text">
+      Updated 1 day ago
+    </Text>,
+    <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={avatarList} key="avatars" />,
+    <Button className="mr-4" onClick={action('export')} key="export">
+      Export
+    </Button>,
+    <Button className="mr-4" onClick={action('edit')} key="edit">
+      Edit
+    </Button>,
+    <Button
+      icon="more_vertical"
+      largeIcon={true}
+      className="mr-4"
+      aria-label="More options"
+      onClick={action('menu')}
+      key="menu"
+    />,
+  ];
+
+  const actions =
+    actionCount > 0 ? (
+      <div className="d-flex align-items-center justify-content-end">
+        {extraActionElements.slice(MAX_ACTIONS - actionCount)}
+        <Button appearance="primary" onClick={action('save')} key="save">
+          Save
+        </Button>
+      </div>
+    ) : undefined;
 
   const breadcrumbs = showBreadcrumb ? (
     <Breadcrumbs
@@ -66,6 +100,12 @@ export const Responsiveness = () => {
       onClick={(link) => action(`breadcrumb: ${link}`)()}
     />
   ) : undefined;
+
+  const button = showButton ? (
+    <Button icon="arrow_back" size="tiny" largeIcon={true} aria-label="Go back" onClick={action('back')} />
+  ) : undefined;
+
+  const title = ALL_TITLE_WORDS.slice(0, titleWordCount).join(' ');
 
   const containerStyle = {
     width: viewportPreset === '320' ? 320 : viewportPreset === '640' ? 640 : '100%',
@@ -81,56 +121,165 @@ export const Responsiveness = () => {
 
   return (
     <div>
-      <Flex direction="row" wrap="wrap" gap="spacing-40" className="mb-6 align-items-center">
-        <Chip
-          type="selection"
-          name="viewport320"
-          label="320px"
-          selected={viewportPreset === '320'}
-          aria-label="Constrain header to 320px width"
-          onClick={() => togglePreset('320')}
-        />
-        <Chip
-          type="selection"
-          name="viewport640"
-          label="640px"
-          selected={viewportPreset === '640'}
-          aria-label="Constrain header to 640px width"
-          onClick={() => togglePreset('640')}
-        />
-        <Chip
-          type="selection"
-          name="showActions"
-          label="Actions"
-          selected={showActions}
-          aria-label="Toggle action buttons"
-          onClick={() => setShowActions((v) => !v)}
-        />
-        <Chip
-          type="selection"
-          name="showBreadcrumb"
-          label="Breadcrumb"
-          selected={showBreadcrumb}
-          aria-label="Toggle breadcrumb (level 1)"
-          onClick={() => setShowBreadcrumb((v) => !v)}
-        />
-        <Chip
-          type="selection"
-          name="showBadge"
-          label="Badge"
-          selected={showBadge}
-          aria-label="Toggle badge beside title"
-          onClick={() => setShowBadge((v) => !v)}
-        />
+      <Flex direction="column" gap="spacing-20" className="mb-6">
+        {/* Viewport */}
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Chip
+            type="selection"
+            name="viewport320"
+            label="320px"
+            selected={viewportPreset === '320'}
+            aria-label="Constrain header to 320px width"
+            onClick={() => togglePreset('320')}
+          />
+          <Chip
+            type="selection"
+            name="viewport640"
+            label="640px"
+            selected={viewportPreset === '640'}
+            aria-label="Constrain header to 640px width"
+            onClick={() => togglePreset('640')}
+          />
+          <Chip
+            type="selection"
+            name="viewportFull"
+            label="Full width"
+            selected={viewportPreset === 'full'}
+            aria-label="Full width"
+            onClick={() => togglePreset('full')}
+          />
+        </Flex>
+
+        {/* Actions */}
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Chip
+            type="selection"
+            name="showActions"
+            label="Actions"
+            selected={actionCount > 0}
+            aria-label="Toggle actions"
+            onClick={() => setActionCount((c) => (c > 0 ? 0 : MIN_ACTIONS))}
+          />
+          <Button
+            icon="remove"
+            size="tiny"
+            aria-label="Remove one action"
+            disabled={actionCount <= MIN_ACTIONS}
+            onClick={() => setActionCount((c) => Math.max(MIN_ACTIONS, c - 1))}
+          />
+          <Button
+            icon="add"
+            size="tiny"
+            aria-label="Add one action"
+            disabled={actionCount >= MAX_ACTIONS}
+            onClick={() => setActionCount((c) => Math.min(MAX_ACTIONS, c + 1))}
+          />
+          <Chip
+            type="selection"
+            name="actionsMax"
+            label="Max"
+            selected={actionCount >= MAX_ACTIONS}
+            aria-label="Set actions to max or remove one"
+            onClick={() => setActionCount((c) => (c >= MAX_ACTIONS ? MAX_ACTIONS - 1 : MAX_ACTIONS))}
+          />
+        </Flex>
+
+        {/* Nav */}
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Chip
+            type="selection"
+            name="showNav"
+            label="Nav"
+            selected={navCount > 0}
+            aria-label="Toggle navigation"
+            onClick={() => setNavCount((c) => (c > 0 ? 0 : MIN_NAV))}
+          />
+          <Button
+            icon="remove"
+            size="tiny"
+            aria-label="Remove one nav item"
+            disabled={navCount <= MIN_NAV}
+            onClick={() => setNavCount((c) => Math.max(MIN_NAV, c - 1))}
+          />
+          <Button
+            icon="add"
+            size="tiny"
+            aria-label="Add one nav item"
+            disabled={navCount >= MAX_NAV}
+            onClick={() => setNavCount((c) => Math.min(MAX_NAV, c + 1))}
+          />
+          <Chip
+            type="selection"
+            name="navMax"
+            label="Max"
+            selected={navCount >= MAX_NAV}
+            aria-label="Set nav to max or remove one"
+            onClick={() => setNavCount((c) => (c >= MAX_NAV ? MAX_NAV - 1 : MAX_NAV))}
+          />
+        </Flex>
+
+        {/* Title length + content toggles */}
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Text appearance="subtle" weight="medium">
+            Title
+          </Text>
+          <Button
+            icon="remove"
+            size="tiny"
+            aria-label="Shorten title by one word"
+            disabled={titleWordCount <= MIN_TITLE}
+            onClick={() => setTitleWordCount((c) => Math.max(MIN_TITLE, c - 1))}
+          />
+          <Button
+            icon="add"
+            size="tiny"
+            aria-label="Lengthen title by one word"
+            disabled={titleWordCount >= MAX_TITLE}
+            onClick={() => setTitleWordCount((c) => Math.min(MAX_TITLE, c + 1))}
+          />
+          <Chip
+            type="selection"
+            name="titleMax"
+            label="Max"
+            selected={titleWordCount >= MAX_TITLE}
+            aria-label="Set title to max length or shorten by one word"
+            onClick={() => setTitleWordCount((c) => (c >= MAX_TITLE ? MAX_TITLE - 1 : MAX_TITLE))}
+          />
+          <Chip
+            type="selection"
+            name="showBreadcrumb"
+            label="Breadcrumb"
+            selected={showBreadcrumb}
+            aria-label="Toggle breadcrumb (level 1)"
+            onClick={() => setShowBreadcrumb((v) => !v)}
+          />
+          <Chip
+            type="selection"
+            name="showButton"
+            label="Back button"
+            selected={showButton}
+            aria-label="Toggle back button"
+            onClick={() => setShowButton((v) => !v)}
+          />
+          <Chip
+            type="selection"
+            name="showBadge"
+            label="Badge"
+            selected={showBadge}
+            aria-label="Toggle badge beside title"
+            onClick={() => setShowBadge((v) => !v)}
+          />
+        </Flex>
       </Flex>
 
       <div style={containerStyle} className="bg-secondary-lightest">
         <PageHeader
-          title="Pac Follow-Up Protocol"
+          title={title}
           navigationPosition="center"
           navigation={navigation}
           actions={actions}
           breadcrumbs={breadcrumbs}
+          button={button}
           badge={showBadge ? <Badge appearance="secondary">Draft</Badge> : undefined}
           status={<StatusHint appearance="info">Ongoing</StatusHint>}
           separator={false}
@@ -142,17 +291,31 @@ export const Responsiveness = () => {
 };
 
 const customCode = `() => {
-  const [viewportPreset, setViewportPreset] = React.useState('full');
-  const [showActions, setShowActions] = React.useState(true);
-  const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
-  const [showBadge, setShowBadge] = React.useState(true);
+  const ALL_TITLE_WORDS = ['Pac', 'Follow-Up', 'Protocol', 'for', 'Advanced', 'Cardiac', 'Care', 'Management'];
+  const MIN_TITLE = 1;
+  const MAX_TITLE = ALL_TITLE_WORDS.length;
 
-  const navigationData = [
+  const ALL_NAV_DATA = [
     { name: 'overview', label: 'Overview' },
     { name: 'interventions', label: 'Interventions' },
     { name: 'activities', label: 'Activities' },
     { name: 'documents', label: 'Documents' },
+    { name: 'reports', label: 'Reports' },
+    { name: 'settings', label: 'Settings' },
+    { name: 'analytics', label: 'Analytics' },
   ];
+  const MIN_NAV = 2;
+  const MAX_NAV = ALL_NAV_DATA.length;
+  const MIN_ACTIONS = 1;
+  const MAX_ACTIONS = 5;
+
+  const [viewportPreset, setViewportPreset] = React.useState('full');
+  const [titleWordCount, setTitleWordCount] = React.useState(3);
+  const [actionCount, setActionCount] = React.useState(MIN_ACTIONS);
+  const [navCount, setNavCount] = React.useState(MIN_NAV);
+  const [showBreadcrumb, setShowBreadcrumb] = React.useState(false);
+  const [showButton, setShowButton] = React.useState(false);
+  const [showBadge, setShowBadge] = React.useState(true);
 
   const avatarList = [
     { firstName: 'John', lastName: 'Doe', appearance: 'accent2' },
@@ -161,21 +324,27 @@ const customCode = `() => {
 
   const [active, setActive] = React.useState({ name: 'overview' });
 
-  const navigation = (
+  const navigation = navCount > 0 ? (
     <HorizontalNav
-      menus={navigationData}
+      menus={ALL_NAV_DATA.slice(0, navCount)}
       active={active}
       onClick={(menu) => setActive(menu)}
       aria-label="Protocol navigation"
     />
-  );
+  ) : undefined;
 
-  const actions = showActions ? (
+  const extraActionElements = [
+    <Text appearance="subtle" className="mr-4" key="text">Updated 1 day ago</Text>,
+    <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={avatarList} key="avatars" />,
+    <Button className="mr-4" key="export">Export</Button>,
+    <Button className="mr-4" key="edit">Edit</Button>,
+    <Button icon="more_vertical" largeIcon={true} className="mr-4" aria-label="More options" key="menu" />,
+  ];
+
+  const actions = actionCount > 0 ? (
     <div className="d-flex align-items-center justify-content-end">
-      <Text appearance="subtle" className="mr-4">Updated 1 day ago</Text>
-      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-5" list={avatarList} />
-      <Button className="mr-4">Edit</Button>
-      <Button appearance="primary">Save</Button>
+      {extraActionElements.slice(MAX_ACTIONS - actionCount)}
+      <Button appearance="primary" key="save">Save</Button>
     </div>
   ) : undefined;
 
@@ -185,6 +354,12 @@ const customCode = `() => {
       onClick={(link) => console.log(\`breadcrumb: \${link}\`)}
     />
   ) : undefined;
+
+  const button = showButton ? (
+    <Button icon="arrow_back" size="tiny" largeIcon={true} aria-label="Go back" />
+  ) : undefined;
+
+  const title = ALL_TITLE_WORDS.slice(0, titleWordCount).join(' ');
 
   const containerStyle = {
     width: viewportPreset === '320' ? 320 : viewportPreset === '640' ? 640 : '100%',
@@ -200,26 +375,66 @@ const customCode = `() => {
 
   return (
     <div>
-      <Flex direction="row" wrap="wrap" gap="spacing-40" className="mb-6 align-items-center">
-        <Chip type="selection" name="viewport320" label="320px" selected={viewportPreset === '320'}
-          aria-label="Constrain header to 320px width" onClick={() => togglePreset('320')} />
-        <Chip type="selection" name="viewport640" label="640px" selected={viewportPreset === '640'}
-          aria-label="Constrain header to 640px width" onClick={() => togglePreset('640')} />
-        <Chip type="selection" name="showActions" label="Actions" selected={showActions}
-          aria-label="Toggle action buttons" onClick={() => setShowActions((v) => !v)} />
-        <Chip type="selection" name="showBreadcrumb" label="Breadcrumb" selected={showBreadcrumb}
-          aria-label="Toggle breadcrumb (level 1)" onClick={() => setShowBreadcrumb((v) => !v)} />
-        <Chip type="selection" name="showBadge" label="Badge" selected={showBadge}
-          aria-label="Toggle badge beside title" onClick={() => setShowBadge((v) => !v)} />
+      <Flex direction="column" gap="spacing-20" className="mb-6">
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Chip type="selection" name="viewport320" label="320px" selected={viewportPreset === '320'}
+            aria-label="Constrain header to 320px width" onClick={() => togglePreset('320')} />
+          <Chip type="selection" name="viewport640" label="640px" selected={viewportPreset === '640'}
+            aria-label="Constrain header to 640px width" onClick={() => togglePreset('640')} />
+          <Chip type="selection" name="viewportFull" label="Full width" selected={viewportPreset === 'full'}
+            aria-label="Full width" onClick={() => togglePreset('full')} />
+        </Flex>
+
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Chip type="selection" name="showActions" label="Actions" selected={actionCount > 0}
+            aria-label="Toggle actions" onClick={() => setActionCount((c) => (c > 0 ? 0 : MIN_ACTIONS))} />
+          <Button icon="remove" size="tiny" aria-label="Remove one action"
+            disabled={actionCount <= MIN_ACTIONS} onClick={() => setActionCount((c) => Math.max(MIN_ACTIONS, c - 1))} />
+          <Button icon="add" size="tiny" aria-label="Add one action"
+            disabled={actionCount >= MAX_ACTIONS} onClick={() => setActionCount((c) => Math.min(MAX_ACTIONS, c + 1))} />
+          <Chip type="selection" name="actionsMax" label="Max" selected={actionCount >= MAX_ACTIONS}
+            aria-label="Set actions to max or remove one"
+            onClick={() => setActionCount((c) => (c >= MAX_ACTIONS ? MAX_ACTIONS - 1 : MAX_ACTIONS))} />
+        </Flex>
+
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Chip type="selection" name="showNav" label="Nav" selected={navCount > 0}
+            aria-label="Toggle navigation" onClick={() => setNavCount((c) => (c > 0 ? 0 : MIN_NAV))} />
+          <Button icon="remove" size="tiny" aria-label="Remove one nav item"
+            disabled={navCount <= MIN_NAV} onClick={() => setNavCount((c) => Math.max(MIN_NAV, c - 1))} />
+          <Button icon="add" size="tiny" aria-label="Add one nav item"
+            disabled={navCount >= MAX_NAV} onClick={() => setNavCount((c) => Math.min(MAX_NAV, c + 1))} />
+          <Chip type="selection" name="navMax" label="Max" selected={navCount >= MAX_NAV}
+            aria-label="Set nav to max or remove one"
+            onClick={() => setNavCount((c) => (c >= MAX_NAV ? MAX_NAV - 1 : MAX_NAV))} />
+        </Flex>
+
+        <Flex direction="row" wrap="wrap" gap="spacing-40" className="align-items-center">
+          <Text appearance="subtle" weight="medium">Title</Text>
+          <Button icon="remove" size="tiny" aria-label="Shorten title by one word"
+            disabled={titleWordCount <= MIN_TITLE} onClick={() => setTitleWordCount((c) => Math.max(MIN_TITLE, c - 1))} />
+          <Button icon="add" size="tiny" aria-label="Lengthen title by one word"
+            disabled={titleWordCount >= MAX_TITLE} onClick={() => setTitleWordCount((c) => Math.min(MAX_TITLE, c + 1))} />
+          <Chip type="selection" name="titleMax" label="Max" selected={titleWordCount >= MAX_TITLE}
+            aria-label="Set title to max length or shorten by one word"
+            onClick={() => setTitleWordCount((c) => (c >= MAX_TITLE ? MAX_TITLE - 1 : MAX_TITLE))} />
+          <Chip type="selection" name="showBreadcrumb" label="Breadcrumb" selected={showBreadcrumb}
+            aria-label="Toggle breadcrumb (level 1)" onClick={() => setShowBreadcrumb((v) => !v)} />
+          <Chip type="selection" name="showButton" label="Back button" selected={showButton}
+            aria-label="Toggle back button" onClick={() => setShowButton((v) => !v)} />
+          <Chip type="selection" name="showBadge" label="Badge" selected={showBadge}
+            aria-label="Toggle badge beside title" onClick={() => setShowBadge((v) => !v)} />
+        </Flex>
       </Flex>
 
       <div style={containerStyle} className="bg-secondary-lightest">
         <PageHeader
-          title="Pac Follow-Up Protocol"
+          title={title}
           navigationPosition="center"
           navigation={navigation}
           actions={actions}
           breadcrumbs={breadcrumbs}
+          button={button}
           badge={showBadge ? <Badge appearance="secondary">Draft</Badge> : undefined}
           status={<StatusHint appearance="info">Ongoing</StatusHint>}
           separator={false}

--- a/core/components/organisms/pageHeader/__stories__/level1/withBreadcrumb/withNavigationL1.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/level1/withBreadcrumb/withNavigationL1.story.jsx
@@ -1,8 +1,54 @@
 import * as React from 'react';
-import { HorizontalNav, Breadcrumbs, Badge, MetaList, PageHeader, StatusHint, Row, Column } from '@/index';
+import {
+  HorizontalNav,
+  Breadcrumbs,
+  Badge,
+  MetaList,
+  PageHeader,
+  StatusHint,
+  Button,
+  AvatarGroup,
+  Text,
+  Menu,
+} from '@/index';
 import { action } from '@/utils/action';
+import '../../style.css';
 
 export const withNavigation = () => {
+  const options = [
+    {
+      label: 'Option 1',
+      value: 'Option 1',
+    },
+    {
+      label: 'Option 2',
+      value: 'Option 2',
+    },
+    {
+      label: 'Option 3',
+      value: 'Option 3',
+    },
+  ];
+
+  const list = [
+    {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+    {
+      firstName: 'Steven',
+      lastName: 'Packton',
+    },
+    {
+      firstName: 'Nancy',
+      lastName: 'Wheeler',
+    },
+    {
+      firstName: 'Monica',
+      lastName: 'Geller',
+    },
+  ];
+
   const navigationData = [
     {
       name: 'menu_1',
@@ -23,7 +69,31 @@ export const withNavigation = () => {
   };
 
   const navigation = <HorizontalNav menus={navigationData} onClick={onClickHandler} active={active} />;
-  const actions = <div className="d-flex justify-content-end align-items-center" />;
+  const actions = (
+    <div className="d-flex justify-content-end align-items-center">
+      <Text appearance="subtle" className="mr-4">
+        Few minutes ago
+      </Text>
+      <AvatarGroup
+        className="mr-4"
+        list={list}
+        borderColor="var(--secondary-lightest)"
+        popoverOptions={{ dark: true, on: 'hover', position: 'bottom' }}
+      />
+      <div className="mr-4">
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            {options.map((item, key) => {
+              const { label } = item;
+              return <Menu.Item key={key}>{label}</Menu.Item>;
+            })}
+          </Menu.List>
+        </Menu>
+      </div>
+      <Button className="mr-4">Finish later</Button>
+      <Button appearance="primary">Next</Button>
+    </div>
+  );
   const breadcrumbs = (
     <Breadcrumbs
       list={[
@@ -45,27 +115,65 @@ export const withNavigation = () => {
   const status = <StatusHint appearance="info">Ongoing</StatusHint>;
 
   return (
-    <Row>
-      <Column size={11}>
-        <div className="bg-secondary-lightest">
-          <PageHeader
-            title="Covid-19"
-            separator={false}
-            navigationPosition="center"
-            navigation={navigation}
-            actions={actions}
-            breadcrumbs={breadcrumbs}
-            badge={badge}
-            status={status}
-            meta={meta}
-          />
-        </div>
-      </Column>
-    </Row>
+    <div className="bg-secondary-lightest Pageheader-longWrapper">
+      <PageHeader
+        title="Covid-19"
+        separator={false}
+        navigationPosition="center"
+        navigation={navigation}
+        actions={actions}
+        breadcrumbs={breadcrumbs}
+        badge={badge}
+        status={status}
+        meta={meta}
+      />
+    </div>
   );
 };
 
-const customCode = `() => {
+const customCode = `/*
+// style.css
+.Pageheader-longWrapper {
+    width: 1200px;
+}
+
+*/
+
+() => {
+  const options = [
+    {
+      label: 'Option 1',
+      value: 'Option 1',
+    },
+    {
+      label: 'Option 2',
+      value: 'Option 2',
+    },
+    {
+      label: 'Option 3',
+      value: 'Option 3',
+    },
+  ];
+
+  const list = [
+    {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+    {
+      firstName: 'Steven',
+      lastName: 'Packton',
+    },
+    {
+      firstName: 'Nancy',
+      lastName: 'Wheeler',
+    },
+    {
+      firstName: 'Monica',
+      lastName: 'Geller',
+    },
+  ];
+
   const navigationData = [
     {
       name: 'menu_1',
@@ -93,7 +201,28 @@ const customCode = `() => {
     />
   );
   const actions = (
-    <div className="d-flex justify-content-end align-items-center"/>
+    <div className="d-flex justify-content-end align-items-center">
+      <Text appearance="subtle" className="mr-4">Few minutes ago</Text>
+      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-4" list={list} popoverOptions={{ dark: true, on: 'hover', position: 'bottom' }} />
+      <div className="mr-4">
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            {
+              options.map((item, key) => {
+                const { label } = item;
+                return (
+                  <Menu.Item key={key}>
+                    {label}
+                  </Menu.Item>
+                );
+              })
+            }
+          </Menu.List>
+        </Menu>
+      </div>
+      <Button className="mr-4">Finish later</Button>
+      <Button appearance="primary">Next</Button>
+    </div>
   );
   const breadcrumbs = (
     <Breadcrumbs
@@ -116,23 +245,19 @@ const customCode = `() => {
   const status = <StatusHint appearance="info">Ongoing</StatusHint>;
 
   return (
-    <Row>
-      <Column size={11}>
-        <div className="bg-secondary-lightest">
-          <PageHeader
-            title="Covid-19"
-            separator={false}
-            navigationPosition="center"
-            navigation={navigation}
-            actions={actions}
-            breadcrumbs={breadcrumbs}
-            badge={badge}
-            status={status}
-            meta={meta}
-          />
-        </div>
-      </Column>
-    </Row>
+    <div className="bg-secondary-lightest Pageheader-longWrapper">
+      <PageHeader
+        title="Covid-19"
+        separator={false}
+        navigationPosition="center"
+        navigation={navigation}
+        actions={actions}
+        breadcrumbs={breadcrumbs}
+        badge={badge}
+        status={status}
+        meta={meta}
+      />
+    </div>
   );
 }`;
 

--- a/core/components/organisms/pageHeader/__stories__/level1/withBreadcrumb/withTabsL1.story.jsx
+++ b/core/components/organisms/pageHeader/__stories__/level1/withBreadcrumb/withTabsL1.story.jsx
@@ -1,8 +1,43 @@
 import * as React from 'react';
-import { Tabs, PageHeader, Breadcrumbs, Row, Column } from '@/index';
+import { Tabs, PageHeader, Breadcrumbs, Button, AvatarGroup, Text, Menu } from '@/index';
 import { action } from '@/utils/action';
+import '../../style.css';
 
 export const withTabs = () => {
+  const options = [
+    {
+      label: 'Option 1',
+      value: 'Option 1',
+    },
+    {
+      label: 'Option 2',
+      value: 'Option 2',
+    },
+    {
+      label: 'Option 3',
+      value: 'Option 3',
+    },
+  ];
+
+  const list = [
+    {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+    {
+      firstName: 'Steven',
+      lastName: 'Packton',
+    },
+    {
+      firstName: 'Nancy',
+      lastName: 'Wheeler',
+    },
+    {
+      firstName: 'Monica',
+      lastName: 'Geller',
+    },
+  ];
+
   const tabs = [
     {
       count: 32,
@@ -22,6 +57,34 @@ export const withTabs = () => {
 
   const tab = <Tabs tabs={tabs} activeIndex={activeIndex} onTabChange={setActiveIndex} />;
 
+  const actions = (
+    <div className="d-flex justify-content-end align-items-center">
+      <Text appearance="subtle" className="mr-4">
+        Few minutes ago
+      </Text>
+      <AvatarGroup
+        className="mr-4"
+        list={list}
+        borderColor="var(--secondary-lightest)"
+        popoverOptions={{ dark: true, on: 'hover', position: 'bottom' }}
+      />
+      <div className="mr-4">
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            {options.map((item, key) => {
+              const { label } = item;
+              return <Menu.Item key={key}>{label}</Menu.Item>;
+            })}
+          </Menu.List>
+        </Menu>
+      </div>
+      <Button appearance="subtle" className="mr-4">
+        Finish later
+      </Button>
+      <Button appearance="primary">Next</Button>
+    </div>
+  );
+
   const breadcrumbs = (
     <Breadcrumbs
       list={[
@@ -35,17 +98,61 @@ export const withTabs = () => {
   );
 
   return (
-    <Row>
-      <Column size={11}>
-        <div className="bg-secondary-lightest">
-          <PageHeader title="Sender creation report" separator={true} tabs={tab} breadcrumbs={breadcrumbs} />
-        </div>
-      </Column>
-    </Row>
+    <div className="bg-secondary-lightest Pageheader-longWrapper">
+      <PageHeader
+        title="Sender creation report"
+        separator={true}
+        tabs={tab}
+        actions={actions}
+        breadcrumbs={breadcrumbs}
+      />
+    </div>
   );
 };
 
-const customCode = `() => {
+const customCode = `/*
+// style.css
+.Pageheader-longWrapper {
+    width: 1200px;
+}
+
+*/
+
+() => {
+  const options = [
+    {
+      label: 'Option 1',
+      value: 'Option 1',
+    },
+    {
+      label: 'Option 2',
+      value: 'Option 2',
+    },
+    {
+      label: 'Option 3',
+      value: 'Option 3',
+    },
+  ];
+
+  const list = [
+    {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
+    {
+      firstName: 'Steven',
+      lastName: 'Packton',
+    },
+    {
+      firstName: 'Nancy',
+      lastName: 'Wheeler',
+    },
+    {
+      firstName: 'Monica',
+      lastName: 'Geller',
+    },
+  ];
+
   const tabs = [
     {
       count: 32,
@@ -71,6 +178,31 @@ const customCode = `() => {
     />
   );
 
+  const actions = (
+    <div className="d-flex justify-content-end align-items-center">
+      <Text appearance="subtle" className="mr-4">Few minutes ago</Text>
+      <AvatarGroup borderColor="var(--secondary-lightest)" className="mr-4" list={list} popoverOptions={{ dark: true, on: 'hover', position: 'bottom' }} />
+      <div className="mr-4">
+        <Menu trigger={<Menu.Trigger />}>
+          <Menu.List>
+            {
+              options.map((item, key) => {
+                const { label } = item;
+                return (
+                  <Menu.Item key={key}>
+                    {label}
+                  </Menu.Item>
+                );
+              })
+            }
+          </Menu.List>
+        </Menu>
+      </div>
+      <Button className="mr-4">Finish later</Button>
+      <Button appearance="primary">Next</Button>
+    </div>
+  );
+
   const breadcrumbs = (
     <Breadcrumbs
       list={[{
@@ -82,18 +214,15 @@ const customCode = `() => {
   );
 
   return (
-    <Row>
-      <Column size={11}>
-        <div className="bg-secondary-lightest">
-          <PageHeader
-            title="Sender creation report"
-            separator={true}
-            tabs={tab}
-            breadcrumbs={breadcrumbs}
-          />
-        </div>
-      </Column>
-    </Row>
+    <div className="bg-secondary-lightest Pageheader-longWrapper">
+      <PageHeader
+        title="Sender creation report"
+        separator={true}
+        tabs={tab}
+        actions={actions}
+        breadcrumbs={breadcrumbs}
+      />
+    </div>
   );
 }`;
 

--- a/core/components/organisms/pageHeader/__tests__/PageHeader.test.tsx
+++ b/core/components/organisms/pageHeader/__tests__/PageHeader.test.tsx
@@ -5,6 +5,20 @@ import PageHeader, { PageHeaderProps as Props } from '../PageHeader';
 import { Stepper, Button, Tabs, Breadcrumbs, Badge, MetaList, StatusHint, HorizontalNav } from '@/index';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
 
+declare global {
+  interface Window {
+    ResizeObserver: unknown;
+  }
+}
+
+const ResizeObserverMock = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));
+
+window.ResizeObserver = ResizeObserverMock;
+
 const BooleanValues = [true, false];
 const title = 'PageHeader title';
 const navPosition = ['center', 'bottom'];

--- a/core/components/organisms/pageHeader/__tests__/PageHeader.test.tsx
+++ b/core/components/organisms/pageHeader/__tests__/PageHeader.test.tsx
@@ -120,6 +120,13 @@ describe('PageHeader Component with stepper', () => {
   expect(getByTestId('DesignSystem-PageHeader--Nav')).toBeInTheDocument();
 });
 
+describe('PageHeader Component with navigationPosition bottom and no nav/stepper', () => {
+  it('does not render bottom wrapper when no navigation or stepper is provided', () => {
+    const { queryByTestId } = render(<PageHeader title={title} navigationPosition="bottom" />);
+    expect(queryByTestId('DesignSystem-PageHeader--Nav')).not.toBeInTheDocument();
+  });
+});
+
 describe('PageHeader Component with actions', () => {
   const { getAllByTestId } = render(<PageHeader title={title} actions={actions} />);
   expect(getAllByTestId('DesignSystem-PageHeader--Actions')[0]).toBeInTheDocument();

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -31,7 +31,11 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                Senders
+                <span
+                  class="Link-text Link-text--subtle"
+                >
+                  Senders
+                </span>
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -352,7 +356,11 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                Senders
+                <span
+                  class="Link-text Link-text--subtle"
+                >
+                  Senders
+                </span>
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -678,7 +686,11 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                Senders
+                <span
+                  class="Link-text Link-text--subtle"
+                >
+                  Senders
+                </span>
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -1331,7 +1343,11 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                Senders
+                <span
+                  class="Link-text Link-text--subtle"
+                >
+                  Senders
+                </span>
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -1558,7 +1574,11 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                Senders
+                <span
+                  class="Link-text Link-text--subtle"
+                >
+                  Senders
+                </span>
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -1238,9 +1238,6 @@ exports[`Navigation component
             </div>
           </div>
         </div>
-        <div
-          class="pl-3 PageHeader-bottom"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -1299,9 +1296,6 @@ exports[`Navigation component
             </div>
           </div>
         </div>
-        <div
-          class="pl-3 PageHeader-bottom"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -1374,9 +1368,6 @@ exports[`Navigation component
             </div>
           </div>
         </div>
-        <div
-          class="pl-3 PageHeader-bottom"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -1425,9 +1416,6 @@ exports[`Navigation component
             </div>
           </div>
         </div>
-        <div
-          class="pl-3 PageHeader-bottom"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -1470,9 +1458,6 @@ exports[`Navigation component
             </div>
           </div>
         </div>
-        <div
-          class="pl-3 PageHeader-bottom"
-        />
       </div>
       <hr
         aria-orientation="horizontal"
@@ -1538,9 +1523,6 @@ exports[`Navigation component
             </div>
           </div>
         </div>
-        <div
-          class="pl-3 PageHeader-bottom"
-        />
       </div>
       <hr
         aria-orientation="horizontal"

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -79,6 +79,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -165,6 +166,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--actions"
+                data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
                 <button
@@ -404,6 +406,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -490,6 +493,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--center"
+                data-group="center"
                 data-test="DesignSystem-PageHeader--CenterNav"
               >
                 <div
@@ -529,6 +533,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--actions"
+                data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
                 <button
@@ -734,6 +739,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -820,6 +826,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--actions"
+                data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
                 <button
@@ -1007,6 +1014,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1152,6 +1160,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1167,6 +1176,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--center"
+                data-group="center"
                 data-test="DesignSystem-PageHeader--CenterNav"
               >
                 <div
@@ -1276,6 +1286,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1291,6 +1302,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--actions"
+                data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
                 <button
@@ -1368,6 +1380,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1410,6 +1423,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1458,6 +1472,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1523,6 +1538,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1622,6 +1638,7 @@ exports[`Navigation component
             >
               <div
                 class="PageHeader-group--title"
+                data-group="title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1708,6 +1725,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--center"
+                data-group="center"
                 data-test="DesignSystem-PageHeader--CenterNav"
               >
                 <div
@@ -1747,6 +1765,7 @@ exports[`Navigation component
               </div>
               <div
                 class="PageHeader-group--actions"
+                data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
                 <button

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -535,6 +535,7 @@ exports[`Navigation component
                 class="PageHeader-group--actions"
                 data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
+                style=""
               >
                 <button
                   class="Button Button--regular Button--basic Button--iconAlign-left"
@@ -1767,6 +1768,7 @@ exports[`Navigation component
                 class="PageHeader-group--actions"
                 data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
+                style=""
               >
                 <button
                   class="Button Button--regular Button--basic Button--iconAlign-left"

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Navigation component
       data-test="DesignSystem-PageHeader"
     >
       <div
-        class="PageHeader-wrapper PageHeader-wrapper--withTabs"
+        class="PageHeader-wrapper PageHeader-wrapper--withTabs PageHeader-wrapper--level1 PageHeader-wrapper--withActions"
       >
         <div
           class="pl-6"
@@ -31,11 +31,7 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                <span
-                  class="Link-text Link-text--subtle"
-                >
-                  Senders
-                </span>
+                Senders
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -75,12 +71,10 @@ exports[`Navigation component
             class="PageHeader"
           >
             <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
+              class="PageHeader-row"
             >
               <div
-                class="Col Col--8 Col--m-8 Col--xl-8"
-                data-test="DesignSystem-Column"
+                class="PageHeader-group--title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -99,97 +93,93 @@ exports[`Navigation component
                     Sent
                   </span>
                 </div>
-              </div>
-              <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-PageHeader--Actions"
-              >
                 <div
-                  class="PageHeader-actionsWrapper"
+                  class="PageHeader-statusWrapper"
+                  data-test="DesignSystem-PageHeader--Status"
                 >
-                  <button
-                    class="Button Button--regular Button--basic Button--iconAlign-left"
-                    data-test="DesignSystem-Button"
-                    tabindex="0"
+                  <div
+                    class="StatusHint"
+                    data-test="DesignSystem-StatusHint"
                   >
                     <span
-                      class="Button-text"
+                      aria-label="default status"
+                      class="StatusHint-icon StatusHint--default mr-4"
+                      data-test="DesignSystem-StatusHint--Icon"
+                      role="img"
+                    />
+                    <span
+                      class="Text Text--default Text--medium Text--regular"
+                      data-test="DesignSystem-StatusHint--Text"
                     >
-                      Action Section
+                      Ongoing
                     </span>
-                  </button>
+                  </div>
+                  <div
+                    class="MetaList"
+                    data-test="DesignSystem-MetaList"
+                  >
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Text
+                        </span>
+                      </span>
+                      <i
+                        aria-hidden="true"
+                        class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
+                        data-test="DesignSystem-MetaList--rightSeperator"
+                        style="font-size: 8px; width: 8px;"
+                      >
+                        fiber_manual_record
+                      </i>
+                    </span>
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Email
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="PageHeader-statusWrapper mb-3"
-              data-test="DesignSystem-PageHeader--Status"
-            >
               <div
-                class="StatusHint"
-                data-test="DesignSystem-StatusHint"
+                class="PageHeader-group--actions"
+                data-test="DesignSystem-PageHeader--Actions"
               >
-                <span
-                  aria-label="default status"
-                  class="StatusHint-icon StatusHint--default mr-4"
-                  data-test="DesignSystem-StatusHint--Icon"
-                  role="img"
-                />
-                <span
-                  class="Text Text--default Text--medium Text--regular"
-                  data-test="DesignSystem-StatusHint--Text"
-                >
-                  Ongoing
-                </span>
-              </div>
-              <div
-                class="MetaList"
-                data-test="DesignSystem-MetaList"
-              >
-                <span
-                  class="MetaList-item"
+                <button
+                  class="Button Button--regular Button--basic Button--iconAlign-left"
+                  data-test="DesignSystem-Button"
+                  tabindex="0"
                 >
                   <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
+                    class="Button-text"
                   >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Text
-                    </span>
+                    Action Section
                   </span>
-                  <i
-                    aria-hidden="true"
-                    class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
-                    data-test="DesignSystem-MetaList--rightSeperator"
-                    style="font-size: 8px; width: 8px;"
-                  >
-                    fiber_manual_record
-                  </i>
-                </span>
-                <span
-                  class="MetaList-item"
-                >
-                  <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
-                  >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Email
-                    </span>
-                  </span>
-                </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="pl-3"
+          class="pl-3 PageHeader-bottom"
         >
           <div
             class="PageHeader-navigationWrapper"
@@ -340,7 +330,7 @@ exports[`Navigation component
       data-test="DesignSystem-PageHeader"
     >
       <div
-        class="PageHeader-wrapper PageHeader-wrapper--withTabs"
+        class="PageHeader-wrapper PageHeader-wrapper--withTabs PageHeader-wrapper--level1 PageHeader-wrapper--withActions"
       >
         <div
           class="pl-6"
@@ -362,11 +352,7 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                <span
-                  class="Link-text Link-text--subtle"
-                >
-                  Senders
-                </span>
+                Senders
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -406,12 +392,10 @@ exports[`Navigation component
             class="PageHeader"
           >
             <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
+              class="PageHeader-row PageHeader-row--withCenter"
             >
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-Column"
+                class="PageHeader-group--title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -430,9 +414,74 @@ exports[`Navigation component
                     Sent
                   </span>
                 </div>
+                <div
+                  class="PageHeader-statusWrapper"
+                  data-test="DesignSystem-PageHeader--Status"
+                >
+                  <div
+                    class="StatusHint"
+                    data-test="DesignSystem-StatusHint"
+                  >
+                    <span
+                      aria-label="default status"
+                      class="StatusHint-icon StatusHint--default mr-4"
+                      data-test="DesignSystem-StatusHint--Icon"
+                      role="img"
+                    />
+                    <span
+                      class="Text Text--default Text--medium Text--regular"
+                      data-test="DesignSystem-StatusHint--Text"
+                    >
+                      Ongoing
+                    </span>
+                  </div>
+                  <div
+                    class="MetaList"
+                    data-test="DesignSystem-MetaList"
+                  >
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Text
+                        </span>
+                      </span>
+                      <i
+                        aria-hidden="true"
+                        class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
+                        data-test="DesignSystem-MetaList--rightSeperator"
+                        style="font-size: 8px; width: 8px;"
+                      >
+                        fiber_manual_record
+                      </i>
+                    </span>
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Email
+                        </span>
+                      </span>
+                    </span>
+                  </div>
+                </div>
               </div>
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
+                class="PageHeader-group--center"
                 data-test="DesignSystem-PageHeader--CenterNav"
               >
                 <div
@@ -471,95 +520,26 @@ exports[`Navigation component
                 </div>
               </div>
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
+                class="PageHeader-group--actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
-                <div
-                  class="PageHeader-actionsWrapper"
-                >
-                  <button
-                    class="Button Button--regular Button--basic Button--iconAlign-left"
-                    data-test="DesignSystem-Button"
-                    tabindex="0"
-                  >
-                    <span
-                      class="Button-text"
-                    >
-                      Action Section
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div
-              class="PageHeader-statusWrapper mb-3"
-              data-test="DesignSystem-PageHeader--Status"
-            >
-              <div
-                class="StatusHint"
-                data-test="DesignSystem-StatusHint"
-              >
-                <span
-                  aria-label="default status"
-                  class="StatusHint-icon StatusHint--default mr-4"
-                  data-test="DesignSystem-StatusHint--Icon"
-                  role="img"
-                />
-                <span
-                  class="Text Text--default Text--medium Text--regular"
-                  data-test="DesignSystem-StatusHint--Text"
-                >
-                  Ongoing
-                </span>
-              </div>
-              <div
-                class="MetaList"
-                data-test="DesignSystem-MetaList"
-              >
-                <span
-                  class="MetaList-item"
+                <button
+                  class="Button Button--regular Button--basic Button--iconAlign-left"
+                  data-test="DesignSystem-Button"
+                  tabindex="0"
                 >
                   <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
+                    class="Button-text"
                   >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Text
-                    </span>
+                    Action Section
                   </span>
-                  <i
-                    aria-hidden="true"
-                    class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
-                    data-test="DesignSystem-MetaList--rightSeperator"
-                    style="font-size: 8px; width: 8px;"
-                  >
-                    fiber_manual_record
-                  </i>
-                </span>
-                <span
-                  class="MetaList-item"
-                >
-                  <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
-                  >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Email
-                    </span>
-                  </span>
-                </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="pl-3"
+          class="pl-3 PageHeader-bottom"
         >
           <div
             data-test="DesignSystem-PageHeader--Tabs"
@@ -676,7 +656,7 @@ exports[`Navigation component
       data-test="DesignSystem-PageHeader"
     >
       <div
-        class="PageHeader-wrapper PageHeader-wrapper--withTabs"
+        class="PageHeader-wrapper PageHeader-wrapper--withTabs PageHeader-wrapper--level1 PageHeader-wrapper--withActions"
       >
         <div
           class="pl-6"
@@ -698,11 +678,7 @@ exports[`Navigation component
                 href="/Senders"
                 tabindex="0"
               >
-                <span
-                  class="Link-text Link-text--subtle"
-                >
-                  Senders
-                </span>
+                Senders
               </a>
               <span
                 class="Breadcrumbs-itemSeparator"
@@ -742,12 +718,10 @@ exports[`Navigation component
             class="PageHeader"
           >
             <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
+              class="PageHeader-row"
             >
               <div
-                class="Col Col--8 Col--m-8 Col--xl-8"
-                data-test="DesignSystem-Column"
+                class="PageHeader-group--title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -766,97 +740,93 @@ exports[`Navigation component
                     Sent
                   </span>
                 </div>
-              </div>
-              <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-PageHeader--Actions"
-              >
                 <div
-                  class="PageHeader-actionsWrapper"
+                  class="PageHeader-statusWrapper"
+                  data-test="DesignSystem-PageHeader--Status"
                 >
-                  <button
-                    class="Button Button--regular Button--basic Button--iconAlign-left"
-                    data-test="DesignSystem-Button"
-                    tabindex="0"
+                  <div
+                    class="StatusHint"
+                    data-test="DesignSystem-StatusHint"
                   >
                     <span
-                      class="Button-text"
+                      aria-label="default status"
+                      class="StatusHint-icon StatusHint--default mr-4"
+                      data-test="DesignSystem-StatusHint--Icon"
+                      role="img"
+                    />
+                    <span
+                      class="Text Text--default Text--medium Text--regular"
+                      data-test="DesignSystem-StatusHint--Text"
                     >
-                      Action Section
+                      Ongoing
                     </span>
-                  </button>
+                  </div>
+                  <div
+                    class="MetaList"
+                    data-test="DesignSystem-MetaList"
+                  >
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Text
+                        </span>
+                      </span>
+                      <i
+                        aria-hidden="true"
+                        class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
+                        data-test="DesignSystem-MetaList--rightSeperator"
+                        style="font-size: 8px; width: 8px;"
+                      >
+                        fiber_manual_record
+                      </i>
+                    </span>
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Email
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div
-              class="PageHeader-statusWrapper mb-3"
-              data-test="DesignSystem-PageHeader--Status"
-            >
               <div
-                class="StatusHint"
-                data-test="DesignSystem-StatusHint"
+                class="PageHeader-group--actions"
+                data-test="DesignSystem-PageHeader--Actions"
               >
-                <span
-                  aria-label="default status"
-                  class="StatusHint-icon StatusHint--default mr-4"
-                  data-test="DesignSystem-StatusHint--Icon"
-                  role="img"
-                />
-                <span
-                  class="Text Text--default Text--medium Text--regular"
-                  data-test="DesignSystem-StatusHint--Text"
-                >
-                  Ongoing
-                </span>
-              </div>
-              <div
-                class="MetaList"
-                data-test="DesignSystem-MetaList"
-              >
-                <span
-                  class="MetaList-item"
+                <button
+                  class="Button Button--regular Button--basic Button--iconAlign-left"
+                  data-test="DesignSystem-Button"
+                  tabindex="0"
                 >
                   <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
+                    class="Button-text"
                   >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Text
-                    </span>
+                    Action Section
                   </span>
-                  <i
-                    aria-hidden="true"
-                    class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
-                    data-test="DesignSystem-MetaList--rightSeperator"
-                    style="font-size: 8px; width: 8px;"
-                  >
-                    fiber_manual_record
-                  </i>
-                </span>
-                <span
-                  class="MetaList-item"
-                >
-                  <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
-                  >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Email
-                    </span>
-                  </span>
-                </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="pl-3"
+          class="pl-3 PageHeader-bottom"
         >
           <div
             class="PageHeader-navigationWrapper"
@@ -1021,12 +991,10 @@ exports[`Navigation component
             class="PageHeader"
           >
             <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
+              class="PageHeader-row"
             >
               <div
-                class="Col Col--12 Col--m-12 Col--xl-12"
-                data-test="DesignSystem-Column"
+                class="PageHeader-group--title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1044,7 +1012,7 @@ exports[`Navigation component
           </div>
         </div>
         <div
-          class="pl-3"
+          class="pl-3 PageHeader-bottom"
         >
           <div
             data-test="DesignSystem-PageHeader--Tabs"
@@ -1168,12 +1136,10 @@ exports[`Navigation component
             class="PageHeader"
           >
             <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
+              class="PageHeader-row PageHeader-row--withCenter"
             >
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-Column"
+                class="PageHeader-group--title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1188,7 +1154,7 @@ exports[`Navigation component
                 </div>
               </div>
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
+                class="PageHeader-group--center"
                 data-test="DesignSystem-PageHeader--CenterNav"
               >
                 <div
@@ -1269,19 +1235,147 @@ exports[`Navigation component
                   </div>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pl-3 PageHeader-bottom"
+        />
+      </div>
+      <hr
+        aria-orientation="horizontal"
+        class="Divider Divider--horizontal Divider--header"
+        data-test="DesignSystem-Divider"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      data-test="DesignSystem-PageHeader"
+    >
+      <div
+        class="PageHeader-wrapper PageHeader-wrapper--withActions"
+      >
+        <div
+          class="d-flex pl-6"
+        >
+          <div
+            class="PageHeader"
+          >
+            <div
+              class="PageHeader-row"
+            >
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-PageHeader--Actions"
+                class="PageHeader-group--title"
               >
                 <div
-                  class="PageHeader-actionsWrapper"
-                />
+                  class="PageHeader-titleWrapper"
+                  data-test="DesignSystem-PageHeader--Title"
+                >
+                  <h4
+                    class="Heading Heading--m Heading--default PageHeader-title"
+                    data-test="DesignSystem-Heading"
+                  >
+                    PageHeader title
+                  </h4>
+                </div>
+              </div>
+              <div
+                class="PageHeader-group--actions"
+                data-test="DesignSystem-PageHeader--Actions"
+              >
+                <button
+                  class="Button Button--regular Button--basic Button--iconAlign-left"
+                  data-test="DesignSystem-Button"
+                  tabindex="0"
+                >
+                  <span
+                    class="Button-text"
+                  >
+                    Action Section
+                  </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="pl-3"
+          class="pl-3 PageHeader-bottom"
+        />
+      </div>
+      <hr
+        aria-orientation="horizontal"
+        class="Divider Divider--horizontal Divider--header"
+        data-test="DesignSystem-Divider"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      data-test="DesignSystem-PageHeader"
+    >
+      <div
+        class="PageHeader-wrapper PageHeader-wrapper--level1"
+      >
+        <div
+          class="pl-6"
+          data-test="DesignSystem-PageHeader--Breadcrumbs"
+        >
+          <nav
+            aria-label="Breadcrumb"
+            class="Breadcrumbs"
+            data-test="DesignSystem-Breadcrumbs"
+          >
+            <div
+              class="Breadcrumbs-item"
+              data-test="DesignSystem-Breadcrumbs-item"
+            >
+              <a
+                aria-disabled="false"
+                class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
+                data-test="DesignSystem-Breadcrumbs-link"
+                href="/Senders"
+                tabindex="0"
+              >
+                Senders
+              </a>
+              <span
+                class="Breadcrumbs-itemSeparator"
+              >
+                /
+              </span>
+            </div>
+          </nav>
+        </div>
+        <div
+          class="d-flex pl-6"
+        >
+          <div
+            class="PageHeader"
+          >
+            <div
+              class="PageHeader-row"
+            >
+              <div
+                class="PageHeader-group--title"
+              >
+                <div
+                  class="PageHeader-titleWrapper"
+                  data-test="DesignSystem-PageHeader--Title"
+                >
+                  <h4
+                    class="Heading Heading--m Heading--default PageHeader-title"
+                    data-test="DesignSystem-Heading"
+                  >
+                    PageHeader title
+                  </h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pl-3 PageHeader-bottom"
         />
       </div>
       <hr
@@ -1305,12 +1399,61 @@ exports[`Navigation component
             class="PageHeader"
           >
             <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
+              class="PageHeader-row"
             >
               <div
-                class="Col Col--8 Col--m-8 Col--xl-8"
-                data-test="DesignSystem-Column"
+                class="PageHeader-group--title"
+              >
+                <div
+                  class="PageHeader-titleWrapper"
+                  data-test="DesignSystem-PageHeader--Title"
+                >
+                  <h4
+                    class="Heading Heading--m Heading--default PageHeader-title"
+                    data-test="DesignSystem-Heading"
+                  >
+                    PageHeader title
+                  </h4>
+                  <span
+                    class="Badge Badge--secondary"
+                    data-test="DesignSystem-Badge"
+                  >
+                    Sent
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pl-3 PageHeader-bottom"
+        />
+      </div>
+      <hr
+        aria-orientation="horizontal"
+        class="Divider Divider--horizontal Divider--header"
+        data-test="DesignSystem-Divider"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      data-test="DesignSystem-PageHeader"
+    >
+      <div
+        class="PageHeader-wrapper"
+      >
+        <div
+          class="d-flex pl-6"
+        >
+          <div
+            class="PageHeader"
+          >
+            <div
+              class="PageHeader-row"
+            >
+              <div
+                class="PageHeader-group--title"
               >
                 <div
                   class="PageHeader-titleWrapper"
@@ -1324,389 +1467,245 @@ exports[`Navigation component
                   </h4>
                 </div>
               </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pl-3 PageHeader-bottom"
+        />
+      </div>
+      <hr
+        aria-orientation="horizontal"
+        class="Divider Divider--horizontal Divider--header"
+        data-test="DesignSystem-Divider"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      data-test="DesignSystem-PageHeader"
+    >
+      <div
+        class="PageHeader-wrapper PageHeader-wrapper--level1"
+      >
+        <div
+          class="d-flex pl-6"
+        >
+          <div
+            class="mr-5 my-3"
+            data-test="DesignSystem-PageHeader--Button"
+          >
+            <button
+              class="Button Button--tiny Button--tinySquare Button--basic"
+              data-test="DesignSystem-Button"
+              tabindex="0"
+            >
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-PageHeader--Actions"
+                class="Button-icon"
+                data-test="DesignSystem-Button--Icon-Wrapper"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon"
+                  data-test="DesignSystem-Button--Icon"
+                  style="font-size: 14px; width: 14px;"
+                >
+                  arrow_back
+                </i>
+              </div>
+            </button>
+          </div>
+          <div
+            class="PageHeader"
+          >
+            <div
+              class="PageHeader-row"
+            >
+              <div
+                class="PageHeader-group--title"
               >
                 <div
-                  class="PageHeader-actionsWrapper"
+                  class="PageHeader-titleWrapper"
+                  data-test="DesignSystem-PageHeader--Title"
                 >
-                  <button
-                    class="Button Button--regular Button--basic Button--iconAlign-left"
-                    data-test="DesignSystem-Button"
-                    tabindex="0"
+                  <h4
+                    class="Heading Heading--m Heading--default PageHeader-title"
+                    data-test="DesignSystem-Heading"
+                  >
+                    PageHeader title
+                  </h4>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pl-3 PageHeader-bottom"
+        />
+      </div>
+      <hr
+        aria-orientation="horizontal"
+        class="Divider Divider--horizontal Divider--header"
+        data-test="DesignSystem-Divider"
+      />
+    </div>
+  </div>
+  <div>
+    <div
+      data-test="DesignSystem-PageHeader"
+    >
+      <div
+        class="PageHeader-wrapper PageHeader-wrapper--withTabs PageHeader-wrapper--level1 PageHeader-wrapper--withActions"
+      >
+        <div
+          class="pl-6"
+          data-test="DesignSystem-PageHeader--Breadcrumbs"
+        >
+          <nav
+            aria-label="Breadcrumb"
+            class="Breadcrumbs"
+            data-test="DesignSystem-Breadcrumbs"
+          >
+            <div
+              class="Breadcrumbs-item"
+              data-test="DesignSystem-Breadcrumbs-item"
+            >
+              <a
+                aria-disabled="false"
+                class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
+                data-test="DesignSystem-Breadcrumbs-link"
+                href="/Senders"
+                tabindex="0"
+              >
+                Senders
+              </a>
+              <span
+                class="Breadcrumbs-itemSeparator"
+              >
+                /
+              </span>
+            </div>
+          </nav>
+        </div>
+        <div
+          class="d-flex pl-6"
+        >
+          <div
+            class="mr-5 my-3"
+            data-test="DesignSystem-PageHeader--Button"
+          >
+            <button
+              class="Button Button--tiny Button--tinySquare Button--basic"
+              data-test="DesignSystem-Button"
+              tabindex="0"
+            >
+              <div
+                class="Button-icon"
+                data-test="DesignSystem-Button--Icon-Wrapper"
+              >
+                <i
+                  class="material-symbols material-symbols-rounded Icon"
+                  data-test="DesignSystem-Button--Icon"
+                  style="font-size: 14px; width: 14px;"
+                >
+                  arrow_back
+                </i>
+              </div>
+            </button>
+          </div>
+          <div
+            class="PageHeader"
+          >
+            <div
+              class="PageHeader-row PageHeader-row--withCenter"
+            >
+              <div
+                class="PageHeader-group--title"
+              >
+                <div
+                  class="PageHeader-titleWrapper"
+                  data-test="DesignSystem-PageHeader--Title"
+                >
+                  <h4
+                    class="Heading Heading--m Heading--default PageHeader-title"
+                    data-test="DesignSystem-Heading"
+                  >
+                    PageHeader title
+                  </h4>
+                  <span
+                    class="Badge Badge--secondary"
+                    data-test="DesignSystem-Badge"
+                  >
+                    Sent
+                  </span>
+                </div>
+                <div
+                  class="PageHeader-statusWrapper"
+                  data-test="DesignSystem-PageHeader--Status"
+                >
+                  <div
+                    class="StatusHint"
+                    data-test="DesignSystem-StatusHint"
                   >
                     <span
-                      class="Button-text"
+                      aria-label="default status"
+                      class="StatusHint-icon StatusHint--default mr-4"
+                      data-test="DesignSystem-StatusHint--Icon"
+                      role="img"
+                    />
+                    <span
+                      class="Text Text--default Text--medium Text--regular"
+                      data-test="DesignSystem-StatusHint--Text"
                     >
-                      Action Section
+                      Ongoing
                     </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pl-3"
-        />
-      </div>
-      <hr
-        aria-orientation="horizontal"
-        class="Divider Divider--horizontal Divider--header"
-        data-test="DesignSystem-Divider"
-      />
-    </div>
-  </div>
-  <div>
-    <div
-      data-test="DesignSystem-PageHeader"
-    >
-      <div
-        class="PageHeader-wrapper"
-      >
-        <div
-          class="pl-6"
-          data-test="DesignSystem-PageHeader--Breadcrumbs"
-        >
-          <nav
-            aria-label="Breadcrumb"
-            class="Breadcrumbs"
-            data-test="DesignSystem-Breadcrumbs"
-          >
-            <div
-              class="Breadcrumbs-item"
-              data-test="DesignSystem-Breadcrumbs-item"
-            >
-              <a
-                aria-disabled="false"
-                class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
-                data-test="DesignSystem-Breadcrumbs-link"
-                href="/Senders"
-                tabindex="0"
-              >
-                <span
-                  class="Link-text Link-text--subtle"
-                >
-                  Senders
-                </span>
-              </a>
-              <span
-                class="Breadcrumbs-itemSeparator"
-              >
-                /
-              </span>
-            </div>
-          </nav>
-        </div>
-        <div
-          class="d-flex pl-6"
-        >
-          <div
-            class="PageHeader"
-          >
-            <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
-            >
-              <div
-                class="Col Col--12 Col--m-12 Col--xl-12"
-                data-test="DesignSystem-Column"
-              >
-                <div
-                  class="PageHeader-titleWrapper"
-                  data-test="DesignSystem-PageHeader--Title"
-                >
-                  <h4
-                    class="Heading Heading--m Heading--default PageHeader-title"
-                    data-test="DesignSystem-Heading"
+                  </div>
+                  <div
+                    class="MetaList"
+                    data-test="DesignSystem-MetaList"
                   >
-                    PageHeader title
-                  </h4>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pl-3"
-        />
-      </div>
-      <hr
-        aria-orientation="horizontal"
-        class="Divider Divider--horizontal Divider--header"
-        data-test="DesignSystem-Divider"
-      />
-    </div>
-  </div>
-  <div>
-    <div
-      data-test="DesignSystem-PageHeader"
-    >
-      <div
-        class="PageHeader-wrapper"
-      >
-        <div
-          class="d-flex pl-6"
-        >
-          <div
-            class="PageHeader"
-          >
-            <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
-            >
-              <div
-                class="Col Col--12 Col--m-12 Col--xl-12"
-                data-test="DesignSystem-Column"
-              >
-                <div
-                  class="PageHeader-titleWrapper"
-                  data-test="DesignSystem-PageHeader--Title"
-                >
-                  <h4
-                    class="Heading Heading--m Heading--default PageHeader-title"
-                    data-test="DesignSystem-Heading"
-                  >
-                    PageHeader title
-                  </h4>
-                  <span
-                    class="Badge Badge--secondary"
-                    data-test="DesignSystem-Badge"
-                  >
-                    Sent
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pl-3"
-        />
-      </div>
-      <hr
-        aria-orientation="horizontal"
-        class="Divider Divider--horizontal Divider--header"
-        data-test="DesignSystem-Divider"
-      />
-    </div>
-  </div>
-  <div>
-    <div
-      data-test="DesignSystem-PageHeader"
-    >
-      <div
-        class="PageHeader-wrapper"
-      >
-        <div
-          class="d-flex pl-6"
-        >
-          <div
-            class="PageHeader"
-          >
-            <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
-            >
-              <div
-                class="Col Col--12 Col--m-12 Col--xl-12"
-                data-test="DesignSystem-Column"
-              >
-                <div
-                  class="PageHeader-titleWrapper"
-                  data-test="DesignSystem-PageHeader--Title"
-                >
-                  <h4
-                    class="Heading Heading--m Heading--default PageHeader-title"
-                    data-test="DesignSystem-Heading"
-                  >
-                    PageHeader title
-                  </h4>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pl-3"
-        />
-      </div>
-      <hr
-        aria-orientation="horizontal"
-        class="Divider Divider--horizontal Divider--header"
-        data-test="DesignSystem-Divider"
-      />
-    </div>
-  </div>
-  <div>
-    <div
-      data-test="DesignSystem-PageHeader"
-    >
-      <div
-        class="PageHeader-wrapper"
-      >
-        <div
-          class="d-flex pl-6"
-        >
-          <div
-            class="mr-5 my-3"
-            data-test="DesignSystem-PageHeader--Button"
-          >
-            <button
-              class="Button Button--tiny Button--tinySquare Button--basic"
-              data-test="DesignSystem-Button"
-              tabindex="0"
-            >
-              <div
-                class="Button-icon"
-                data-test="DesignSystem-Button--Icon-Wrapper"
-              >
-                <i
-                  class="material-symbols material-symbols-rounded Icon"
-                  data-test="DesignSystem-Button--Icon"
-                  style="font-size: 14px; width: 14px;"
-                >
-                  arrow_back
-                </i>
-              </div>
-            </button>
-          </div>
-          <div
-            class="PageHeader"
-          >
-            <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
-            >
-              <div
-                class="Col Col--12 Col--m-12 Col--xl-12"
-                data-test="DesignSystem-Column"
-              >
-                <div
-                  class="PageHeader-titleWrapper"
-                  data-test="DesignSystem-PageHeader--Title"
-                >
-                  <h4
-                    class="Heading Heading--m Heading--default PageHeader-title"
-                    data-test="DesignSystem-Heading"
-                  >
-                    PageHeader title
-                  </h4>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pl-3"
-        />
-      </div>
-      <hr
-        aria-orientation="horizontal"
-        class="Divider Divider--horizontal Divider--header"
-        data-test="DesignSystem-Divider"
-      />
-    </div>
-  </div>
-  <div>
-    <div
-      data-test="DesignSystem-PageHeader"
-    >
-      <div
-        class="PageHeader-wrapper PageHeader-wrapper--withTabs"
-      >
-        <div
-          class="pl-6"
-          data-test="DesignSystem-PageHeader--Breadcrumbs"
-        >
-          <nav
-            aria-label="Breadcrumb"
-            class="Breadcrumbs"
-            data-test="DesignSystem-Breadcrumbs"
-          >
-            <div
-              class="Breadcrumbs-item"
-              data-test="DesignSystem-Breadcrumbs-item"
-            >
-              <a
-                aria-disabled="false"
-                class="Link Link--tiny Link--subtle Breadcrumbs-link ellipsis--noWrap"
-                data-test="DesignSystem-Breadcrumbs-link"
-                href="/Senders"
-                tabindex="0"
-              >
-                <span
-                  class="Link-text Link-text--subtle"
-                >
-                  Senders
-                </span>
-              </a>
-              <span
-                class="Breadcrumbs-itemSeparator"
-              >
-                /
-              </span>
-            </div>
-          </nav>
-        </div>
-        <div
-          class="d-flex pl-6"
-        >
-          <div
-            class="mr-5 my-3"
-            data-test="DesignSystem-PageHeader--Button"
-          >
-            <button
-              class="Button Button--tiny Button--tinySquare Button--basic"
-              data-test="DesignSystem-Button"
-              tabindex="0"
-            >
-              <div
-                class="Button-icon"
-                data-test="DesignSystem-Button--Icon-Wrapper"
-              >
-                <i
-                  class="material-symbols material-symbols-rounded Icon"
-                  data-test="DesignSystem-Button--Icon"
-                  style="font-size: 14px; width: 14px;"
-                >
-                  arrow_back
-                </i>
-              </div>
-            </button>
-          </div>
-          <div
-            class="PageHeader"
-          >
-            <div
-              class="Row w-100"
-              data-test="DesignSystem-Row"
-            >
-              <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
-                data-test="DesignSystem-Column"
-              >
-                <div
-                  class="PageHeader-titleWrapper"
-                  data-test="DesignSystem-PageHeader--Title"
-                >
-                  <h4
-                    class="Heading Heading--m Heading--default PageHeader-title"
-                    data-test="DesignSystem-Heading"
-                  >
-                    PageHeader title
-                  </h4>
-                  <span
-                    class="Badge Badge--secondary"
-                    data-test="DesignSystem-Badge"
-                  >
-                    Sent
-                  </span>
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Text
+                        </span>
+                      </span>
+                      <i
+                        aria-hidden="true"
+                        class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
+                        data-test="DesignSystem-MetaList--rightSeperator"
+                        style="font-size: 8px; width: 8px;"
+                      >
+                        fiber_manual_record
+                      </i>
+                    </span>
+                    <span
+                      class="MetaList-item"
+                    >
+                      <span
+                        class="Meta"
+                        data-test="DesignSystem-MetaList--Meta"
+                      >
+                        <span
+                          class="Text Text--subtle Text--regular"
+                          data-test="DesignSystem-MetaList--MetaLabel"
+                        >
+                          Email
+                        </span>
+                      </span>
+                    </span>
+                  </div>
                 </div>
               </div>
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
+                class="PageHeader-group--center"
                 data-test="DesignSystem-PageHeader--CenterNav"
               >
                 <div
@@ -1745,95 +1744,26 @@ exports[`Navigation component
                 </div>
               </div>
               <div
-                class="Col Col--4 Col--m-4 Col--xl-4"
+                class="PageHeader-group--actions"
                 data-test="DesignSystem-PageHeader--Actions"
               >
-                <div
-                  class="PageHeader-actionsWrapper"
-                >
-                  <button
-                    class="Button Button--regular Button--basic Button--iconAlign-left"
-                    data-test="DesignSystem-Button"
-                    tabindex="0"
-                  >
-                    <span
-                      class="Button-text"
-                    >
-                      Action Section
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div
-              class="PageHeader-statusWrapper mb-3"
-              data-test="DesignSystem-PageHeader--Status"
-            >
-              <div
-                class="StatusHint"
-                data-test="DesignSystem-StatusHint"
-              >
-                <span
-                  aria-label="default status"
-                  class="StatusHint-icon StatusHint--default mr-4"
-                  data-test="DesignSystem-StatusHint--Icon"
-                  role="img"
-                />
-                <span
-                  class="Text Text--default Text--medium Text--regular"
-                  data-test="DesignSystem-StatusHint--Text"
-                >
-                  Ongoing
-                </span>
-              </div>
-              <div
-                class="MetaList"
-                data-test="DesignSystem-MetaList"
-              >
-                <span
-                  class="MetaList-item"
+                <button
+                  class="Button Button--regular Button--basic Button--iconAlign-left"
+                  data-test="DesignSystem-Button"
+                  tabindex="0"
                 >
                   <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
+                    class="Button-text"
                   >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Text
-                    </span>
+                    Action Section
                   </span>
-                  <i
-                    aria-hidden="true"
-                    class="material-symbols material-symbols-rounded Icon Icon--disabled MetaList-seperator"
-                    data-test="DesignSystem-MetaList--rightSeperator"
-                    style="font-size: 8px; width: 8px;"
-                  >
-                    fiber_manual_record
-                  </i>
-                </span>
-                <span
-                  class="MetaList-item"
-                >
-                  <span
-                    class="Meta"
-                    data-test="DesignSystem-MetaList--Meta"
-                  >
-                    <span
-                      class="Text Text--subtle Text--regular"
-                      data-test="DesignSystem-MetaList--MetaLabel"
-                    >
-                      Email
-                    </span>
-                  </span>
-                </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
         <div
-          class="pl-3"
+          class="pl-3 PageHeader-bottom"
         >
           <div
             data-test="DesignSystem-PageHeader--Tabs"

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -403,6 +403,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row PageHeader-row--withCenter"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -535,7 +536,6 @@ exports[`Navigation component
                 class="PageHeader-group--actions"
                 data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
-                style=""
               >
                 <button
                   class="Button Button--regular Button--basic Button--iconAlign-left"
@@ -1158,6 +1158,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row PageHeader-row--withCenter"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1636,6 +1637,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row PageHeader-row--withCenter"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1768,7 +1770,6 @@ exports[`Navigation component
                 class="PageHeader-group--actions"
                 data-group="actions"
                 data-test="DesignSystem-PageHeader--Actions"
-                style=""
               >
                 <button
                   class="Button Button--regular Button--basic Button--iconAlign-left"

--- a/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
+++ b/core/components/organisms/pageHeader/__tests__/__snapshots__/PageHeader.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -737,6 +738,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1012,6 +1014,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1285,6 +1288,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1379,6 +1383,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1422,6 +1427,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1471,6 +1477,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"
@@ -1537,6 +1544,7 @@ exports[`Navigation component
           >
             <div
               class="PageHeader-row"
+              style=""
             >
               <div
                 class="PageHeader-group--title"

--- a/core/components/organisms/pageHeader/utils.tsx
+++ b/core/components/organisms/pageHeader/utils.tsx
@@ -1,27 +1,15 @@
 import * as React from 'react';
-import classNames from 'classnames';
+import { Heading } from '@/index';
 import { navigationPositionType } from './PageHeader';
-import { Heading, Column } from '@/index';
 import styles from '@css/components/pageHeader.module.css';
 
-export const Status = (props: {
-  status: React.ReactNode;
-  meta: React.ReactNode;
-  navigationPosition: navigationPositionType;
-  navigation: React.ReactNode;
-  tabs: React.ReactNode;
-}) => {
-  const { status, meta, navigationPosition, navigation, tabs } = props;
-
-  const statusClasses = classNames({
-    [styles['PageHeader-statusWrapper']]: true,
-    'mb-3': (navigationPosition === 'bottom' && navigation) || tabs,
-  });
+export const Status = (props: { status: React.ReactNode; meta: React.ReactNode }) => {
+  const { status, meta } = props;
 
   return (
     <>
       {(status || meta) && (
-        <div className={statusClasses} data-test="DesignSystem-PageHeader--Status">
+        <div className={styles['PageHeader-statusWrapper']} data-test="DesignSystem-PageHeader--Status">
           {status}
           {meta}
         </div>
@@ -31,20 +19,32 @@ export const Status = (props: {
 };
 
 export const Action = (props: { actions: React.ReactNode; navigation: React.ReactNode; stepper: React.ReactNode }) => {
-  const { actions, navigation, stepper } = props;
+  const { actions } = props;
 
   return (
     <>
-      {actions ? (
-        <Column size="4" sizeXL="4" sizeM="4" data-test="DesignSystem-PageHeader--Actions">
-          <div className={styles['PageHeader-actionsWrapper']}>{actions}</div>
-        </Column>
-      ) : (
-        (navigation || stepper) && (
-          <Column size="4" sizeXL="4" sizeM="4" data-test="DesignSystem-PageHeader--Actions">
-            <div className={styles['PageHeader-actionsWrapper']}></div>
-          </Column>
-        )
+      {actions && (
+        <div className={styles['PageHeader-group--actions']} data-test="DesignSystem-PageHeader--Actions">
+          {actions}
+        </div>
+      )}
+    </>
+  );
+};
+
+export const CenterNav = (props: {
+  navigationPosition: navigationPositionType;
+  navigation: React.ReactNode;
+  stepper: React.ReactNode;
+}) => {
+  const { navigationPosition, navigation, stepper } = props;
+  const showCenterNav = (navigation || stepper) && navigationPosition === 'center';
+  return (
+    <>
+      {showCenterNav && (
+        <div className={styles['PageHeader-group--center']} data-test="DesignSystem-PageHeader--CenterNav">
+          <Nav {...props} />
+        </div>
       )}
     </>
   );
@@ -60,25 +60,6 @@ export const Nav = (props: { navigation: React.ReactNode; stepper: React.ReactNo
     <div className={styles['PageHeader-navigationWrapper']} data-test="DesignSystem-PageHeader--Nav">
       {navigation || stepper}
     </div>
-  );
-};
-
-export const CenterNav = (props: {
-  colSize: string;
-  breadcrumbs: React.ReactNode;
-  navigationPosition: navigationPositionType;
-  navigation: React.ReactNode;
-  stepper: React.ReactNode;
-}) => {
-  const { colSize, breadcrumbs, navigationPosition } = props;
-  return (
-    <>
-      {(!breadcrumbs || navigationPosition === 'center') && colSize === '4' && (
-        <Column size="4" sizeXL="4" sizeM="4" data-test="DesignSystem-PageHeader--CenterNav">
-          <Nav {...props} />
-        </Column>
-      )}
-    </>
   );
 };
 

--- a/core/components/organisms/pageHeader/utils.tsx
+++ b/core/components/organisms/pageHeader/utils.tsx
@@ -24,7 +24,11 @@ export const Action = (props: { actions: React.ReactNode; navigation: React.Reac
   return (
     <>
       {actions && (
-        <div className={styles['PageHeader-group--actions']} data-test="DesignSystem-PageHeader--Actions">
+        <div
+          className={styles['PageHeader-group--actions']}
+          data-group="actions"
+          data-test="DesignSystem-PageHeader--Actions"
+        >
           {actions}
         </div>
       )}
@@ -42,7 +46,11 @@ export const CenterNav = (props: {
   return (
     <>
       {showCenterNav && (
-        <div className={styles['PageHeader-group--center']} data-test="DesignSystem-PageHeader--CenterNav">
+        <div
+          className={styles['PageHeader-group--center']}
+          data-group="center"
+          data-test="DesignSystem-PageHeader--CenterNav"
+        >
           <Nav {...props} />
         </div>
       )}

--- a/core/components/organisms/pageHeader/utils.tsx
+++ b/core/components/organisms/pageHeader/utils.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import classNames from 'classnames';
 import { Heading } from '@/index';
 import { navigationPositionType } from './PageHeader';
 import styles from '@css/components/pageHeader.module.css';
@@ -40,18 +41,22 @@ export const CenterNav = (props: {
   navigationPosition: navigationPositionType;
   navigation: React.ReactNode;
   stepper: React.ReactNode;
+  ghost?: boolean;
 }) => {
-  const { navigationPosition, navigation, stepper } = props;
+  const { navigationPosition, navigation, stepper, ghost } = props;
   const showCenterNav = (navigation || stepper) && navigationPosition === 'center';
   return (
     <>
       {showCenterNav && (
         <div
-          className={styles['PageHeader-group--center']}
+          className={classNames(styles['PageHeader-group--center'], {
+            [styles['PageHeader-group--center--ghost']]: ghost,
+          })}
           data-group="center"
-          data-test="DesignSystem-PageHeader--CenterNav"
+          data-test={ghost ? undefined : 'DesignSystem-PageHeader--CenterNav'}
+          aria-hidden={ghost || undefined}
         >
-          <Nav {...props} />
+          <Nav navigation={navigation} stepper={stepper} />
         </div>
       )}
     </>

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -3969,6 +3969,7 @@ exports[`TS renders children 1`] = `
           >
             <div
               class="PageHeader-group--title"
+              data-group="title"
             >
               <div
                 class="PageHeader-titleWrapper"

--- a/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
+++ b/core/utils/__tests__/__snapshots__/TS.test.tsx.snap
@@ -3965,12 +3965,10 @@ exports[`TS renders children 1`] = `
           class="PageHeader"
         >
           <div
-            class="Row w-100"
-            data-test="DesignSystem-Row"
+            class="PageHeader-row"
           >
             <div
-              class="Col Col--12 Col--m-12 Col--xl-12"
-              data-test="DesignSystem-Column"
+              class="PageHeader-group--title"
             >
               <div
                 class="PageHeader-titleWrapper"
@@ -3987,9 +3985,6 @@ exports[`TS renders children 1`] = `
           </div>
         </div>
       </div>
-      <div
-        class="pl-3"
-      />
     </div>
     <hr
       aria-orientation="horizontal"

--- a/css/src/components/horizontalNav.module.css
+++ b/css/src/components/horizontalNav.module.css
@@ -27,8 +27,7 @@
   outline: none;
 }
 
-.HorizontalNav-menu--default:focus-visible,
-.HorizontalNav-menu--default:focus {
+.HorizontalNav-menu--default:focus-visible {
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-05);
 }
@@ -46,8 +45,7 @@
   box-shadow: 0 0 0 var(--border-width-05) var(--primary);
 }
 
-.HorizontalNav-menu--active:focus-visible,
-.HorizontalNav-menu--active:focus {
+.HorizontalNav-menu--active:focus-visible {
   background-color: var(--primary-ultra-light);
   outline: var(--border-width-05) solid var(--primary-focus);
   outline-offset: var(--spacing-10);
@@ -67,8 +65,7 @@
   color: var(--primary-darker);
 }
 
-.HorizontalNav-menu--active:focus-visible:active,
-.HorizontalNav-menu--active:focus:active {
+.HorizontalNav-menu--active:focus-visible:active {
   background-color: var(--primary-lighter);
   box-shadow: 0 0 0 var(--border-width-05) var(--primary-dark);
 }
@@ -104,8 +101,7 @@
   }
 
   .HorizontalNav-menu--active:active,
-  .HorizontalNav-menu--active:focus-visible:active,
-  .HorizontalNav-menu--active:focus:active {
+  .HorizontalNav-menu--active:focus-visible:active {
     border-color: Highlight;
     box-shadow: none;
   }

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -18,6 +18,11 @@
   margin-top: var(--spacing-30);
 }
 
+/* When tabs and bottom nav coexist, PageHeader-bottom owns the gap — prevent nav wrapper from doubling it */
+.PageHeader-wrapper--withTabs .PageHeader-bottom .PageHeader-navigationWrapper {
+  margin-top: 0;
+}
+
 .PageHeader .Row {
   width: 100%;
 }
@@ -108,7 +113,7 @@
 @media (min-width: 768px) {
   .PageHeader-row--withCenter {
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     align-items: center;
   }
 

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -78,13 +78,13 @@
 .PageHeader-row {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: start;
   width: 100%;
 }
 
 .PageHeader-group--title {
   flex: 1 1 auto;
-  min-width: 320px;
+  min-width: 0;
   order: 1;
 }
 
@@ -125,7 +125,7 @@
 
 .PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--title {
   flex: 1 1 auto;
-  min-width: 320px;
+  min-width: 0;
   order: 1;
 }
 

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -84,7 +84,7 @@
 
 .PageHeader-group--title {
   flex: 1 1 auto;
-  min-width: 0;
+  min-width: 320px;
   order: 1;
 }
 
@@ -103,6 +103,7 @@
 .PageHeader-group--actions {
   flex: 0 0 auto;
   display: flex;
+  flex-wrap: wrap;
   justify-content: flex-end;
   align-items: center;
   padding-left: var(--spacing-20);
@@ -113,7 +114,7 @@
 .PageHeader-row--withCenter {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  align-items: center;
+  align-items: start;
 }
 
 /* Center nav wraps to its own row */
@@ -124,7 +125,7 @@
 
 .PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--title {
   flex: 1 1 auto;
-  min-width: 0;
+  min-width: 320px;
   order: 1;
 }
 

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -41,16 +41,12 @@
 }
 
 .PageHeader-navigationWrapper {
-  margin-top: var(--spacing-10);
+  margin-top: var(--spacing-30);
 }
 
+/* Zero out the top-margin when nav sits inside the main row (center position) */
 .PageHeader .PageHeader-navigationWrapper {
-  justify-content: center;
-  align-items: center;
-  margin-top: 0 !important;
-  padding-right: var(--spacing-20);
-  padding-left: var(--spacing-20);
-  display: flex;
+  margin-top: 0;
 }
 
 .PageHeader-title {
@@ -63,4 +59,132 @@
   display: flex;
   justify-content: flex-end;
   padding-left: var(--spacing-20);
+}
+
+/* =====================================================
+   Responsive main header row
+   ===================================================== */
+
+/* Base: flex layout — used by all variants */
+.PageHeader-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  width: 100%;
+}
+
+.PageHeader-group--title {
+  flex: 1 1 auto;
+  min-width: 0;
+  order: 1;
+}
+
+/* Center-nav group — navigation/stepper in center position */
+.PageHeader-group--center {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 var(--spacing-20);
+  min-width: 0;
+  order: 2;
+}
+
+/* Actions / right-side group */
+.PageHeader-group--actions {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-left: var(--spacing-20);
+  order: 3;
+}
+
+/* ≥ 768 px (center-nav variant): CSS Grid for true 3-col centering */
+@media (min-width: 768px) {
+  .PageHeader-row--withCenter {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+  }
+
+  .PageHeader-row--withCenter .PageHeader-group--title {
+    flex: none;
+    order: unset;
+    align-self: center;
+  }
+
+  .PageHeader-row--withCenter .PageHeader-group--center {
+    flex: none;
+    order: unset;
+  }
+
+  .PageHeader-row--withCenter .PageHeader-group--actions {
+    flex: none;
+    order: unset;
+    justify-content: flex-end;
+  }
+}
+
+/* 576 px – 767 px: collision reflow — center nav drops to its own row */
+@media (max-width: 767px) {
+  .PageHeader-row--withCenter .PageHeader-group--title {
+    flex: 1 1 auto;
+    min-width: 0;
+    order: 1;
+  }
+
+  .PageHeader-row--withCenter .PageHeader-group--actions {
+    flex: 0 0 auto;
+    order: 2;
+  }
+
+  .PageHeader-row--withCenter .PageHeader-group--center {
+    flex: 0 0 100%;
+    order: 3;
+    justify-content: flex-start;
+    padding: var(--spacing-30) 0 0;
+  }
+}
+
+/* < 576 px: stacked — Title+Status → Actions → Nav */
+@media (max-width: 575px) {
+  .PageHeader-row .PageHeader-group--title,
+  .PageHeader-row--withCenter .PageHeader-group--title {
+    flex: 0 0 100%;
+    order: 1;
+  }
+
+  .PageHeader-row .PageHeader-group--actions,
+  .PageHeader-row--withCenter .PageHeader-group--actions {
+    flex: 0 0 100%;
+    order: 2;
+    padding-left: 0;
+    padding-top: var(--spacing-10);
+    justify-content: flex-start;
+  }
+
+  .PageHeader-row--withCenter .PageHeader-group--center {
+    flex: 0 0 100%;
+    order: 3;
+    justify-content: flex-start;
+    padding: var(--spacing-30) 0 0;
+  }
+}
+
+/* =====================================================
+   Level 1: inter-section spacing when right group wraps
+   ===================================================== */
+
+/* At < 576 px, the actions group sits between title and nav/stepper/tabs.
+   For level 1 headers that have actions, increase the gap to 12 px so all
+   three sections (title, actions, nav) have consistent breathing room. */
+@media (max-width: 575px) {
+  .PageHeader-wrapper--level1.PageHeader-wrapper--withActions .PageHeader-group--actions {
+    padding-top: var(--spacing-30);
+  }
+
+  .PageHeader-wrapper--level1.PageHeader-wrapper--withActions .PageHeader-bottom {
+    margin-top: var(--spacing-30);
+  }
 }

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -117,28 +117,12 @@
   align-items: start;
 }
 
-/* Center nav wraps to its own row */
-.PageHeader-row--withCenter.PageHeader-row--centerWrapped {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--title {
-  flex: 1 1 auto;
-  min-width: 0;
-  order: 1;
-}
-
-.PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--actions {
-  flex: 0 0 auto;
-  order: 2;
-}
-
-.PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--center {
-  flex: 0 0 100%;
-  order: 3;
-  justify-content: flex-start;
-  padding: var(--spacing-30) 0 0;
+/* Ghost: center nav stays in the grid for measurement but is invisible and out of flow.
+   Used when collision detection moves the nav to PageHeader-bottom. */
+.PageHeader-group--center--ghost {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 /* All stacked */
@@ -160,13 +144,6 @@
   padding-left: 0;
   padding-top: var(--spacing-10);
   justify-content: flex-start;
-}
-
-.PageHeader-row--withCenter.PageHeader-row--allStacked .PageHeader-group--center {
-  flex: 0 0 100%;
-  order: 3;
-  justify-content: flex-start;
-  padding: var(--spacing-30) 0 0;
 }
 
 /* =====================================================

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -107,6 +107,7 @@
   justify-content: flex-end;
   align-items: center;
   padding-left: var(--spacing-20);
+  row-gap: var(--spacing-30);
   order: 3;
 }
 

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -109,76 +109,63 @@
   order: 3;
 }
 
-/* ≥ 768 px (center-nav variant): CSS Grid for true 3-col centering */
-@media (min-width: 768px) {
-  .PageHeader-row--withCenter {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-    align-items: center;
-  }
-
-  .PageHeader-row--withCenter .PageHeader-group--title {
-    flex: none;
-    order: unset;
-    align-self: center;
-  }
-
-  .PageHeader-row--withCenter .PageHeader-group--center {
-    flex: none;
-    order: unset;
-  }
-
-  .PageHeader-row--withCenter .PageHeader-group--actions {
-    flex: none;
-    order: unset;
-    justify-content: flex-end;
-  }
+/* Default (full): CSS Grid for true 3-col centering */
+.PageHeader-row--withCenter {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
 }
 
-/* 576 px – 767 px: collision reflow — center nav drops to its own row */
-@media (max-width: 767px) {
-  .PageHeader-row--withCenter .PageHeader-group--title {
-    flex: 1 1 auto;
-    min-width: 0;
-    order: 1;
-  }
-
-  .PageHeader-row--withCenter .PageHeader-group--actions {
-    flex: 0 0 auto;
-    order: 2;
-  }
-
-  .PageHeader-row--withCenter .PageHeader-group--center {
-    flex: 0 0 100%;
-    order: 3;
-    justify-content: flex-start;
-    padding: var(--spacing-30) 0 0;
-  }
+/* Center nav wraps to its own row */
+.PageHeader-row--withCenter.PageHeader-row--centerWrapped {
+  display: flex;
+  flex-wrap: wrap;
 }
 
-/* < 576 px: stacked — Title+Status → Actions → Nav */
-@media (max-width: 575px) {
-  .PageHeader-row .PageHeader-group--title,
-  .PageHeader-row--withCenter .PageHeader-group--title {
-    flex: 0 0 100%;
-    order: 1;
-  }
+.PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--title {
+  flex: 1 1 auto;
+  min-width: 0;
+  order: 1;
+}
 
-  .PageHeader-row .PageHeader-group--actions,
-  .PageHeader-row--withCenter .PageHeader-group--actions {
-    flex: 0 0 100%;
-    order: 2;
-    padding-left: 0;
-    padding-top: var(--spacing-10);
-    justify-content: flex-start;
-  }
+.PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--actions {
+  flex: 0 0 auto;
+  order: 2;
+}
 
-  .PageHeader-row--withCenter .PageHeader-group--center {
-    flex: 0 0 100%;
-    order: 3;
-    justify-content: flex-start;
-    padding: var(--spacing-30) 0 0;
-  }
+.PageHeader-row--withCenter.PageHeader-row--centerWrapped .PageHeader-group--center {
+  flex: 0 0 100%;
+  order: 3;
+  justify-content: flex-start;
+  padding: var(--spacing-30) 0 0;
+}
+
+/* All stacked */
+.PageHeader-row--withCenter.PageHeader-row--allStacked {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.PageHeader-row--allStacked .PageHeader-group--title,
+.PageHeader-row--withCenter.PageHeader-row--allStacked .PageHeader-group--title {
+  flex: 0 0 100%;
+  order: 1;
+}
+
+.PageHeader-row--allStacked .PageHeader-group--actions,
+.PageHeader-row--withCenter.PageHeader-row--allStacked .PageHeader-group--actions {
+  flex: 0 0 100%;
+  order: 2;
+  padding-left: 0;
+  padding-top: var(--spacing-10);
+  justify-content: flex-start;
+}
+
+.PageHeader-row--withCenter.PageHeader-row--allStacked .PageHeader-group--center {
+  flex: 0 0 100%;
+  order: 3;
+  justify-content: flex-start;
+  padding: var(--spacing-30) 0 0;
 }
 
 /* =====================================================

--- a/css/src/components/pageHeader.module.css
+++ b/css/src/components/pageHeader.module.css
@@ -14,6 +14,10 @@
   border-bottom: none;
 }
 
+.PageHeader-wrapper--withTabs .PageHeader-bottom {
+  margin-top: var(--spacing-30);
+}
+
 .PageHeader .Row {
   width: 100%;
 }
@@ -186,5 +190,10 @@
 
   .PageHeader-wrapper--level1.PageHeader-wrapper--withActions .PageHeader-bottom {
     margin-top: var(--spacing-30);
+  }
+
+  /* Bottom section already handles the gap; prevent nav wrapper from doubling it */
+  .PageHeader-wrapper--level1.PageHeader-wrapper--withActions .PageHeader-bottom .PageHeader-navigationWrapper {
+    margin-top: 0;
   }
 }


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

Makes `PageHeader` responsive across all viewport sizes.

- Replaced the fixed `Row`/`Column` grid with a flex/CSS-grid layout so title, center nav, and actions reflow gracefully as the viewport narrows.
- Stacks the groups (title → actions → nav/tabs) on small screens with consistent vertical spacing.
- Keeps the center nav geometrically centred even when actions are wider than the title.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...

### Describe breaking changes, if any.

None.

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch