### PR TITLE
fix(Forms): accessible password show/hide toggle

### DIFF
--- a/core/components/patterns/forms/CreatePassword.story.tsx
+++ b/core/components/patterns/forms/CreatePassword.story.tsx
@@ -123,7 +123,8 @@ const customCode = `
                 onChange={this.onPasswordChange}
                 autocomplete="off"
                 actionIcon={(
-                  <Icon
+                  <Input.ActionButton
+                    className="p-3"
                     name={this.state.passwordVisible ? 'visibility' : 'visibility_off'}
                     aria-label={this.state.passwordVisible ? 'Hide password' : 'Show password'}
                     onClick={() => this.setState({ passwordVisible: !passwordVisible })}
@@ -141,7 +142,8 @@ const customCode = `
                 onChange={this.onConfirmPasswordChange}
                 autocomplete="off"
                 actionIcon={(
-                  <Icon
+                  <Input.ActionButton
+                    className="p-3"
                     name={this.state.confirmPasswordVisible ? 'visibility' : 'visibility_off'}
                     aria-label={this.state.confirmPasswordVisible ? 'Hide confirm password' : 'Show confirm password'}
                     onClick={() => this.setState({ confirmPasswordVisible: !confirmPasswordVisible })}

--- a/core/components/patterns/forms/basicForm.story.tsx
+++ b/core/components/patterns/forms/basicForm.story.tsx
@@ -84,8 +84,10 @@ const customCode = `
                 value={password}
                 onChange={this.onPasswordChange}
                 actionIcon={(
-                  <Icon
+                  <Input.ActionButton
+                    className="p-3"
                     name={this.state.passwordVisible ? 'visibility' : 'visibility_off'}
+                    aria-label={this.state.passwordVisible ? 'Hide password' : 'Show password'}
                     onClick={this.onActionClick}
                   />
                 )}


### PR DESCRIPTION
### What this fixes
The password **show/hide ("eye") button** in the Basic Form and Create Password examples was rendered as a plain icon. That caused two accessibility problems:

- it was only 16px — smaller than the 24px minimum needed to reliably tap/click it, and
- on the Basic Form it had no text label, so a screen reader couldn't tell the user what it does.

### The change
Swap the plain `Icon` for the design system's **`Input.ActionButton`** (with `className="p-3"`). This gives the control enough padding to meet the 24px minimum target size and carries a proper `aria-label` ("Show password" / "Hide password"). No component code changed — only the two example (story) files.

### Deque findings addressed
- [Basic Form — target does not meet minimum size/spacing](https://axeauditor.dequecloud.com/test-run/054f7146-b498-11f0-8651-138fa5c9f8c3/issue/e3746a12-b4d9-11f0-b07c-4f6d6c40b2f5)
- [Create Password — target does not meet minimum size/spacing](https://axeauditor.dequecloud.com/test-run/054f7146-b498-11f0-8651-138fa5c9f8c3/issue/520d422c-b8aa-11f0-b652-97a532e6ab50)
- [Basic Form — control has no accessible label](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/4168cca4-b4d9-11f0-b779-af87fbe40b3b)
- [Create Password — text alternative for image](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/2bf4eb16-b577-11f0-8d84-6f8e2e5d3a42)

### Files
- `core/components/patterns/forms/basicForm.story.tsx`
- `core/components/patterns/forms/CreatePassword.story.tsx`

### Testing
eslint, TypeScript, and Prettier pass on the changed files. These are live-code doc examples, so there are no snapshots to update.
