### PR TITLE
fix(Icon): announce aria-label instead of icon name (role=img)

### DIFF
--- a/core/components/atoms/icon/Icon.tsx
+++ b/core/components/atoms/icon/Icon.tsx
@@ -133,6 +133,16 @@ export const Icon = (props: IconProps) => {
 
   const baseProps = extractBaseProps(props);
 
+  const { onClick } = rest;
+  const ariaLabel = rest['aria-label'];
+  const ariaLabelledby = rest['aria-labelledby'];
+  // Non-interactive icons render the material-symbols ligature (e.g. `fiber_manual_record`) as their
+  // text content. Without a role, assistive tech treats the `<i>` as generic and ignores aria-label,
+  // announcing the ligature text instead. `role="img"` makes the aria-label/aria-labelledby the
+  // accessible name and suppresses the ligature text. Interactive icons already get `role="button"`
+  // from `useAccessibilityProps` and must stay unchanged.
+  const labelledNonInteractive = !onClick && (ariaLabel || ariaLabelledby);
+
   const mapper: Record<string, string> = {
     outline: 'outlined',
     sharp: 'outlined',
@@ -173,7 +183,14 @@ export const Icon = (props: IconProps) => {
     );
   }
   return (
-    <i data-test="DesignSystem-Icon" {...baseProps} className={iconClass} style={styles} {...accessibilityProps}>
+    <i
+      data-test="DesignSystem-Icon"
+      {...baseProps}
+      className={iconClass}
+      style={styles}
+      role={labelledNonInteractive ? 'img' : undefined}
+      {...accessibilityProps}
+    >
       {name}
     </i>
   );

--- a/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/core/components/atoms/label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`Label component - info prop tests
             aria-label="long information text"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
+            role="img"
             style="font-size: 12px; width: 12px;"
           >
             info
@@ -135,6 +136,7 @@ exports[`Label component - info prop tests
             aria-label="sample info"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
+            role="img"
             style="font-size: 12px; width: 12px;"
           >
             info
@@ -168,6 +170,7 @@ exports[`Label component - info prop tests
             aria-label="tooltip text"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center"
             data-test="DesignSystem-Label--Info"
+            role="img"
             style="font-size: 12px; width: 12px;"
           >
             info
@@ -263,6 +266,7 @@ exports[`Label component - size prop snapshot tests renders correctly with size=
             aria-label="Small label info"
             class="material-symbols material-symbols-rounded Icon Icon--subtle ml-3 cursor-pointer d-flex align-items-center mb-3-5"
             data-test="DesignSystem-Label--Info"
+            role="img"
             style="font-size: 12px; width: 12px;"
           >
             info

--- a/core/components/molecules/chat/chatBubble/__tests__/__snapshots__/ChatBubble.test.tsx.snap
+++ b/core/components/molecules/chat/chatBubble/__tests__/__snapshots__/ChatBubble.test.tsx.snap
@@ -348,6 +348,7 @@ Object {
             aria-label="Message sent successfully"
             class="material-symbols material-symbols-rounded Icon Icon--success ml-3"
             data-test="DesignSystem-OutgoingChatBubble-Status"
+            role="img"
             style="font-size: 16px; width: 16px;"
           >
             check_circle
@@ -431,6 +432,7 @@ Object {
           aria-label="Message sent successfully"
           class="material-symbols material-symbols-rounded Icon Icon--success ml-3"
           data-test="DesignSystem-OutgoingChatBubble-Status"
+          role="img"
           style="font-size: 16px; width: 16px;"
         >
           check_circle


### PR DESCRIPTION
### What this fixes
When an `Icon` has a text label (`aria-label`) but isn't a button, screen readers were reading out its raw material-symbols code name (e.g. "fiber_manual_record") instead of the label. A role-less `<i>` element has its `aria-label` ignored by assistive tech, so it falls back to announcing the visible ligature text.

Found via VoiceOver testing of the Create Password form: the "requirement met / not met" indicator icons (which already carry a correct `aria-label`) were being announced as "fiber_manual_record" / "check_circle" instead of "Requirement met/not met".

### The change
In `Icon`, when a non-interactive icon has an `aria-label` (or `aria-labelledby`), render it with `role="img"`. That makes the label the accessible name and stops the code name from being spoken. Interactive icons (with `onClick`) already get `role="button"` and are unchanged. One small behavioral change, matching the existing `role="img"` pattern already used by `StatusHint`.

This fixes the same issue for all labelled, non-interactive icons across the system (e.g. Label info icons, chat status icons, form requirement indicators) — not just the password form.

### Testing
- Full test suite passes (9474 tests). 5 snapshots updated to add the new `role="img"` on labelled icons (`Label`, `ChatBubble`).
- eslint, TypeScript, and Prettier pass.

_Note: this is a screen-reader-only change with no visual difference, so there is no meaningful visual before/after preview._
