### PR TITLE
fix(Dropdown): hide decorative option icons from screen readers

### DIFF
--- a/core/components/atoms/dropdown/option/IconOption.tsx
+++ b/core/components/atoms/dropdown/option/IconOption.tsx
@@ -52,7 +52,9 @@ const IconOption = (props: OptionTypeProps) => {
       aria-selected={!menu ? selected : undefined}
     >
       {/* eslint-enable  */}
-      {icon && <Icon className={IconClass} data-test={`${dataTest}--Icon`} name={icon} type={iconType} />}
+      {icon && (
+        <Icon className={IconClass} data-test={`${dataTest}--Icon`} name={icon} type={iconType} aria-hidden={true} />
+      )}
       <div className={styles['Option-label']}>
         <Text className={textClassName} color={color}>
           {label}

--- a/core/components/atoms/dropdown/option/IconWithMetaOption.tsx
+++ b/core/components/atoms/dropdown/option/IconWithMetaOption.tsx
@@ -54,7 +54,15 @@ const IconWithMetaOption = (props: OptionTypeProps) => {
       aria-selected={!menu ? selected : undefined}
     >
       {/* eslint-enable  */}
-      {icon && <Icon data-test={`${dataTest}--Icon`} className={IconClass} name={icon} appearance={appearance} />}
+      {icon && (
+        <Icon
+          data-test={`${dataTest}--Icon`}
+          className={IconClass}
+          name={icon}
+          appearance={appearance}
+          aria-hidden={true}
+        />
+      )}
       <div className={styles['Option-label']}>
         <Text className={textClassName} color={color}>
           {label}


### PR DESCRIPTION
### What this fixes
In dropdown/menu options that pair an icon with a text label (for example the Table column menu's sort / pin / hide options), screen readers were reading the icon's raw code name (e.g. "unfold_more") as part of the option. The icon is decorative — the text label already names the option — so it should be hidden from assistive tech.

### The change
Added `aria-hidden` to the decorative leading `Icon` in the `IconOption` and `IconWithMetaOption` dropdown variants. The visible text label is unchanged and remains the accessible name.

### Deque finding
- [Column menu option announces icon name](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/6753e9cc-b631-11f0-a727-4712e01dc2e6)

### Testing
Dropdown suite passes (111 tests, 27 snapshots, no changes needed). eslint / TypeScript / Prettier pass.

_Screen-reader-only change — no visual difference._
