### PR TITLE
fix(Forms): convey Inline Form gender selection via aria-pressed

### DIFF
--- a/core/components/patterns/forms/InlineForm.story.tsx
+++ b/core/components/patterns/forms/InlineForm.story.tsx
@@ -73,10 +73,10 @@ const customCode = `
                 <div className="mr-6 mb-6">
                   <Label withInput={true}>Gender</Label>
                   <div className="d-flex" role="group" aria-label="Gender">
-                    <Button className="mr-3" onClick={() => this.onChange('Male', 'gender')}>Male</Button>
-                    <Button className="mr-3" onClick={() => this.onChange('Female', 'gender')}>Female</Button>
-                    <Button className="mr-3" onClick={() => this.onChange('Other', 'gender')}>Other</Button>
-                    <Button onClick={() => this.onChange('Unknown', 'gender')}>Unknown</Button>
+                    <Button className="mr-3" selected={this.state.data.gender === 'Male'} onClick={() => this.onChange('Male', 'gender')}>Male</Button>
+                    <Button className="mr-3" selected={this.state.data.gender === 'Female'} onClick={() => this.onChange('Female', 'gender')}>Female</Button>
+                    <Button className="mr-3" selected={this.state.data.gender === 'Other'} onClick={() => this.onChange('Other', 'gender')}>Other</Button>
+                    <Button selected={this.state.data.gender === 'Unknown'} onClick={() => this.onChange('Unknown', 'gender')}>Unknown</Button>
                   </div>
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>


### PR DESCRIPTION
### What this fixes
In the Inline Form demo, the Gender option buttons (Male / Female / Other / Unknown) didn't tell screen readers which one was selected — and had no selected styling either.

### The change
Added a `selected` prop to each Gender `Button`, driven by the form's state, so the chosen option renders `aria-pressed` (and gets the design system's selected styling). Story-only change.

### Deque finding
- [Inline Form — button pressed state not conveyed](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/408c73b4-b66c-11f0-b423-e7f3b5b0ac0d)

### Note
This single-select group is represented as toggle buttons with `aria-pressed`, which closes the finding. A radio group would be a more semantically complete pattern, but that's a larger redesign — flagged for future consideration.

### Testing
eslint / TypeScript / Prettier pass. (Live-code doc story — no snapshots.)

### Preview
- **Inline Form** — [Before (prod)](https://mds.innovaccer.com/?path=/docs/patterns-forms-inline-form--inline-form) · [After (this PR)](https://60be48651a7b640049c35704-housimrwac.chromatic.com/?path=/docs/patterns-forms-inline-form--inline-form)
