### PR TITLE
fix(Select): accessible option names and decorative icons

### DIFF
--- a/core/components/organisms/select/SelectOption.tsx
+++ b/core/components/organisms/select/SelectOption.tsx
@@ -138,7 +138,7 @@ export const SelectOption = (props: SelectOptionProps) => {
       role="option"
       onClick={onClickHandler}
       aria-selected={checked}
-      aria-label={props['aria-label'] || 'option item'}
+      aria-label={props['aria-label'] || optionLabelString || undefined}
       onKeyDown={(event) => onKeyDownHandler(event)}
       onFocus={(e) => setFocusedOption?.(e.currentTarget)}
       selected={checked}

--- a/core/components/organisms/select/SelectTrigger.tsx
+++ b/core/components/organisms/select/SelectTrigger.tsx
@@ -211,6 +211,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
                 name={icon}
                 type={iconType}
                 size={iconSize}
+                aria-hidden={true}
               />
             )}
             {value && (
@@ -233,7 +234,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
           </button>
         )}
 
-        <Icon appearance={buttonDisabled} name={iconName} type={iconType} />
+        <Icon appearance={buttonDisabled} name={iconName} type={iconType} aria-hidden={true} />
       </button>
     </Tooltip>
   );

--- a/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
+++ b/core/components/organisms/select/__test__/__snapshots__/Select.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -83,6 +84,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -131,6 +133,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -179,6 +182,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -227,6 +231,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -275,6 +280,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -323,6 +329,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -371,6 +378,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -419,6 +427,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -467,6 +476,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -515,6 +525,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -563,6 +574,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -611,6 +623,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -659,6 +672,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -707,6 +721,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -755,6 +770,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -803,6 +819,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -851,6 +868,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -899,6 +917,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -947,6 +966,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -995,6 +1015,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1043,6 +1064,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1091,6 +1113,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1139,6 +1162,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1187,6 +1211,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1235,6 +1260,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1283,6 +1309,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1331,6 +1358,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1379,6 +1407,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1427,6 +1456,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1475,6 +1505,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1523,6 +1554,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1571,6 +1603,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1619,6 +1652,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1667,6 +1701,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1715,6 +1750,7 @@ exports[`Select List component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1763,6 +1799,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1811,6 +1848,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1859,6 +1897,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1907,6 +1946,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -1955,6 +1995,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2003,6 +2044,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2051,6 +2093,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2099,6 +2142,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2147,6 +2191,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2195,6 +2240,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2243,6 +2289,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2291,6 +2338,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2339,6 +2387,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2387,6 +2436,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2435,6 +2485,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2483,6 +2534,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2531,6 +2583,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2579,6 +2632,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2627,6 +2681,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2675,6 +2730,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2723,6 +2779,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2771,6 +2828,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2819,6 +2877,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2867,6 +2926,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2915,6 +2975,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -2963,6 +3024,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3011,6 +3073,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3059,6 +3122,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3107,6 +3171,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3155,6 +3220,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3203,6 +3269,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3251,6 +3318,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3299,6 +3367,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3347,6 +3416,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3395,6 +3465,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3443,6 +3514,7 @@ exports[`Select Option component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3491,6 +3563,7 @@ exports[`Select component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"
@@ -3539,6 +3612,7 @@ exports[`Select component snapshots
             </span>
           </div>
           <i
+            aria-hidden="true"
             class="material-symbols material-symbols-rounded Icon Icon--default"
             data-test="DesignSystem-Icon"
             style="font-size: 16px; width: 16px;"


### PR DESCRIPTION
### What this fixes
Two screen-reader problems on the Select component:
1. **Every option was announced as "option item"** instead of its real text. The component hard-coded `aria-label="option item"` as a fallback, which *overrides* the visible option label — so a screen-reader user picking from a list heard "option item, option item, option item…" instead of the actual choices.
2. **The dropdown chevron (and an optional leading icon) were read aloud.** These are purely decorative, so the icon's underlying name (e.g. "keyboard_arrow_down") was being announced as if it were content.

### What changed
- `SelectOption`: the option's accessible name now falls back to its **own visible label text** (and only to nothing if there's no string label), instead of the literal "option item". Consumer-supplied `aria-label` still takes precedence. As a bonus this makes the visible text the accessible name, so any decorative icon inside an option no longer leaks its ligature into the announcement.
- `SelectTrigger`: added `aria-hidden` to the decorative expand/collapse **chevron** and to the optional **leading icon**. (The clear-selection button was already correct — it has its own `aria-label` and a hidden icon.)

No visual change. This is a shared component, so it improves **every** Select across the system at once and removes the need for per-story `aria-label` workarounds.

### Deque issues
Select option naming (screen-reader name/role/value):
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/382a9f0e
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/08c36074
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/46e46762
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/21acc2be

### Testing
`lint`, `types`, `prettier` pass. Select + Table Jest suites pass; snapshots regenerated (only the chevron `aria-hidden` appears in snapshots — the option-label and leading-icon paths aren't covered by existing snapshot fixtures). Before/After Storybook links to follow from the Chromatic build.