### PR TITLE
fix(InputMask): honor consumer autoComplete

### DIFF
--- a/core/common.type.tsx
+++ b/core/common.type.tsx
@@ -17,7 +17,7 @@ export type FileStatus = 'uploading' | 'completed' | 'error';
 export type FooterOptions = {
   actions: OverlayFooterProps['actions'];
 };
-export type AutoComplete = 'on' | 'off';
+export type AutoComplete = NonNullable<React.InputHTMLAttributes<HTMLInputElement>['autoComplete']>;
 export type NumberRange = [number, number];
 export type ChangeEvent = React.ChangeEvent<HTMLInputElement>;
 

--- a/core/components/molecules/inputMask/InputMask.tsx
+++ b/core/components/molecules/inputMask/InputMask.tsx
@@ -96,6 +96,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
     className,
     helpText,
     label,
+    autoComplete = 'off',
     'aria-describedby': ariaDescribedBy,
     ...rest
   } = props;
@@ -421,7 +422,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
         onClear={!isValueEqualPlaceholder ? onClearHandler : undefined}
         onBlur={onBlurHandler}
         onPaste={onPasteHandler}
-        autoComplete={'off'}
+        autoComplete={autoComplete}
         ref={ref}
         aria-describedby={resolvedDescribedBy}
       />


### PR DESCRIPTION
### What this fixes
Masked inputs (date fields, phone, etc.) built on `InputMask` — including `DatePicker`/`DateRangePicker` — could never receive an `autocomplete` token. Even when a consumer passed one, `InputMask` hard-coded `autoComplete="off"` on the underlying input, so the token never reached the DOM. That blocks WCAG 1.3.5 (Identify Input Purpose): e.g. a Date-of-Birth field can't advertise itself as `bday`, so assistive tech / browser autofill can't identify its purpose.

### Root cause
`InputMask` spread the consumer's props and then set `autoComplete="off"` *after* the spread, so the hard-coded value always won.

### What changed (2 lines)
`autoComplete` is now read from props with a default of `"off"`, and that value is used on the input. So:
- No token passed → still `"off"` (unchanged default behavior — no regression for existing masked inputs).
- A token passed (e.g. `autoComplete="bday"`) → it now reaches the input and satisfies input-purpose.

### Follow-up unblocked
This re-enables the Date-of-Birth autocomplete token that had to be removed from the Create User form PR (#3121) because it was a no-op.

### Deque
- WCAG 1.3.5 input purpose on masked/date fields (surfaced via Codex review on #3121; part of the Create User DOB finding `a42f85ca`).

### Testing
`lint`, `types`, `prettier` pass. InputMask + DatePicker + DateRangePicker Jest suites pass (250 tests, 160 snapshots) with **no snapshot changes** — the default remains `"off"`.