### PR TITLE
style(icons): change stroke color from #DD2D38 to #CA1822 in AISparkle

### DIFF
--- a/core/ai-components/AIButton/icons/AISparkle.svg
+++ b/core/ai-components/AIButton/icons/AISparkle.svg
@@ -1,7 +1,7 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M1 8C4.86599 8 8 4.86599 8 1C8 4.86599 11.134 8 15 8C11.134 8 8 11.134 8 15C8 11.134 4.86599 8 1 8Z" fill="url(#paint0_linear_64038_5798)"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M1 8C4.86599 8 8 4.86599 8 1C8 4.86599 11.134 8 15 8C11.134 8 8 11.134 8 15C8 11.134 4.86599 8 1 8Z" fill="url(#paint1_linear_64038_5798)" fill-opacity="0.24"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M1 8C4.86599 8 8 4.86599 8 1C8 4.86599 11.134 8 15 8C11.134 8 8 11.134 8 15C8 11.134 4.86599 8 1 8Z" fill="none" stroke="#DD2D38" stroke-width="1" vector-effect="non-scaling-stroke" clip-path="url(#clip0_64038_5798)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1 8C4.86599 8 8 4.86599 8 1C8 4.86599 11.134 8 15 8C11.134 8 8 11.134 8 15C8 11.134 4.86599 8 1 8Z" fill="none" stroke="#CA1822" stroke-width="1" vector-effect="non-scaling-stroke" clip-path="url(#clip0_64038_5798)"/>
 <defs>
 <clipPath id="clip0_64038_5798">
 <path fill-rule="evenodd" clip-rule="evenodd" d="M1 8C4.86599 8 8 4.86599 8 1C8 4.86599 11.134 8 15 8C11.134 8 8 11.134 8 15C8 11.134 4.86599 8 1 8Z"/>

--- a/core/ai-components/AIIconButton/icons/SaraIconDefault.tsx
+++ b/core/ai-components/AIIconButton/icons/SaraIconDefault.tsx
@@ -37,7 +37,7 @@ const SaraIconDefault = (props: SaraIconType) => {
         clipRule="evenodd"
         d="M6 0.75C6 3.6495 8.3505 6 11.25 6C8.3505 6 6 8.35051 6 11.25C6 8.35051 3.64949 6 0.75 6C3.64949 6 6 3.6495 6 0.75Z"
         fill="none"
-        stroke="#DD2D38"
+        stroke="#CA1822"
         strokeWidth="1"
         vectorEffect="non-scaling-stroke"
         clipPath="url(#clip0_54537_3573)"

--- a/core/ai-components/AIIconButton/icons/SaraIconDisabled.tsx
+++ b/core/ai-components/AIIconButton/icons/SaraIconDisabled.tsx
@@ -37,7 +37,7 @@ const SaraIconDisabled = (props: SaraIconType) => {
         clipRule="evenodd"
         d="M0.75 6C3.6495 6 6 3.6495 6 0.75C6 3.6495 8.35051 6 11.25 6C8.35051 6 6 8.35051 6 11.25C6 8.35051 3.6495 6 0.75 6Z"
         fill="none"
-        stroke="#DD2D38"
+        stroke="#CA1822"
         strokeWidth="1"
         vectorEffect="non-scaling-stroke"
         clipPath="url(#clip0_63015_2821)"


### PR DESCRIPTION
### What does this implement/fix? Explain your changes.

AI Sparkle outline made darker.

### Does this close any currently open issues?

...

### Any other comments?

...

### Dependent PRs/Commits

...


### Describe breaking changes, if any.

...

### Checklist

Check all those that are applicable and complete.

- [ ] Merged with latest `master` branch
