### PR TITLE
fix(Forms): add placeholder to Stepper regex textarea

### DIFF
--- a/core/components/patterns/forms/StepperForm.story.tsx
+++ b/core/components/patterns/forms/StepperForm.story.tsx
@@ -249,6 +249,7 @@ const customCode = `
                   <Label withInput={true} required htmlFor="regex-input">Regex</Label>
                   <Textarea
                     id="regex-input"
+                    placeholder="Enter regex pattern"
                     rows={3}
                     onChange={(e, value) => {
                       this.setState({


### PR DESCRIPTION
### What this fixes
The "Regex" field in the Stepper Form demo was a textarea with no placeholder text, so it gave no hint about what to enter. Every other text field/textarea across the design system's examples has a placeholder — this was the one gap.

### The change
Added `placeholder="Enter regex pattern"` to the Regex textarea in the Stepper Form demo. Story-only change, one line.

### Testing
eslint / TypeScript / Prettier pass. (Live-code doc story — no snapshots.)

### Preview
- **Stepper Form** — [Before (prod)](https://mds.innovaccer.com/?path=/docs/patterns-forms-stepper-form--stepper-form) · [After](https://60be48651a7b640049c35704-mivshthswf.chromatic.com/?path=/docs/patterns-forms-stepper-form--stepper-form)
