### PR TITLE
fix(Forms): wire labels and distinct option names on Time Period & Stepper forms

### DIFF
--- a/core/components/patterns/forms/StepperForm.story.tsx
+++ b/core/components/patterns/forms/StepperForm.story.tsx
@@ -109,11 +109,11 @@ const customCode = `
                   The system automatically creates collection for multiple support.
                 </Text>
                 <div className="mt-4">
-                  <Label withInput={true}>Input Collection 1</Label>
+                  <Label withInput={true} htmlFor="stepper-input-collection-1">Input Collection 1</Label>
                   <Select
                     width="100%"
                     className="mb-4"
-                    triggerOptions={{ placeholder: "Input Collection 1", 'aria-label': "Input Collection 1" }}
+                    triggerOptions={{ id: "stepper-input-collection-1", placeholder: "Input Collection 1", 'aria-label': "Input Collection 1" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection1')}
                   >
                     <Select.List>
@@ -126,10 +126,10 @@ const customCode = `
                       })}
                     </Select.List>
                   </Select>
-                  <Label withInput={true}>Input Collection 2</Label>
+                  <Label withInput={true} htmlFor="stepper-input-collection-2">Input Collection 2</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ placeholder: "Input Collection 2", 'aria-label': "Input Collection 2" }}
+                    triggerOptions={{ id: "stepper-input-collection-2", placeholder: "Input Collection 2", 'aria-label': "Input Collection 2" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection2')}
                   >
                     <Select.List>
@@ -151,10 +151,10 @@ const customCode = `
                   The system automatically creates collection for multiple support.
                 </Text>
                 <div className="mt-6">
-                  <Label withInput={true}>Destination Collection</Label>
+                  <Label withInput={true} htmlFor="stepper-destination-collection">Destination Collection</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ placeholder: "Select Destination", 'aria-label': "Destination Collection" }}
+                    triggerOptions={{ id: "stepper-destination-collection", placeholder: "Select Destination", 'aria-label': "Destination Collection" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection')}
                   >
                     <Select.List>
@@ -180,10 +180,10 @@ const customCode = `
                   />
                 </div>
                 <div className="mt-6">
-                  <Label withInput={true} required>Retention Period</Label>
+                  <Label withInput={true} required htmlFor="stepper-retention-period">Retention Period</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ 'aria-label': "Retention Period" }}
+                    triggerOptions={{ id: "stepper-retention-period", 'aria-label': "Retention Period" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'retention')}
                   >
                     <Select.List>
@@ -196,10 +196,10 @@ const customCode = `
                       })}
                     </Select.List>
                   </Select>
-                  <Label className="mt-6" withInput={true}>Visibility Clarification</Label>
+                  <Label className="mt-6" withInput={true} htmlFor="stepper-visibility-clarification">Visibility Clarification</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ 'aria-label': "Visibility Clarification" }}
+                    triggerOptions={{ id: "stepper-visibility-clarification", 'aria-label': "Visibility Clarification" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'clarification')}
                   >
                     <Select.List>
@@ -225,9 +225,9 @@ const customCode = `
                   </div>
                 </div>
                 <div className="mt-6">
-                  <Label withInput={true} required>Mode</Label>
+                  <Label withInput={true} required htmlFor="stepper-mode">Mode</Label>
                   <Select
-                    triggerOptions={{ 'aria-label': "Mode" }}
+                    triggerOptions={{ id: "stepper-mode", 'aria-label': "Mode" }}
                     onSelect={(option) => {
                       this.setState({
                         configuration: { ...this.state.configuration, mode: option.value }

--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -31,13 +31,13 @@ const customCode = `
             <Heading size="s" className="mb-2">Population Filter</Heading>
             <div className="d-flex mt-5 mb-4">
               <div className="mr-6" style={{ width: 'var(--spacing-440)' }}>
-                <Label withInput={true}>Region</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Region" }}>
+                <Label withInput={true} htmlFor="time-period-region-select">Region</Label>
+                <Select width="100%" triggerOptions={{ id: "time-period-region-select", 'aria-label': "Region" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
-                        <Select.Option key={key} option={{ label: item.label, value: item.value }}> 
-                          {item.label} 
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }} aria-label={\`Region option \${item.label}\`}>
+                          {item.label}
                         </Select.Option>
                       )
                     })}
@@ -45,13 +45,13 @@ const customCode = `
                 </Select>
               </div>
               <div style={{ width: 'var(--spacing-640)' }}>
-                <Label withInput={true}>Organization</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Organization" }}>
+                <Label withInput={true} htmlFor="time-period-organization-select">Organization</Label>
+                <Select width="100%" triggerOptions={{ id: "time-period-organization-select", 'aria-label': "Organization" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
-                        <Select.Option key={key} option={{ label: item.label, value: item.value }}> 
-                          {item.label} 
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }} aria-label={\`Organization option \${item.label}\`}>
+                          {item.label}
                         </Select.Option>
                       )
                     })}


### PR DESCRIPTION
### What this fixes
Two form demos had controls whose visible labels weren't programmatically linked, and the Time Period selects announced every option as the generic "option item" (so screen-reader users heard the same meaningless name for all choices).

### Changes
- **Time Period Form** — wired the Region and Organization selects to their visible `<Label>` (`htmlFor`/`id`); gave each select option a real, distinct accessible name (was defaulting to "option item").
- **Stepper Form** — wired `htmlFor`/`id` for the 6 controls whose visible labels weren't linked (Input Collection 1/2, Destination Collection, Retention Period, Visibility, Mode).

### Deque findings
- Time Period — [9d14035a](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/9d14035a-b666-11f0-b4d4-8b70bfcdccb7), [a2112acc](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/a2112acc-b666-11f0-992e-07b5028d022e), [968fa39e](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/968fa39e-b667-11f0-a45f-230a778c3f54), [5a878d94](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/5a878d94-b667-11f0-abf2-c3fc1a4fa914)
- Stepper — [9e11ab30](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/9e11ab30-b66c-11f0-a2f5-cbe1a3e44436), [a0e57e7c](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/a0e57e7c-b66c-11f0-974a-d727d59caede), [3dfdd1c4](https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/3dfdd1c4-b671-11f0-ae48-5752b70171ce)

### Note
The related finding "Label is not persistent" (319945be) could not be reproduced — every Stepper field already renders a persistent visible label; likely already fixed on develop. Also, the "option item" default originates in the `SelectOption` component itself — a systemic fix there could remove the need for per-story option labels (tracked separately for discussion).

### Testing
eslint / TypeScript / Prettier pass. (Live-code doc stories — no snapshots.) Screen-reader-only change.
