### PR TITLE
fix(VerticalNav): announce selected item via aria-selected

### DIFF
--- a/core/components/organisms/verticalNav/MenuItem.tsx
+++ b/core/components/organisms/verticalNav/MenuItem.tsx
@@ -127,6 +127,7 @@ export const MenuItem = (props: MenuItemProps) => {
     href: menu.link,
     tabIndex: tabIndex !== undefined ? tabIndex : 0,
     role: 'treeitem',
+    'aria-selected': isActive,
     'aria-level': isChildren ? 2 : 1,
     'aria-expanded': hasSubmenu ? (isChildrenVisible ? 'true' : 'false') : undefined,
     'aria-label': !expanded && menu.icon ? menu.label : undefined,

--- a/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
+++ b/core/components/organisms/verticalNav/__tests__/__snapshots__/VerticalNav.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Vertical Navigation component
         <a
           aria-label="Patient 360"
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="patient_360"
           data-test="DesignSystem-VerticalNav--Item"
@@ -46,6 +47,7 @@ exports[`Vertical Navigation component
           aria-expanded="true"
           aria-label="Care Management and Resources"
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="care_management"
           data-test="DesignSystem-VerticalNav--Item"
@@ -72,6 +74,7 @@ exports[`Vertical Navigation component
         <a
           aria-label="Timeline"
           aria-level="2"
+          aria-selected="true"
           class="MenuItem MenuItem--vertical MenuItem--collapsed MenuItem--active color-primary-dark"
           data-menu-name="care_management.timeline"
           role="treeitem"
@@ -97,6 +100,7 @@ exports[`Vertical Navigation component
         <a
           aria-label="Care Plans"
           aria-level="2"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="care_management.care_plans"
           role="treeitem"
@@ -122,6 +126,7 @@ exports[`Vertical Navigation component
         <a
           aria-label="Episodes"
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed MenuItem--disabled color-inverse-lightest"
           data-disabled="true"
           data-menu-name="episodes"
@@ -150,6 +155,7 @@ exports[`Vertical Navigation component
           aria-expanded="false"
           aria-label="Risk"
           aria-level="1"
+          aria-selected="false"
           class="MenuItem MenuItem--vertical MenuItem--collapsed color-inverse"
           data-menu-name="risk"
           data-test="DesignSystem-VerticalNav--Item"
@@ -197,6 +203,7 @@ exports[`Vertical Navigation component
       </div>
       <a
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="patient_360"
         data-test="DesignSystem-VerticalNav--Item"
@@ -241,6 +248,7 @@ exports[`Vertical Navigation component
       <a
         aria-expanded="true"
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="care_management"
         data-test="DesignSystem-VerticalNav--Item"
@@ -274,6 +282,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         aria-level="2"
+        aria-selected="true"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--active MenuItem--activeExpanded MenuItem--activeExpandedRounded MenuItem--subMenu MenuItem--rounded pr-5 color-primary-dark"
         data-menu-name="care_management.timeline"
         role="treeitem"
@@ -299,6 +308,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         aria-level="2"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--subMenu MenuItem--rounded pr-5 color-inverse"
         data-menu-name="care_management.care_plans"
         role="treeitem"
@@ -324,6 +334,7 @@ exports[`Vertical Navigation component
       </a>
       <a
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--disabled MenuItem--rounded color-inverse-lightest"
         data-disabled="true"
         data-menu-name="episodes"
@@ -358,6 +369,7 @@ exports[`Vertical Navigation component
       <a
         aria-expanded="false"
         aria-level="1"
+        aria-selected="false"
         class="MenuItem MenuItem--vertical MenuItem--expanded MenuItem--expandedRounded MenuItem--rounded color-inverse"
         data-menu-name="risk"
         data-test="DesignSystem-VerticalNav--Item"


### PR DESCRIPTION
### What this fixes
In the vertical navigation, the active/selected item was indicated only by a highlight colour — screen readers had no way to know which item is selected. This adds an ARIA selected state so assistive tech announces the current item.

### The change
`MenuItem` renders each item as an ARIA `treeitem` inside a `role="tree"` container, so the correct selection state is `aria-selected`. Added `aria-selected={isActive}` (one line). `aria-current="page"` would be wrong here since the role is `treeitem`, not a link.

### Deque finding
- [Vertical Nav — selection not announced by screen reader](https://axeauditor.dequecloud.com/test-run/aa8a8272-ae0d-11f0-a2d2-5f492969aa5d/issue/5ea7b7bc-d699-11f0-9640-6fdf069e0c81)

### Testing
Full VerticalNav suite passes; 2 snapshots updated to include the new attribute. eslint / TypeScript / Prettier pass.

_Screen-reader-only change — no visual difference._
