### PR TITLE
fix(DatePicker): accessible name and calendar focus management

### DIFF
--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -186,6 +186,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
     readOnly,
     iconType,
     'aria-invalid': ariaInvalid,
+    'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     tabIndex: tabIndexProp,
     ...rest
@@ -219,11 +220,43 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
     }
   }, [type]);
 
-  const resolvedClearButtonAriaLabel = props['aria-label']
-    ? `Clear ${props['aria-label']}`
-    : placeholder
-    ? `Clear ${placeholder}`
-    : 'Clear input';
+  const [resolvedClearButtonAriaLabel, setResolvedClearButtonAriaLabel] = React.useState(() => {
+    if (ariaLabel) return `Clear ${ariaLabel}`;
+    if (placeholder) return `Clear ${placeholder}`;
+    return 'Clear input';
+  });
+
+  React.useLayoutEffect(() => {
+    if (ariaLabel) {
+      setResolvedClearButtonAriaLabel(`Clear ${ariaLabel}`);
+      return;
+    }
+
+    if (ariaLabelledBy && typeof document !== 'undefined') {
+      const labelledByText = ariaLabelledBy
+        .split(/\s+/)
+        .map((id) => document.getElementById(id)?.textContent?.trim())
+        .filter(Boolean)
+        .join(' ');
+      if (labelledByText) {
+        setResolvedClearButtonAriaLabel(`Clear ${labelledByText}`);
+        return;
+      }
+    }
+
+    const inputId = rest.id as string | undefined;
+    if (inputId && typeof document !== 'undefined') {
+      const escapedId = typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(inputId) : inputId;
+      const associatedLabel = document.querySelector(`label[for="${escapedId}"]`);
+      const associatedLabelText = associatedLabel?.textContent?.trim();
+      if (associatedLabelText) {
+        setResolvedClearButtonAriaLabel(`Clear ${associatedLabelText}`);
+        return;
+      }
+    }
+
+    setResolvedClearButtonAriaLabel(placeholder ? `Clear ${placeholder}` : 'Clear input');
+  }, [ariaLabel, ariaLabelledBy, rest.id, placeholder]);
 
   const baseProps = extractBaseProps(props);
 
@@ -318,6 +351,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
             ? [inlineLabelId, ariaLabelledBy].filter(Boolean).join(' ')
             : ariaLabelledBy || undefined
         }
+        aria-label={ariaLabel}
         aria-describedby={
           [rest['aria-describedby'], inlineLabel && !ariaLabelledBy ? inlineLabelId : undefined]
             .filter(Boolean)

--- a/core/components/atoms/input/Input.tsx
+++ b/core/components/atoms/input/Input.tsx
@@ -221,17 +221,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
   }, [type]);
 
   const [resolvedClearButtonAriaLabel, setResolvedClearButtonAriaLabel] = React.useState(() => {
-    if (ariaLabel) return `Clear ${ariaLabel}`;
     if (placeholder) return `Clear ${placeholder}`;
     return 'Clear input';
   });
 
   React.useLayoutEffect(() => {
-    if (ariaLabel) {
-      setResolvedClearButtonAriaLabel(`Clear ${ariaLabel}`);
-      return;
-    }
-
     if (ariaLabelledBy && typeof document !== 'undefined') {
       const labelledByText = ariaLabelledBy
         .split(/\s+/)
@@ -242,6 +236,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forw
         setResolvedClearButtonAriaLabel(`Clear ${labelledByText}`);
         return;
       }
+    }
+
+    if (ariaLabel) {
+      setResolvedClearButtonAriaLabel(`Clear ${ariaLabel}`);
+      return;
     }
 
     const inputId = rest.id as string | undefined;

--- a/core/components/atoms/input/__tests__/Input.test.tsx
+++ b/core/components/atoms/input/__tests__/Input.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { axe } from '@/utils/testAxe';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
 import Input, { InputProps as Props } from '../Input';
+import { Label } from '@/index';
 
 const iconValue = ['events'];
 const inputValue = ['value'];
@@ -469,6 +470,41 @@ describe('Input Component - Comprehensive Behavior Tests', () => {
       );
 
       const clearButton = getByRole('button', { name: 'Clear Email address' });
+      expect(clearButton).toBeInTheDocument();
+    });
+
+    it('uses aria-labelledby text in clear button aria-label when aria-label is absent', () => {
+      const onClearMock = jest.fn();
+      const { getByRole } = render(
+        <>
+          <Label id="dob-label" htmlFor="dob-input">
+            Date of Birth
+          </Label>
+          <Input
+            id="dob-input"
+            name="dob"
+            placeholder="MM/DD/YYYY"
+            value="01/01/2024"
+            onClear={onClearMock}
+            aria-labelledby="dob-label"
+          />
+        </>
+      );
+
+      const clearButton = getByRole('button', { name: 'Clear Date of Birth' });
+      expect(clearButton).toBeInTheDocument();
+    });
+
+    it('uses associated label text in clear button aria-label when wired with htmlFor', () => {
+      const onClearMock = jest.fn();
+      const { getByRole } = render(
+        <>
+          <Label htmlFor="dob-input">Date of Birth</Label>
+          <Input id="dob-input" name="dob" placeholder="MM/DD/YYYY" value="01/01/2024" onClear={onClearMock} />
+        </>
+      );
+
+      const clearButton = getByRole('button', { name: 'Clear Date of Birth' });
       expect(clearButton).toBeInTheDocument();
     });
   });

--- a/core/components/atoms/input/__tests__/Input.test.tsx
+++ b/core/components/atoms/input/__tests__/Input.test.tsx
@@ -495,6 +495,29 @@ describe('Input Component - Comprehensive Behavior Tests', () => {
       expect(clearButton).toBeInTheDocument();
     });
 
+    it('prefers aria-labelledby over aria-label in clear button aria-label', () => {
+      const onClearMock = jest.fn();
+      const { getByRole } = render(
+        <>
+          <Label id="dob-label" htmlFor="dob-input">
+            Date of Birth
+          </Label>
+          <Input
+            id="dob-input"
+            name="dob"
+            placeholder="MM/DD/YYYY"
+            value="01/01/2024"
+            onClear={onClearMock}
+            aria-label="Legacy label"
+            aria-labelledby="dob-label"
+          />
+        </>
+      );
+
+      const clearButton = getByRole('button', { name: 'Clear Date of Birth' });
+      expect(clearButton).toBeInTheDocument();
+    });
+
     it('uses associated label text in clear button aria-label when wired with htmlFor', () => {
       const onClearMock = jest.fn();
       const { getByRole } = render(

--- a/core/components/molecules/inputMask/InputMask.tsx
+++ b/core/components/molecules/inputMask/InputMask.tsx
@@ -414,12 +414,13 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
   const helpMessage = error ? caption : helpText;
   const resolvedDescribedBy =
     [ariaDescribedBy, helpMessage ? helpTextId : undefined].filter(Boolean).join(' ') || undefined;
+  const hasAriaLabelledBy = Boolean(rest['aria-labelledby']);
 
   return (
     <div className={classes} data-test="DesignSystem-InputMask--Wrapper">
       <Input
         label={label}
-        aria-label={label}
+        aria-label={hasAriaLabelledBy ? undefined : label}
         {...rest}
         value={value}
         error={error}

--- a/core/components/molecules/inputMask/InputMask.tsx
+++ b/core/components/molecules/inputMask/InputMask.tsx
@@ -57,6 +57,12 @@ export interface MaskProps extends BaseProps {
    * @ignore
    */
   useDefaultValueOnEmpty?: boolean;
+  /**
+   * When false, focus keeps the input empty so screen readers announce the visible label and
+   * `placeholder` (e.g. mm/dd/yyyy) instead of the mask template (e.g. __/__/____).
+   * @default true
+   */
+  fillTemplateOnFocus?: boolean;
 }
 export type InputMaskProps = InputProps & MaskProps;
 type SelectionPos = {
@@ -83,6 +89,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
     validators = [],
     clearOnEmptyBlur = true,
     useDefaultValueOnEmpty = false,
+    fillTemplateOnFocus = true,
     defaultValue,
     mask,
     error,
@@ -382,14 +389,14 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
   const onFocusHandler = React.useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
       deferId.current = window.requestAnimationFrame(updateSelection);
-      if (!value) {
+      if (!value && fillTemplateOnFocus) {
         newSelectionPos.current = defaultSelection.start;
         setValue(getPlaceholderValue());
       }
 
       onFocus?.(e);
     },
-    [deferId.current, value, updateSelection, setValue, setSelectionPos, onFocus]
+    [deferId.current, value, fillTemplateOnFocus, updateSelection, setValue, setSelectionPos, onFocus]
   );
 
   const classes = React.useMemo(

--- a/core/components/molecules/inputMask/InputMask.tsx
+++ b/core/components/molecules/inputMask/InputMask.tsx
@@ -379,11 +379,11 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>((props, for
   const onClearHandler = React.useCallback(
     (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
       newSelectionPos.current = defaultSelection.start;
-      setValue(defaultPlaceholderValue);
+      setValue(fillTemplateOnFocus ? defaultPlaceholderValue : '');
 
       onClear?.(e);
     },
-    [setValue, getPlaceholderValue, setCursorPosition, getDefaultSelection, onClear]
+    [setValue, defaultPlaceholderValue, defaultSelection, fillTemplateOnFocus, onClear]
   );
 
   const onFocusHandler = React.useCallback(

--- a/core/components/molecules/inputMask/__tests__/InputMask.test.tsx
+++ b/core/components/molecules/inputMask/__tests__/InputMask.test.tsx
@@ -137,6 +137,16 @@ describe('Input Mask component prop: onClearHandler', () => {
     fireEvent.click(closeIcon);
     expect(closeIcon).not.toBeInTheDocument();
   });
+
+  it('clears to empty value when fillTemplateOnFocus is false', () => {
+    const dateMask = [/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/];
+    const { getByTestId } = render(
+      <InputMask mask={dateMask} value="01/15/2024" fillTemplateOnFocus={false} onClear={onClearHandler} />
+    );
+    const input = getByTestId('DesignSystem-Input');
+    fireEvent.click(getByTestId('DesignSystem-Input--closeIcon'));
+    expect(input).toHaveValue('');
+  });
 });
 
 describe('InputMask component a11y', () => {

--- a/core/components/organisms/calendar/utils.ts
+++ b/core/components/organisms/calendar/utils.ts
@@ -68,6 +68,18 @@ export const focusYearCell = (container: HTMLElement, yearIndex: number): boolea
 };
 
 /**
+ * Finds the calendar grid cell that should receive focus when a Calendar-based
+ * popover (`DatePicker`/`DateRangePicker`) opens. Calendar uses a roving `tabIndex`
+ * (one cell per grid has `tabIndex={0}`, matching the currently selected/focused
+ * date, month, or year); this returns that cell, whichever view is active.
+ */
+export const getInitialFocusCell = (container: HTMLElement): HTMLElement | null => {
+  return container.querySelector<HTMLElement>(
+    `${DATE_CELL_SELECTOR}[tabindex="0"], ${MONTH_CELL_SELECTOR}[tabindex="0"], ${YEAR_CELL_SELECTOR}[tabindex="0"]`
+  );
+};
+
+/**
  * Get the row and column of the currently focused date cell.
  */
 export const getFocusedDateCell = (container: HTMLElement): FocusedCell | null => {

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -263,6 +263,12 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
    * Flags the open so focus is not pulled into the calendar dialog.
    */
   openViaInput = () => {
+    if (this.props.inputOptions?.readOnly) {
+      if (!this.state.open) {
+        this.setState({ open: true });
+      }
+      return;
+    }
     this.openedViaInput = true;
     if (this.state.open) {
       this.focusTrapIncludesTrigger = true;
@@ -279,6 +285,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
    * input element, so this does not fire and the calendar still receives focus.
    */
   flagOpenFromInput = () => {
+    if (this.props.inputOptions?.readOnly) return;
     this.triggerHadPointerDown = true;
     this.openedViaInput = true;
     this.includeTriggerInFocusTrapWhenOpen();

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -519,7 +519,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
       const resolvedAriaLabelledby = inputOptions['aria-labelledby'] || this.props['aria-labelledby'];
       const triggerInputOptions = {
         ...inputOptions,
-        ...(resolvedAriaLabel ? { 'aria-label': resolvedAriaLabel } : {}),
+        ...(resolvedAriaLabel && !resolvedAriaLabelledby ? { 'aria-label': resolvedAriaLabel } : {}),
         ...(resolvedAriaLabelledby ? { 'aria-labelledby': resolvedAriaLabelledby } : {}),
       };
       return (

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -194,7 +194,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
   componentWillUnmount() {
     if (this.state.open) {
-      document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+      window.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
     }
   }
 
@@ -202,7 +202,11 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     const container = this.dialogRef.current;
     if (!container) return;
     const externalTargets = this.focusTrapIncludesTrigger ? [this.triggerRef.current] : undefined;
-    handleFocusTrapKeyDown(event, container, undefined, externalTargets);
+    if (handleFocusTrapKeyDown(event, container, undefined, externalTargets)) {
+      // Window capture runs before parent Modal/Sidesheet document traps so Tab
+      // from an external trigger is handled before an outer dialog can steal it.
+      event.stopImmediatePropagation();
+    }
   };
 
   focusInitialElement = () => {
@@ -239,7 +243,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     if (moveFocus) {
       this.waitForDialogAndFocus();
     }
-    document.addEventListener('keydown', this.onFocusTrapKeyDown, true);
+    window.addEventListener('keydown', this.onFocusTrapKeyDown, true);
   };
 
   /**
@@ -294,7 +298,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
   };
 
   deactivateFocusTrap = () => {
-    document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+    window.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
     this.focusTrapIncludesTrigger = false;
     if (this.closedViaOutsideClick) {
       // The user's click already moved focus/interaction elsewhere; don't pull

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -148,6 +148,20 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
   /** When true, the active trigger input is included in Tab trapping (input-originated open). */
   focusTrapIncludesTrigger = false;
 
+  isFocusOnTrigger = () => {
+    const trigger = this.triggerRef.current;
+    const active = document.activeElement;
+    return !!(trigger && active && (trigger === active || trigger.contains(active)));
+  };
+
+  /** Controlled opens that happen while a trigger input already has focus. */
+  flagOpenFromFocusedTrigger = () => {
+    if (this.isFocusOnTrigger()) {
+      this.openedViaInput = true;
+      this.focusTrapIncludesTrigger = true;
+    }
+  };
+
   constructor(props: DatePickerProps) {
     super(props);
 
@@ -321,6 +335,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
+        this.flagOpenFromFocusedTrigger();
         this.activateFocusTrap(!this.openedViaInput);
       } else {
         this.deactivateFocusTrap();

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -147,6 +147,8 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
   closedViaOutsideClick = false;
   /** When true, the active trigger input is included in Tab trapping (input-originated open). */
   focusTrapIncludesTrigger = false;
+  /** Pointer on trigger chrome (icon/wrapper) — not a keyboard focus-origin open. */
+  triggerHadPointerDown = false;
 
   isFocusOnTrigger = () => {
     const trigger = this.triggerRef.current;
@@ -154,12 +156,16 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     return !!(trigger && active && (trigger === active || trigger.contains(active)));
   };
 
-  /** Controlled opens that happen while a trigger input already has focus. */
+  /** Controlled opens that happen while a trigger input already has focus (Tab/onFocus). */
   flagOpenFromFocusedTrigger = () => {
-    if (this.isFocusOnTrigger()) {
+    if (this.isFocusOnTrigger() && !this.triggerHadPointerDown) {
       this.openedViaInput = true;
       this.focusTrapIncludesTrigger = true;
     }
+  };
+
+  flagTriggerPointerDown = () => {
+    this.triggerHadPointerDown = true;
   };
 
   constructor(props: DatePickerProps) {
@@ -267,6 +273,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
    * input element, so this does not fire and the calendar still receives focus.
    */
   flagOpenFromInput = () => {
+    this.triggerHadPointerDown = true;
     this.openedViaInput = true;
     this.includeTriggerInFocusTrapWhenOpen();
   };
@@ -335,12 +342,16 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
-        this.flagOpenFromFocusedTrigger();
+        const openedFromControlledProp = prevProps.open !== this.props.open && this.props.open === true;
+        if (openedFromControlledProp) {
+          this.flagOpenFromFocusedTrigger();
+        }
         this.activateFocusTrap(!this.openedViaInput);
       } else {
         this.deactivateFocusTrap();
       }
       this.openedViaInput = false;
+      this.triggerHadPointerDown = false;
     }
   }
 
@@ -509,6 +520,7 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
               triggerRef={this.triggerRef}
               openViaInput={this.openViaInput}
               onInputMouseDown={this.flagOpenFromInput}
+              onTriggerPointerDown={this.flagTriggerPointerDown}
               onKeyboardOpen={this.openViaKeyboard}
             />
           }

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -5,10 +5,13 @@ import { Popover, Utils, Chip } from '@/index';
 import { PopoverProps, InputMaskProps } from '@/index.type';
 import { Validators } from '@/utils/types';
 import { convertToDate, translateToString, compareDate, getDateInfo } from '../calendar/utility';
+import { getInitialFocusCell } from '../calendar/utils';
 import { Trigger } from './Trigger';
 import config from '../calendar/config';
 import classNames from 'classnames';
 import styles from '@css/components/datePicker.module.css';
+import uidGenerator from '@/utils/uidGenerator';
+import { getFocusableElements, handleFocusTrapKeyDown, restoreFocusToElementIfConnected } from '@/utils/overlayHelper';
 
 export type DatePickerProps = SharedProps & {
   /**
@@ -126,6 +129,25 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     closeOnSelect: true,
   };
 
+  dialogRef = React.createRef<HTMLDivElement>();
+  triggerRef = React.createRef<HTMLInputElement>();
+  panelId: string;
+  /**
+   * `true` when the popover opened as a side effect of typing/pasting into the
+   * editable input. In that case focus must stay in the input (caret preserved)
+   * and must NOT be moved into the calendar dialog.
+   */
+  openedViaInput = false;
+  /**
+   * `true` when the popover is closing as a result of a click outside the
+   * dialog. In that case the user has already moved focus/interaction
+   * elsewhere, so `deactivateFocusTrap` must NOT steal focus back to the
+   * trigger. Reset immediately after being consumed.
+   */
+  closedViaOutsideClick = false;
+  /** When true, the active trigger input is included in Tab trapping (input-originated open). */
+  focusTrapIncludesTrigger = false;
+
   constructor(props: DatePickerProps) {
     super(props);
 
@@ -134,6 +156,8 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     const date = convertToDate(props.date, inputFormat, validators);
     const error = this.getError(date);
 
+    this.panelId = `DatePicker-dialog-${uidGenerator()}`;
+
     this.state = {
       date,
       error,
@@ -141,6 +165,124 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
       open: props.open || false,
     };
   }
+
+  componentDidMount() {
+    if (this.state.open) {
+      this.activateFocusTrap();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.state.open) {
+      document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+    }
+  }
+
+  onFocusTrapKeyDown = (event: KeyboardEvent) => {
+    const container = this.dialogRef.current;
+    if (!container) return;
+    const externalTargets = this.focusTrapIncludesTrigger ? [this.triggerRef.current] : undefined;
+    handleFocusTrapKeyDown(event, container, undefined, externalTargets);
+  };
+
+  focusInitialElement = () => {
+    const container = this.dialogRef.current;
+    if (!container) return;
+    const target = getInitialFocusCell(container) || getFocusableElements(container)[0];
+    target?.focus({ preventScroll: true });
+  };
+
+  /**
+   * `Popover` mounts its portal (and therefore `dialogRef`) in a passive
+   * `useEffect`, which can run after the `requestAnimationFrame` scheduled
+   * below. Poll across a bounded number of animation frames until the dialog
+   * node exists before moving focus into it, so focus isn't silently dropped
+   * back on the input (leaving Tab free to escape the `aria-modal` dialog).
+   */
+  waitForDialogAndFocus = (retriesLeft = 10) => {
+    window.requestAnimationFrame(() => {
+      if (!this.state.open) return;
+      if (this.dialogRef.current) {
+        this.focusInitialElement();
+      } else if (retriesLeft > 0) {
+        this.waitForDialogAndFocus(retriesLeft - 1);
+      }
+    });
+  };
+
+  activateFocusTrap = (moveFocus = true) => {
+    // Always arm the focus trap (Tab handling) while the dialog is open.
+    // Only move focus into the calendar for explicit opens; when the popover
+    // opened because the user is typing/pasting, leave the caret in the input
+    // and include that trigger in the trap cycle.
+    this.focusTrapIncludesTrigger = !moveFocus;
+    if (moveFocus) {
+      this.waitForDialogAndFocus();
+    }
+    document.addEventListener('keydown', this.onFocusTrapKeyDown, true);
+  };
+
+  /**
+   * When the popover is already open, re-include the trigger in Tab trapping
+   * after the user refocuses the editable input (click/label/type path).
+   */
+  includeTriggerInFocusTrapWhenOpen = () => {
+    if (this.state.open) {
+      this.focusTrapIncludesTrigger = true;
+    }
+  };
+
+  /**
+   * Opens the popover as a result of typing/pasting in the editable input.
+   * Flags the open so focus is not pulled into the calendar dialog.
+   */
+  openViaInput = () => {
+    this.openedViaInput = true;
+    if (this.state.open) {
+      this.focusTrapIncludesTrigger = true;
+    } else {
+      this.setState({ open: true });
+    }
+  };
+
+  /**
+   * Flags that the popover open about to be triggered originates from a pointer
+   * press on the input itself (mouse click into the editable field). Fires on
+   * `mousedown`, before the wrapper click that opens the popover, so focus stays
+   * in the input (caret preserved). Pressing the calendar icon does NOT hit the
+   * input element, so this does not fire and the calendar still receives focus.
+   */
+  flagOpenFromInput = () => {
+    this.openedViaInput = true;
+    this.includeTriggerInFocusTrapWhenOpen();
+  };
+
+  /**
+   * Explicit keyboard open (ArrowDown / Alt+ArrowDown on the input). Unlike
+   * typing, this is an intentional request to enter the calendar, so focus IS
+   * moved into the grid: opening goes through the explicit path
+   * (`openedViaInput` stays false → `activateFocusTrap(true)`), and when the
+   * popover is already open focus is moved into the grid directly.
+   */
+  openViaKeyboard = () => {
+    if (this.state.open) {
+      this.waitForDialogAndFocus();
+    } else {
+      this.setState({ open: true });
+    }
+  };
+
+  deactivateFocusTrap = () => {
+    document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+    this.focusTrapIncludesTrigger = false;
+    if (this.closedViaOutsideClick) {
+      // The user's click already moved focus/interaction elsewhere; don't pull
+      // it back to the trigger.
+      this.closedViaOutsideClick = false;
+      return;
+    }
+    restoreFocusToElementIfConnected(this.triggerRef.current, this.dialogRef.current);
+  };
 
   componentDidUpdate(prevProps: DatePickerProps, prevState: DatePickerState) {
     if (prevProps.date !== this.props.date) {
@@ -175,6 +317,15 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
           onDateChange(undefined, '');
         }
       }
+    }
+
+    if (prevState.open !== this.state.open) {
+      if (this.state.open) {
+        this.activateFocusTrap(!this.openedViaInput);
+      } else {
+        this.deactivateFocusTrap();
+      }
+      this.openedViaInput = false;
     }
   }
 
@@ -213,6 +364,9 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
     switch (type) {
       case 'outsideClick':
+        if (!o) this.closedViaOutsideClick = true;
+        this.setState({ open: o });
+        break;
       case 'escapeKeypress':
         this.setState({ open: o });
         break;
@@ -319,10 +473,12 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     const { open } = this.state;
 
     if (withInput) {
+      const resolvedAriaLabel = inputOptions['aria-label'] || this.props['aria-label'];
+      const resolvedAriaLabelledby = inputOptions['aria-labelledby'] || this.props['aria-labelledby'];
       const triggerInputOptions = {
         ...inputOptions,
-        'aria-label': inputOptions['aria-label'] || this.props['aria-label'],
-        'aria-labelledby': inputOptions['aria-labelledby'] || this.props['aria-labelledby'],
+        ...(resolvedAriaLabel ? { 'aria-label': resolvedAriaLabel } : {}),
+        ...(resolvedAriaLabelledby ? { 'aria-labelledby': resolvedAriaLabelledby } : {}),
       };
       return (
         <Popover
@@ -333,6 +489,12 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
               validators={validators}
               state={this.state}
               setState={this.setState.bind(this)}
+              open={open}
+              panelId={this.panelId}
+              triggerRef={this.triggerRef}
+              openViaInput={this.openViaInput}
+              onInputMouseDown={this.flagOpenFromInput}
+              onKeyboardOpen={this.openViaKeyboard}
             />
           }
           triggerClass="w-100"
@@ -342,7 +504,9 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
           onToggle={this.onToggleHandler}
           {...popoverOptions}
         >
-          {this.renderCalendar()}
+          <div role="dialog" aria-modal="true" aria-label="Choose date" id={this.panelId} ref={this.dialogRef}>
+            {this.renderCalendar()}
+          </div>
         </Popover>
       );
     }

--- a/core/components/organisms/datePicker/DatePicker.tsx
+++ b/core/components/organisms/datePicker/DatePicker.tsx
@@ -149,6 +149,8 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
   focusTrapIncludesTrigger = false;
   /** Pointer on trigger chrome (icon/wrapper) — not a keyboard focus-origin open. */
   triggerHadPointerDown = false;
+  /** Props.open flipped true before deferred state.open sync (controlled onFocus opens). */
+  pendingControlledOpen = false;
 
   isFocusOnTrigger = () => {
     const trigger = this.triggerRef.current;
@@ -320,6 +322,9 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     }
 
     if (prevProps.open !== this.props.open) {
+      if (this.props.open && !prevProps.open) {
+        this.pendingControlledOpen = true;
+      }
       this.setState({
         open: this.props.open || false,
       });
@@ -346,10 +351,10 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
 
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
-        const openedFromControlledProp = prevProps.open !== this.props.open && this.props.open === true;
-        if (openedFromControlledProp) {
+        if (this.pendingControlledOpen && !this.openedViaInput) {
           this.flagOpenFromFocusedTrigger();
         }
+        this.pendingControlledOpen = false;
         this.activateFocusTrap(!this.openedViaInput);
       } else {
         this.deactivateFocusTrap();

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -91,6 +91,7 @@ export const Trigger = (props: TriggerProps) => {
   const { placeholderChar = '_', label, ...inputMaskOptions } = inputOptions;
   const fieldIdRef = React.useRef<string>(`DatePicker-input-${uidGenerator()}`);
   const fieldId = inputOptions.id || fieldIdRef.current;
+  const labelId = `${fieldId}-label`;
 
   const onPasteHandler = (_e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
     const { onPaste } = inputOptions;
@@ -160,6 +161,7 @@ export const Trigger = (props: TriggerProps) => {
     <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
       {label && (
         <Label
+          id={labelId}
           required={inputOptions.required}
           withInput={true}
           htmlFor={fieldId}
@@ -177,13 +179,7 @@ export const Trigger = (props: TriggerProps) => {
         id={fieldId}
         error={showError}
         mask={mask}
-        value={
-          date
-            ? translateToString(inputFormat, date)
-            : init
-            ? InputMask.utils.getDefaultValue(mask, placeholderChar)
-            : ''
-        }
+        value={date ? translateToString(inputFormat, date) : ''}
         onChange={onChangeHandler}
         onPaste={onPasteHandler}
         onBlur={onBlurHandler}
@@ -194,11 +190,13 @@ export const Trigger = (props: TriggerProps) => {
         validators={[inputValidator]}
         clearOnEmptyBlur={true}
         useDefaultValueOnEmpty={true}
+        fillTemplateOnFocus={false}
         ref={triggerRef}
         role="combobox"
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={panelId}
+        aria-labelledby={label ? labelId : inputMaskOptions['aria-labelledby']}
       />
     </div>
   );

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -155,6 +155,8 @@ export const Trigger = (props: TriggerProps) => {
   };
 
   const mask = Utils.masks.date[inputFormat];
+  const resolvedAriaLabelledby =
+    [label && labelId, inputMaskOptions['aria-labelledby']].filter(Boolean).join(' ') || undefined;
   return (
     // Capture pointer on trigger chrome (icon/wrapper) for focus-trap routing.
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
@@ -198,7 +200,7 @@ export const Trigger = (props: TriggerProps) => {
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={panelId}
-        aria-labelledby={label ? labelId : inputMaskOptions['aria-labelledby']}
+        aria-labelledby={resolvedAriaLabelledby}
       />
     </div>
   );

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -63,7 +63,9 @@ export const Trigger = (props: TriggerProps) => {
 
   const onMouseDownHandler = (e: React.MouseEvent<HTMLInputElement>) => {
     inputOptions.onMouseDown?.(e);
-    onInputMouseDown?.();
+    if (!inputOptions.readOnly) {
+      onInputMouseDown?.();
+    }
   };
 
   const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -131,7 +133,7 @@ export const Trigger = (props: TriggerProps) => {
   const onClearHandler = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
     const { onClear } = inputOptions;
     // Pointer clears bubble to the popover trigger; keyboard clears do not open it.
-    if (e.type === 'click') {
+    if (e.type === 'click' && !inputOptions.readOnly) {
       onInputMouseDown?.();
     }
     setState({

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -34,6 +34,11 @@ type TriggerProps = {
    */
   onInputMouseDown?: () => void;
   /**
+   * Called on `mousedown` anywhere on the trigger chrome (icon, wrapper, input)
+   * so pointer-origin opens are not treated as keyboard focus-origin opens.
+   */
+  onTriggerPointerDown?: () => void;
+  /**
    * Called on an explicit keyboard open gesture (ArrowDown / Alt+ArrowDown) to
    * open the calendar AND move focus into the grid.
    */
@@ -52,6 +57,7 @@ export const Trigger = (props: TriggerProps) => {
     triggerRef,
     openViaInput,
     onInputMouseDown,
+    onTriggerPointerDown,
     onKeyboardOpen,
   } = props;
 
@@ -144,28 +150,36 @@ export const Trigger = (props: TriggerProps) => {
 
   const mask = Utils.masks.date[inputFormat];
   return (
-    <InputMask
-      icon="events"
-      placeholder={inputFormat}
-      {...inputOptions}
-      error={showError}
-      mask={mask}
-      value={
-        date ? translateToString(inputFormat, date) : init ? InputMask.utils.getDefaultValue(mask, placeholderChar) : ''
-      }
-      onChange={onChangeHandler}
-      onPaste={onPasteHandler}
-      onBlur={onBlurHandler}
-      onClear={onClearHandler}
-      onMouseDown={onMouseDownHandler}
-      onKeyDown={onKeyDownHandler}
-      caption={showError ? errorMessage : ''}
-      validators={[inputValidator]}
-      clearOnEmptyBlur={true}
-      useDefaultValueOnEmpty={true}
-      ref={triggerRef}
-      aria-expanded={open}
-      aria-controls={panelId}
-    />
+    // Capture pointer on trigger chrome (icon/wrapper) for focus-trap routing.
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
+      <InputMask
+        icon="events"
+        placeholder={inputFormat}
+        {...inputOptions}
+        error={showError}
+        mask={mask}
+        value={
+          date
+            ? translateToString(inputFormat, date)
+            : init
+            ? InputMask.utils.getDefaultValue(mask, placeholderChar)
+            : ''
+        }
+        onChange={onChangeHandler}
+        onPaste={onPasteHandler}
+        onBlur={onBlurHandler}
+        onClear={onClearHandler}
+        onMouseDown={onMouseDownHandler}
+        onKeyDown={onKeyDownHandler}
+        caption={showError ? errorMessage : ''}
+        validators={[inputValidator]}
+        clearOnEmptyBlur={true}
+        useDefaultValueOnEmpty={true}
+        ref={triggerRef}
+        aria-expanded={open}
+        aria-controls={panelId}
+      />
+    </div>
   );
 };

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { InputMask, Utils } from '@/index';
+import { InputMask, Label, Utils } from '@/index';
 import { translateToDate, translateToString } from '../calendar/utility';
 import { DatePickerProps, DatePickerState } from './DatePicker';
+import uidGenerator from '@/utils/uidGenerator';
 
 type TriggerProps = {
   inputFormat: DatePickerProps['inputFormat'];
@@ -87,7 +88,9 @@ export const Trigger = (props: TriggerProps) => {
 
   const { init, date, error } = state;
 
-  const { placeholderChar = '_' } = inputOptions;
+  const { placeholderChar = '_', label, ...inputMaskOptions } = inputOptions;
+  const fieldIdRef = React.useRef<string>(`DatePicker-input-${uidGenerator()}`);
+  const fieldId = inputOptions.id || fieldIdRef.current;
 
   const onPasteHandler = (_e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
     const { onPaste } = inputOptions;
@@ -155,10 +158,23 @@ export const Trigger = (props: TriggerProps) => {
     // Capture pointer on trigger chrome (icon/wrapper) for focus-trap routing.
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
+      {label && (
+        <Label
+          required={inputOptions.required}
+          withInput={true}
+          htmlFor={fieldId}
+          onMouseDown={() => {
+            if (!inputOptions.readOnly) onInputMouseDown?.();
+          }}
+        >
+          {label}
+        </Label>
+      )}
       <InputMask
         icon="events"
         placeholder={inputFormat}
-        {...inputOptions}
+        {...inputMaskOptions}
+        id={fieldId}
         error={showError}
         mask={mask}
         value={

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -177,6 +177,8 @@ export const Trigger = (props: TriggerProps) => {
         clearOnEmptyBlur={true}
         useDefaultValueOnEmpty={true}
         ref={triggerRef}
+        role="combobox"
+        aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={panelId}
       />

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -124,9 +124,10 @@ export const Trigger = (props: TriggerProps) => {
 
   const onClearHandler = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
     const { onClear } = inputOptions;
-    // Clear focuses the input and the click can bubble to the popover trigger;
-    // treat this like an input-originated open so focus stays in the field.
-    onInputMouseDown?.();
+    // Pointer clears bubble to the popover trigger; keyboard clears do not open it.
+    if (e.type === 'click') {
+      onInputMouseDown?.();
+    }
     setState({
       init: true,
       date: undefined,

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -173,8 +173,10 @@ export const Trigger = (props: TriggerProps) => {
         </Label>
       )}
       <InputMask
+        label={label}
         icon="events"
         placeholder={inputFormat}
+        placeholderChar={placeholderChar}
         {...inputMaskOptions}
         id={fieldId}
         error={showError}

--- a/core/components/organisms/datePicker/Trigger.tsx
+++ b/core/components/organisms/datePicker/Trigger.tsx
@@ -9,10 +9,73 @@ type TriggerProps = {
   validators: DatePickerProps['validators'];
   state: DatePickerState;
   setState: any;
+  /**
+   * Whether the calendar popover is currently open (drives `aria-expanded`)
+   */
+  open?: boolean;
+  /**
+   * `id` of the calendar dialog panel this trigger controls (drives `aria-controls`)
+   */
+  panelId?: string;
+  /**
+   * Ref to the underlying `input` element, used to return focus on popover close
+   */
+  triggerRef?: React.Ref<HTMLInputElement>;
+  /**
+   * Opens the popover as a side effect of typing/pasting, WITHOUT moving focus
+   * into the calendar dialog (keeps the caret in the input). Falls back to a
+   * plain `open` state update when not provided.
+   */
+  openViaInput?: () => void;
+  /**
+   * Called on `mousedown` on the input element (before the wrapper click that
+   * opens the popover) so a click INTO the editable field keeps the caret in
+   * the input instead of moving focus into the calendar.
+   */
+  onInputMouseDown?: () => void;
+  /**
+   * Called on an explicit keyboard open gesture (ArrowDown / Alt+ArrowDown) to
+   * open the calendar AND move focus into the grid.
+   */
+  onKeyboardOpen?: () => void;
 };
 
 export const Trigger = (props: TriggerProps) => {
-  const { inputFormat, inputOptions, validators, state, setState } = props;
+  const {
+    inputFormat,
+    inputOptions,
+    validators,
+    state,
+    setState,
+    open,
+    panelId,
+    triggerRef,
+    openViaInput,
+    onInputMouseDown,
+    onKeyboardOpen,
+  } = props;
+
+  const onMouseDownHandler = (e: React.MouseEvent<HTMLInputElement>) => {
+    inputOptions.onMouseDown?.(e);
+    onInputMouseDown?.();
+  };
+
+  const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    inputOptions.onKeyDown?.(e);
+    if (e.key === 'ArrowDown') {
+      // Explicit keyboard open: enter the calendar grid (prevent caret jump).
+      e.preventDefault();
+      onKeyboardOpen?.();
+    }
+  };
+
+  const openPopoverFromInput = () => {
+    if (openViaInput) {
+      openViaInput();
+    } else {
+      setState({ open: true });
+    }
+  };
 
   const { init, date, error } = state;
 
@@ -20,9 +83,7 @@ export const Trigger = (props: TriggerProps) => {
 
   const onPasteHandler = (_e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
     const { onPaste } = inputOptions;
-    setState({
-      open: true,
-    });
+    openPopoverFromInput();
 
     if (val && !val.includes(placeholderChar)) {
       const d = translateToDate(inputFormat, val, validators);
@@ -34,9 +95,7 @@ export const Trigger = (props: TriggerProps) => {
 
   const onChangeHandler = (_e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
     const { onChange } = inputOptions;
-    setState({
-      open: true,
-    });
+    openPopoverFromInput();
 
     if (val && !val.includes(placeholderChar)) {
       const d = translateToDate(inputFormat, val, validators);
@@ -65,6 +124,9 @@ export const Trigger = (props: TriggerProps) => {
 
   const onClearHandler = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
     const { onClear } = inputOptions;
+    // Clear focuses the input and the click can bubble to the popover trigger;
+    // treat this like an input-originated open so focus stays in the field.
+    onInputMouseDown?.();
     setState({
       init: true,
       date: undefined,
@@ -94,10 +156,15 @@ export const Trigger = (props: TriggerProps) => {
       onPaste={onPasteHandler}
       onBlur={onBlurHandler}
       onClear={onClearHandler}
+      onMouseDown={onMouseDownHandler}
+      onKeyDown={onKeyDownHandler}
       caption={showError ? errorMessage : ''}
       validators={[inputValidator]}
       clearOnEmptyBlur={true}
       useDefaultValueOnEmpty={true}
+      ref={triggerRef}
+      aria-expanded={open}
+      aria-controls={panelId}
     />
   );
 };

--- a/core/components/organisms/datePicker/__tests__/DatePicker.test.tsx
+++ b/core/components/organisms/datePicker/__tests__/DatePicker.test.tsx
@@ -173,7 +173,7 @@ describe('renders DatePicker component Event Handlers ', () => {
     );
     const closeIcon = getByTestId('DesignSystem-Input--closeIcon');
     fireEvent.click(closeIcon);
-    expect(getByTestId('DesignSystem-Input')).toHaveValue('**/**/****');
+    expect(getByTestId('DesignSystem-Input')).toHaveValue('');
   });
 
   it('checks for input field onChange event with empty date', async () => {
@@ -181,20 +181,20 @@ describe('renders DatePicker component Event Handlers ', () => {
     const input = getByTestId('DesignSystem-Input');
     fireEvent.change(input, { currentTarget: { value: '' } });
     fireEvent.blur(input);
-    expect(input).toHaveValue('__/__/____');
+    expect(input).toHaveValue('');
   });
 
   it('checks onBlur Event', () => {
     const { getByTestId } = render(<DatePicker onDateChange={FunctionValue} withInput={true} />);
     const input = getByTestId('DesignSystem-Input');
     fireEvent.blur(input);
-    expect(input).toHaveValue('__/__/____');
+    expect(input).toHaveValue('');
   });
   it('checks onFocus Event', () => {
     const { getByTestId } = render(<DatePicker onDateChange={FunctionValue} withInput={true} />);
     const input = getByTestId('DesignSystem-Input');
     fireEvent.focus(input);
-    expect(input).toHaveValue('__/__/____');
+    expect(input).toHaveValue('');
   });
   it('checks for input field onError event', () => {
     const { getByTestId } = render(

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -10234,6 +10234,7 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
               autocomplete="off"
               class="Input-input Input-input--regular mr-4"
               data-test="DesignSystem-Input"
+              id="DatePicker-input-Test-uid"
               placeholder="mm/dd/yyyy"
               role="combobox"
               type="text"

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -10225,6 +10225,8 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
             </i>
           </div>
           <input
+            aria-controls="DatePicker-dialog-Test-uid"
+            aria-expanded="false"
             autocomplete="off"
             class="Input-input Input-input--regular mr-4"
             data-test="DesignSystem-Input"

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -10204,50 +10204,54 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
       class="PopperWrapper-trigger w-100"
     >
       <div
-        class="d-flex flex-column flex-grow-1"
-        data-test="DesignSystem-InputMask--Wrapper"
+        class="w-100"
       >
         <div
-          class="Input Input--regular"
-          data-test="DesignSystem-InputWrapper"
-          role="presentation"
-          style="min-width: 256px;"
+          class="d-flex flex-column flex-grow-1"
+          data-test="DesignSystem-InputMask--Wrapper"
         >
           <div
-            class="Input-icon Input-icon--left"
+            class="Input Input--regular"
+            data-test="DesignSystem-InputWrapper"
+            role="presentation"
+            style="min-width: 256px;"
           >
-            <i
-              class="material-symbols material-symbols-rounded Icon"
-              data-test="DesignSystem-Icon"
-              style="font-size: 16px; width: 16px;"
+            <div
+              class="Input-icon Input-icon--left"
             >
-              events
-            </i>
-          </div>
-          <input
-            aria-controls="DatePicker-dialog-Test-uid"
-            aria-expanded="false"
-            autocomplete="off"
-            class="Input-input Input-input--regular mr-4"
-            data-test="DesignSystem-Input"
-            placeholder="mm/dd/yyyy"
-            type="text"
-            value="03/01/2020"
-          />
-          <div
-            aria-label="Clear mm/dd/yyyy"
-            class="Input-icon Input-iconWrapper--right"
-            role="button"
-            tabindex="0"
-          >
-            <i
-              aria-hidden="true"
-              class="material-symbols material-symbols-rounded Icon Input-icon--right p-3"
-              data-test="DesignSystem-Input--closeIcon"
-              style="font-size: 16px; width: 16px;"
+              <i
+                class="material-symbols material-symbols-rounded Icon"
+                data-test="DesignSystem-Icon"
+                style="font-size: 16px; width: 16px;"
+              >
+                events
+              </i>
+            </div>
+            <input
+              aria-controls="DatePicker-dialog-Test-uid"
+              aria-expanded="false"
+              autocomplete="off"
+              class="Input-input Input-input--regular mr-4"
+              data-test="DesignSystem-Input"
+              placeholder="mm/dd/yyyy"
+              type="text"
+              value="03/01/2020"
+            />
+            <div
+              aria-label="Clear mm/dd/yyyy"
+              class="Input-icon Input-iconWrapper--right"
+              role="button"
+              tabindex="0"
             >
-              close
-            </i>
+              <i
+                aria-hidden="true"
+                class="material-symbols material-symbols-rounded Icon Input-icon--right p-3"
+                data-test="DesignSystem-Input--closeIcon"
+                style="font-size: 16px; width: 16px;"
+              >
+                close
+              </i>
+            </div>
           </div>
         </div>
       </div>

--- a/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
+++ b/core/components/organisms/datePicker/__tests__/__snapshots__/DatePicker.test.tsx.snap
@@ -10230,10 +10230,12 @@ exports[`DatePicker component snapshots renders snapshot for prop:withInput
             <input
               aria-controls="DatePicker-dialog-Test-uid"
               aria-expanded="false"
+              aria-haspopup="dialog"
               autocomplete="off"
               class="Input-input Input-input--regular mr-4"
               data-test="DesignSystem-Input"
               placeholder="mm/dd/yyyy"
+              role="combobox"
               type="text"
               value="03/01/2020"
             />

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -663,19 +663,23 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
       const resolvedSingleAriaLabelledby = inputOptions['aria-labelledby'] || ariaLabelledBy;
       const mergedSingleInputOptions = {
         ...inputOptions,
-        ...(resolvedSingleAriaLabel ? { 'aria-label': resolvedSingleAriaLabel } : {}),
+        ...(resolvedSingleAriaLabel && !resolvedSingleAriaLabelledby ? { 'aria-label': resolvedSingleAriaLabel } : {}),
         ...(resolvedSingleAriaLabelledby ? { 'aria-labelledby': resolvedSingleAriaLabelledby } : {}),
       };
       const resolvedStartAriaLabelledby = startInputOptions['aria-labelledby'] || ariaLabelledBy;
       const mergedStartInputOptions = {
         ...startInputOptions,
-        ...(startInputOptions['aria-label'] ? { 'aria-label': startInputOptions['aria-label'] } : {}),
+        ...(startInputOptions['aria-label'] && !resolvedStartAriaLabelledby
+          ? { 'aria-label': startInputOptions['aria-label'] }
+          : {}),
         ...(resolvedStartAriaLabelledby ? { 'aria-labelledby': resolvedStartAriaLabelledby } : {}),
       };
       const resolvedEndAriaLabelledby = endInputOptions['aria-labelledby'] || ariaLabelledBy;
       const mergedEndInputOptions = {
         ...endInputOptions,
-        ...(endInputOptions['aria-label'] ? { 'aria-label': endInputOptions['aria-label'] } : {}),
+        ...(endInputOptions['aria-label'] && !resolvedEndAriaLabelledby
+          ? { 'aria-label': endInputOptions['aria-label'] }
+          : {}),
         ...(resolvedEndAriaLabelledby ? { 'aria-labelledby': resolvedEndAriaLabelledby } : {}),
       };
       const trigger = singleInput ? (

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -686,13 +686,19 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
         <Popover
           trigger={trigger}
           triggerClass="w-100"
-          className={RangePickerClass}
           position={position}
           appendToBody={true}
           open={open}
           onToggle={this.onToggleHandler}
         >
-          <div role="dialog" aria-modal="true" aria-label={dialogLabel} id={this.panelId} ref={this.dialogRef}>
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={dialogLabel}
+            id={this.panelId}
+            ref={this.dialogRef}
+            className={RangePickerClass}
+          >
             {children}
             {this.renderCalendar()}
           </div>

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -242,14 +242,18 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
   componentWillUnmount() {
     if (this.state.open) {
-      document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+      window.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
     }
   }
 
   onFocusTrapKeyDown = (event: KeyboardEvent) => {
     const container = this.dialogRef.current;
     if (!container) return;
-    handleFocusTrapKeyDown(event, container, undefined, this.getFocusTrapExternalTargets());
+    if (handleFocusTrapKeyDown(event, container, undefined, this.getFocusTrapExternalTargets())) {
+      // Window capture runs before parent Modal/Sidesheet document traps so Tab
+      // from an external trigger is handled before an outer dialog can steal it.
+      event.stopImmediatePropagation();
+    }
   };
 
   getFocusTrapExternalTargets = (): (HTMLElement | null)[] | undefined => {
@@ -296,7 +300,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     if (moveFocus) {
       this.waitForDialogAndFocus();
     }
-    document.addEventListener('keydown', this.onFocusTrapKeyDown, true);
+    window.addEventListener('keydown', this.onFocusTrapKeyDown, true);
   };
 
   /**
@@ -352,7 +356,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
   };
 
   deactivateFocusTrap = () => {
-    document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+    window.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
     this.focusTrapIncludesTrigger = false;
     if (this.closedViaOutsideClick) {
       // The user's click already moved focus/interaction elsewhere; don't pull

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -185,6 +185,8 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
   focusTrapIncludesTrigger = false;
   /** Pointer on trigger chrome (icon/wrapper) — not a keyboard focus-origin open. */
   triggerHadPointerDown = false;
+  /** Props.open flipped true before deferred state.open sync (controlled onFocus opens). */
+  pendingControlledOpen = false;
 
   isFocusOnTrigger = () => {
     const active = document.activeElement;
@@ -401,6 +403,9 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     }
 
     if (prevProps.open !== this.props.open) {
+      if (this.props.open && !prevProps.open) {
+        this.pendingControlledOpen = true;
+      }
       this.setState({
         open: this.props.open || false,
       });
@@ -458,10 +463,10 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
-        const openedFromControlledProp = prevProps.open !== this.props.open && this.props.open === true;
-        if (openedFromControlledProp) {
+        if (this.pendingControlledOpen && !this.openedViaInput) {
           this.flagOpenFromFocusedTrigger();
         }
+        this.pendingControlledOpen = false;
         this.activateFocusTrap(!this.openedViaInput);
       } else {
         this.deactivateFocusTrap();

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -364,6 +364,11 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
    * side (start/end) is tracked via `activeField` for focus return on close.
    */
   openViaKeyboard = () => {
+    const { singleInput, inputOptions, startInputOptions, endInputOptions } = this.props;
+    const disabled = singleInput ? inputOptions.disabled : startInputOptions.disabled || endInputOptions.disabled;
+
+    if (disabled) return;
+
     if (this.state.open) {
       this.waitForDialogAndFocus();
     } else {

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -183,6 +183,8 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
   closedViaOutsideClick = false;
   /** When true, the active trigger input is included in Tab trapping (input-originated open). */
   focusTrapIncludesTrigger = false;
+  /** Pointer on trigger chrome (icon/wrapper) — not a keyboard focus-origin open. */
+  triggerHadPointerDown = false;
 
   isFocusOnTrigger = () => {
     const active = document.activeElement;
@@ -191,12 +193,16 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     return triggers.some((el) => el && (el === active || el.contains(active)));
   };
 
-  /** Controlled opens that happen while a trigger input already has focus. */
+  /** Controlled opens that happen while a trigger input already has focus (Tab/onFocus). */
   flagOpenFromFocusedTrigger = () => {
-    if (this.isFocusOnTrigger()) {
+    if (this.isFocusOnTrigger() && !this.triggerHadPointerDown) {
       this.openedViaInput = true;
       this.focusTrapIncludesTrigger = true;
     }
+  };
+
+  flagTriggerPointerDown = () => {
+    this.triggerHadPointerDown = true;
   };
 
   constructor(props: DateRangePickerProps) {
@@ -324,6 +330,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
    * input element, so this does not fire and the calendar still receives focus.
    */
   flagOpenFromInput = () => {
+    this.triggerHadPointerDown = true;
     this.openedViaInput = true;
     this.includeTriggerInFocusTrapWhenOpen();
   };
@@ -447,12 +454,16 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
-        this.flagOpenFromFocusedTrigger();
+        const openedFromControlledProp = prevProps.open !== this.props.open && this.props.open === true;
+        if (openedFromControlledProp) {
+          this.flagOpenFromFocusedTrigger();
+        }
         this.activateFocusTrap(!this.openedViaInput);
       } else {
         this.deactivateFocusTrap();
       }
       this.openedViaInput = false;
+      this.triggerHadPointerDown = false;
     }
   }
 
@@ -646,6 +657,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           triggerRef={this.singleTriggerRef}
           onTriggerFocus={() => this.setActiveField('single')}
           onInputMouseDown={this.flagOpenFromInput}
+          onTriggerPointerDown={this.flagTriggerPointerDown}
           onKeyboardOpen={this.openViaKeyboard}
         />
       ) : (
@@ -663,6 +675,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           onTriggerFocus={this.setActiveField}
           openViaInput={this.openViaInput}
           onInputMouseDown={this.flagOpenFromInput}
+          onTriggerPointerDown={this.flagTriggerPointerDown}
           onKeyboardOpen={this.openViaKeyboard}
         />
       );

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -315,11 +315,24 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     }
   };
 
+  isActiveTriggerReadOnly = () => {
+    const { singleInput, inputOptions, startInputOptions, endInputOptions } = this.props;
+    if (singleInput) return !!inputOptions?.readOnly;
+    if (this.activeField === 'end') return !!endInputOptions?.readOnly;
+    return !!startInputOptions?.readOnly;
+  };
+
   /**
    * Opens the popover as a result of typing/pasting in an editable input.
    * Flags the open so focus is not pulled into the calendar dialog.
    */
   openViaInput = () => {
+    if (this.isActiveTriggerReadOnly()) {
+      if (!this.state.open) {
+        this.setState({ open: true });
+      }
+      return;
+    }
     this.openedViaInput = true;
     if (this.state.open) {
       this.focusTrapIncludesTrigger = true;
@@ -336,6 +349,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
    * input element, so this does not fire and the calendar still receives focus.
    */
   flagOpenFromInput = () => {
+    if (this.isActiveTriggerReadOnly()) return;
     this.triggerHadPointerDown = true;
     this.openedViaInput = true;
     this.includeTriggerInFocusTrapWhenOpen();

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -327,6 +327,11 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
    * Flags the open so focus is not pulled into the calendar dialog.
    */
   openViaInput = () => {
+    const { singleInput, inputOptions, startInputOptions, endInputOptions } = this.props;
+    const disabled = singleInput ? inputOptions.disabled : startInputOptions.disabled || endInputOptions.disabled;
+
+    if (disabled) return;
+
     if (this.isActiveTriggerReadOnly()) {
       if (!this.state.open) {
         this.setState({ open: true });

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -7,8 +7,11 @@ import { Validators } from '@/utils/types';
 import { Trigger } from './Trigger';
 import { SingleInputTrigger } from './SingleInputTrigger';
 import { getDateInfo, convertToDate, compareDate, translateToString } from '../calendar/utility';
+import { getInitialFocusCell } from '../calendar/utils';
 import { Popover, Utils } from '@/index';
 import styles from '@css/components/dateRangePicker.module.css';
+import uidGenerator from '@/utils/uidGenerator';
+import { getFocusableElements, handleFocusTrapKeyDown, restoreFocusToElementIfConnected } from '@/utils/overlayHelper';
 import {
   getCurrentWeek,
   getPreviousWeek,
@@ -158,6 +161,29 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
   };
   monthsInView: number;
 
+  dialogRef = React.createRef<HTMLDivElement>();
+  startTriggerRef = React.createRef<HTMLInputElement>();
+  endTriggerRef = React.createRef<HTMLInputElement>();
+  singleTriggerRef = React.createRef<HTMLInputElement>();
+  panelId: string;
+  /** Tracks which trigger input (start/end/single) most recently had focus, so focus can be returned to it on close */
+  activeField: 'start' | 'end' | 'single' = 'start';
+  /**
+   * `true` when the popover opened as a side effect of typing/pasting into an
+   * editable input. In that case focus must stay in the input (caret preserved)
+   * and must NOT be moved into the calendar dialog.
+   */
+  openedViaInput = false;
+  /**
+   * `true` when the popover is closing as a result of a click outside the
+   * dialog. In that case the user has already moved focus/interaction
+   * elsewhere, so `deactivateFocusTrap` must NOT steal focus back to the
+   * trigger. Reset immediately after being consumed.
+   */
+  closedViaOutsideClick = false;
+  /** When true, the active trigger input is included in Tab trapping (input-originated open). */
+  focusTrapIncludesTrigger = false;
+
   constructor(props: DateRangePickerProps) {
     super(props);
 
@@ -168,6 +194,8 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     const { startValue, endValue } = this.getDate(startDate, endDate);
 
     const { startError, endError } = this.getErrors(startDate, endDate);
+
+    this.panelId = `DateRangePicker-dialog-${uidGenerator()}`;
 
     this.state = {
       startDate,
@@ -184,6 +212,144 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
     this.monthsInView = props.monthsInView || (props.withInput ? 2 : 1);
   }
+
+  componentDidMount() {
+    if (this.state.open) {
+      this.activateFocusTrap();
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.state.open) {
+      document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+    }
+  }
+
+  onFocusTrapKeyDown = (event: KeyboardEvent) => {
+    const container = this.dialogRef.current;
+    if (!container) return;
+    handleFocusTrapKeyDown(event, container, undefined, this.getFocusTrapExternalTargets());
+  };
+
+  getFocusTrapExternalTargets = (): (HTMLElement | null)[] | undefined => {
+    if (!this.focusTrapIncludesTrigger) return undefined;
+    const { singleInput } = this.props;
+    if (singleInput) {
+      return [this.singleTriggerRef.current];
+    }
+    // Dual-input manual entry: Tab must reach both start and end fields.
+    return [this.startTriggerRef.current, this.endTriggerRef.current];
+  };
+
+  focusInitialElement = () => {
+    const container = this.dialogRef.current;
+    if (!container) return;
+    const target = getInitialFocusCell(container) || getFocusableElements(container)[0];
+    target?.focus({ preventScroll: true });
+  };
+
+  /**
+   * `Popover` mounts its portal (and therefore `dialogRef`) in a passive
+   * `useEffect`, which can run after the `requestAnimationFrame` scheduled
+   * below. Poll across a bounded number of animation frames until the dialog
+   * node exists before moving focus into it, so focus isn't silently dropped
+   * back on the input (leaving Tab free to escape the `aria-modal` dialog).
+   */
+  waitForDialogAndFocus = (retriesLeft = 10) => {
+    window.requestAnimationFrame(() => {
+      if (!this.state.open) return;
+      if (this.dialogRef.current) {
+        this.focusInitialElement();
+      } else if (retriesLeft > 0) {
+        this.waitForDialogAndFocus(retriesLeft - 1);
+      }
+    });
+  };
+
+  activateFocusTrap = (moveFocus = true) => {
+    // Always arm the focus trap (Tab handling) while the dialog is open.
+    // Only move focus into the calendar for explicit opens; when the popover
+    // opened because the user is typing/pasting, leave the caret in the input
+    // and include that trigger in the trap cycle.
+    this.focusTrapIncludesTrigger = !moveFocus;
+    if (moveFocus) {
+      this.waitForDialogAndFocus();
+    }
+    document.addEventListener('keydown', this.onFocusTrapKeyDown, true);
+  };
+
+  /**
+   * When the popover is already open, re-include the active trigger in Tab
+   * trapping after the user refocuses an editable input (click/label/type path).
+   */
+  includeTriggerInFocusTrapWhenOpen = () => {
+    if (this.state.open) {
+      this.focusTrapIncludesTrigger = true;
+    }
+  };
+
+  /**
+   * Opens the popover as a result of typing/pasting in an editable input.
+   * Flags the open so focus is not pulled into the calendar dialog.
+   */
+  openViaInput = () => {
+    this.openedViaInput = true;
+    if (this.state.open) {
+      this.focusTrapIncludesTrigger = true;
+    } else {
+      this.setState({ open: true });
+    }
+  };
+
+  /**
+   * Flags that the popover open about to be triggered originates from a pointer
+   * press on an input itself (mouse click into an editable field). Fires on
+   * `mousedown`, before the wrapper click that opens the popover, so focus stays
+   * in the input (caret preserved). Pressing the calendar icon does NOT hit the
+   * input element, so this does not fire and the calendar still receives focus.
+   */
+  flagOpenFromInput = () => {
+    this.openedViaInput = true;
+    this.includeTriggerInFocusTrapWhenOpen();
+  };
+
+  /**
+   * Explicit keyboard open (ArrowDown / Alt+ArrowDown on an input). Unlike
+   * typing, this is an intentional request to enter the calendar, so focus IS
+   * moved into the grid: opening goes through the explicit path
+   * (`openedViaInput` stays false → `activateFocusTrap(true)`), and when the
+   * popover is already open focus is moved into the grid directly. The trigger
+   * side (start/end) is tracked via `activeField` for focus return on close.
+   */
+  openViaKeyboard = () => {
+    if (this.state.open) {
+      this.waitForDialogAndFocus();
+    } else {
+      this.setState({ open: true });
+    }
+  };
+
+  deactivateFocusTrap = () => {
+    document.removeEventListener('keydown', this.onFocusTrapKeyDown, true);
+    this.focusTrapIncludesTrigger = false;
+    if (this.closedViaOutsideClick) {
+      // The user's click already moved focus/interaction elsewhere; don't pull
+      // it back to the trigger.
+      this.closedViaOutsideClick = false;
+      return;
+    }
+    const { singleInput } = this.props;
+    const triggerRef = singleInput
+      ? this.singleTriggerRef
+      : this.activeField === 'end'
+      ? this.endTriggerRef
+      : this.startTriggerRef;
+    restoreFocusToElementIfConnected(triggerRef.current, this.dialogRef.current);
+  };
+
+  setActiveField = (field: 'start' | 'end' | 'single') => {
+    this.activeField = field;
+  };
 
   componentDidUpdate(prevProps: DateRangePickerProps, prevState: DateRangePickerState) {
     if (prevProps.startDate !== this.props.startDate) {
@@ -262,6 +428,15 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           open: false,
         });
       }
+    }
+
+    if (prevState.open !== this.state.open) {
+      if (this.state.open) {
+        this.activateFocusTrap(!this.openedViaInput);
+      } else {
+        this.deactivateFocusTrap();
+      }
+      this.openedViaInput = false;
     }
   }
 
@@ -348,6 +523,9 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
     switch (type) {
       case 'outsideClick':
+        if (!o) this.closedViaOutsideClick = true;
+        this.setState({ open: o });
+        break;
       case 'escapeKeypress':
         this.setState({ open: o });
         break;
@@ -421,20 +599,24 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
     });
 
     if (withInput) {
+      const resolvedSingleAriaLabel = inputOptions['aria-label'] || ariaLabel;
+      const resolvedSingleAriaLabelledby = inputOptions['aria-labelledby'] || ariaLabelledBy;
       const mergedSingleInputOptions = {
         ...inputOptions,
-        'aria-label': inputOptions['aria-label'] || ariaLabel,
-        'aria-labelledby': inputOptions['aria-labelledby'] || ariaLabelledBy,
+        ...(resolvedSingleAriaLabel ? { 'aria-label': resolvedSingleAriaLabel } : {}),
+        ...(resolvedSingleAriaLabelledby ? { 'aria-labelledby': resolvedSingleAriaLabelledby } : {}),
       };
+      const resolvedStartAriaLabelledby = startInputOptions['aria-labelledby'] || ariaLabelledBy;
       const mergedStartInputOptions = {
         ...startInputOptions,
-        'aria-label': startInputOptions['aria-label'],
-        'aria-labelledby': startInputOptions['aria-labelledby'] || ariaLabelledBy,
+        ...(startInputOptions['aria-label'] ? { 'aria-label': startInputOptions['aria-label'] } : {}),
+        ...(resolvedStartAriaLabelledby ? { 'aria-labelledby': resolvedStartAriaLabelledby } : {}),
       };
+      const resolvedEndAriaLabelledby = endInputOptions['aria-labelledby'] || ariaLabelledBy;
       const mergedEndInputOptions = {
         ...endInputOptions,
-        'aria-label': endInputOptions['aria-label'],
-        'aria-labelledby': endInputOptions['aria-labelledby'] || ariaLabelledBy,
+        ...(endInputOptions['aria-label'] ? { 'aria-label': endInputOptions['aria-label'] } : {}),
+        ...(resolvedEndAriaLabelledby ? { 'aria-labelledby': resolvedEndAriaLabelledby } : {}),
       };
       const trigger = singleInput ? (
         <SingleInputTrigger
@@ -443,6 +625,12 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           validators={validators}
           state={this.state}
           setState={this.setState.bind(this)}
+          open={open}
+          panelId={this.panelId}
+          triggerRef={this.singleTriggerRef}
+          onTriggerFocus={() => this.setActiveField('single')}
+          onInputMouseDown={this.flagOpenFromInput}
+          onKeyboardOpen={this.openViaKeyboard}
         />
       ) : (
         <Trigger
@@ -452,8 +640,18 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           validators={validators}
           state={this.state}
           setState={this.setState.bind(this)}
+          open={open}
+          panelId={this.panelId}
+          startTriggerRef={this.startTriggerRef}
+          endTriggerRef={this.endTriggerRef}
+          onTriggerFocus={this.setActiveField}
+          openViaInput={this.openViaInput}
+          onInputMouseDown={this.flagOpenFromInput}
+          onKeyboardOpen={this.openViaKeyboard}
         />
       );
+
+      const dialogLabel = 'Choose date range';
 
       return (
         <Popover
@@ -465,8 +663,10 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
           open={open}
           onToggle={this.onToggleHandler}
         >
-          {children}
-          {this.renderCalendar()}
+          <div role="dialog" aria-modal="true" aria-label={dialogLabel} id={this.panelId} ref={this.dialogRef}>
+            {children}
+            {this.renderCalendar()}
+          </div>
         </Popover>
       );
     }

--- a/core/components/organisms/dateRangePicker/DateRangePicker.tsx
+++ b/core/components/organisms/dateRangePicker/DateRangePicker.tsx
@@ -184,6 +184,21 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
   /** When true, the active trigger input is included in Tab trapping (input-originated open). */
   focusTrapIncludesTrigger = false;
 
+  isFocusOnTrigger = () => {
+    const active = document.activeElement;
+    if (!active) return false;
+    const triggers = [this.startTriggerRef.current, this.endTriggerRef.current, this.singleTriggerRef.current];
+    return triggers.some((el) => el && (el === active || el.contains(active)));
+  };
+
+  /** Controlled opens that happen while a trigger input already has focus. */
+  flagOpenFromFocusedTrigger = () => {
+    if (this.isFocusOnTrigger()) {
+      this.openedViaInput = true;
+      this.focusTrapIncludesTrigger = true;
+    }
+  };
+
   constructor(props: DateRangePickerProps) {
     super(props);
 
@@ -432,6 +447,7 @@ export class DateRangePicker extends React.Component<DateRangePickerProps, DateR
 
     if (prevState.open !== this.state.open) {
       if (this.state.open) {
+        this.flagOpenFromFocusedTrigger();
         this.activateFocusTrap(!this.openedViaInput);
       } else {
         this.deactivateFocusTrap();

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -186,7 +186,10 @@ export const SingleInputTrigger = (props: TriggerProps) => {
     if (!endVal || endVal.includes(placeholderChar)) setState({ endDate: undefined });
   };
 
-  const onClearHandler = () => {
+  const onClearHandler = (e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+    if (e?.type === 'click') {
+      onInputMouseDown?.();
+    }
     setState({
       init: true,
       startDate: undefined,

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -32,6 +32,7 @@ type TriggerProps = {
    * the input instead of moving focus into the calendar.
    */
   onInputMouseDown?: () => void;
+  onTriggerPointerDown?: () => void;
   /**
    * Called on an explicit keyboard open gesture (ArrowDown / Alt+ArrowDown) to
    * open the calendar AND move focus into the grid.
@@ -51,6 +52,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
     triggerRef,
     onTriggerFocus,
     onInputMouseDown,
+    onTriggerPointerDown,
     onKeyboardOpen,
   } = props;
 
@@ -200,50 +202,53 @@ export const SingleInputTrigger = (props: TriggerProps) => {
   };
 
   return (
-    <Row data-test="DesignSystem-DateRangePicker-SingleInputTrigger">
-      <Column>
-        {label && (
-          <Label
-            required={inputOptions.required}
-            withInput={true}
-            htmlFor={fieldId}
-            onMouseDown={() => onInputMouseDown?.()}
-          >
-            {label}
-          </Label>
-        )}
-        <InputMask
-          icon="events"
-          placeholder={`${inputFormat} - ${inputFormat}`}
-          {...inputOptions}
-          id={fieldId}
-          mask={mask}
-          value={!startDate && !endDate && !init ? undefined : `${sValue} - ${eValue}`}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
-            onChangeHandler(e, val || '');
-          }}
-          onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
-            onBlurHandler(e, val || '');
-          }}
-          onPaste={(e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
-            onPasteHandler(e, val || '');
-          }}
-          onClear={onClearHandler}
-          onMouseDown={onMouseDownHandler}
-          onKeyDown={onKeyDownHandler}
-          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
-            inputOptions.onFocus?.(e);
-            onTriggerFocus?.();
-          }}
-          error={showError}
-          caption={showError ? errorMessage : ''}
-          validators={[inputValidator]}
-          clearOnEmptyBlur={true}
-          ref={triggerRef}
-          aria-expanded={open}
-          aria-controls={panelId}
-        />
-      </Column>
-    </Row>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
+      <Row data-test="DesignSystem-DateRangePicker-SingleInputTrigger">
+        <Column>
+          {label && (
+            <Label
+              required={inputOptions.required}
+              withInput={true}
+              htmlFor={fieldId}
+              onMouseDown={() => onInputMouseDown?.()}
+            >
+              {label}
+            </Label>
+          )}
+          <InputMask
+            icon="events"
+            placeholder={`${inputFormat} - ${inputFormat}`}
+            {...inputOptions}
+            id={fieldId}
+            mask={mask}
+            value={!startDate && !endDate && !init ? undefined : `${sValue} - ${eValue}`}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
+              onChangeHandler(e, val || '');
+            }}
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
+              onBlurHandler(e, val || '');
+            }}
+            onPaste={(e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
+              onPasteHandler(e, val || '');
+            }}
+            onClear={onClearHandler}
+            onMouseDown={onMouseDownHandler}
+            onKeyDown={onKeyDownHandler}
+            onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+              inputOptions.onFocus?.(e);
+              onTriggerFocus?.();
+            }}
+            error={showError}
+            caption={showError ? errorMessage : ''}
+            validators={[inputValidator]}
+            clearOnEmptyBlur={true}
+            ref={triggerRef}
+            aria-expanded={open}
+            aria-controls={panelId}
+          />
+        </Column>
+      </Row>
+    </div>
   );
 };

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -81,6 +81,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
   const { placeholderChar = '_' } = inputOptions;
   const fieldIdRef = React.useRef<string>(`DateRangePicker-singleInput-${uidGenerator()}`);
   const fieldId = inputOptions.id || fieldIdRef.current;
+  const labelId = `${fieldId}-label`;
   const defaultValue = InputMask.utils.getDefaultValue(mask, placeholderChar).split(' - ');
   const sValue = startValue || defaultValue[0];
   const eValue = endValue || defaultValue[1];
@@ -210,6 +211,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
         <Column>
           {label && (
             <Label
+              id={labelId}
               required={inputOptions.required}
               withInput={true}
               htmlFor={fieldId}
@@ -247,11 +249,13 @@ export const SingleInputTrigger = (props: TriggerProps) => {
             caption={showError ? errorMessage : ''}
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
+            fillTemplateOnFocus={false}
             ref={triggerRef}
             role="combobox"
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
+            aria-labelledby={label ? labelId : inputOptions['aria-labelledby']}
           />
         </Column>
       </Row>

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -58,7 +58,9 @@ export const SingleInputTrigger = (props: TriggerProps) => {
 
   const onMouseDownHandler = (e: React.MouseEvent<HTMLInputElement>) => {
     inputOptions.onMouseDown?.(e);
-    onInputMouseDown?.();
+    if (!inputOptions.readOnly) {
+      onInputMouseDown?.();
+    }
   };
 
   const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -189,7 +191,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
   };
 
   const onClearHandler = (e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
-    if (e?.type === 'click') {
+    if (e?.type === 'click' && !inputOptions.readOnly) {
       onInputMouseDown?.();
     }
     setState({
@@ -211,7 +213,9 @@ export const SingleInputTrigger = (props: TriggerProps) => {
               required={inputOptions.required}
               withInput={true}
               htmlFor={fieldId}
-              onMouseDown={() => onInputMouseDown?.()}
+              onMouseDown={() => {
+                if (!inputOptions.readOnly) onInputMouseDown?.();
+              }}
             >
               {label}
             </Label>

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -204,6 +204,9 @@ export const SingleInputTrigger = (props: TriggerProps) => {
     });
   };
 
+  const resolvedAriaLabelledby =
+    [label && labelId, inputOptions['aria-labelledby']].filter(Boolean).join(' ') || undefined;
+
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
@@ -256,7 +259,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
-            aria-labelledby={label ? labelId : inputOptions['aria-labelledby']}
+            aria-labelledby={resolvedAriaLabelledby}
           />
         </Column>
       </Row>

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { InputMask, Row, Column, Label, Utils } from '@/index';
 import { compareDate, getDateInfo, translateToDate } from '../calendar/utility';
 import { DateRangePickerProps, DateRangePickerState } from './DateRangePicker';
+import uidGenerator from '@/utils/uidGenerator';
 
 type TriggerProps = {
   inputFormat: DateRangePickerProps['inputFormat'];
@@ -9,10 +10,63 @@ type TriggerProps = {
   validators: DateRangePickerProps['validators'];
   state: DateRangePickerState;
   setState: any;
+  /**
+   * Whether the calendar popover is currently open (drives `aria-expanded`)
+   */
+  open?: boolean;
+  /**
+   * `id` of the calendar dialog panel this trigger controls (drives `aria-controls`)
+   */
+  panelId?: string;
+  /**
+   * Ref to the underlying `input` element, used to return focus on popover close
+   */
+  triggerRef?: React.Ref<HTMLInputElement>;
+  /**
+   * Called when the input receives focus
+   */
+  onTriggerFocus?: () => void;
+  /**
+   * Called on `mousedown` on the input element (before the wrapper click that
+   * opens the popover) so a click INTO the editable field keeps the caret in
+   * the input instead of moving focus into the calendar.
+   */
+  onInputMouseDown?: () => void;
+  /**
+   * Called on an explicit keyboard open gesture (ArrowDown / Alt+ArrowDown) to
+   * open the calendar AND move focus into the grid.
+   */
+  onKeyboardOpen?: () => void;
 };
 
 export const SingleInputTrigger = (props: TriggerProps) => {
-  const { inputFormat, inputOptions, validators, state, setState } = props;
+  const {
+    inputFormat,
+    inputOptions,
+    validators,
+    state,
+    setState,
+    open,
+    panelId,
+    triggerRef,
+    onTriggerFocus,
+    onInputMouseDown,
+    onKeyboardOpen,
+  } = props;
+
+  const onMouseDownHandler = (e: React.MouseEvent<HTMLInputElement>) => {
+    inputOptions.onMouseDown?.(e);
+    onInputMouseDown?.();
+  };
+
+  const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    inputOptions.onKeyDown?.(e);
+    if (e.key === 'ArrowDown') {
+      // Explicit keyboard open: enter the calendar grid (prevent caret jump).
+      e.preventDefault();
+      onKeyboardOpen?.();
+    }
+  };
 
   const { init, startDate, endDate, startValue, endValue, startError, endError } = state;
 
@@ -21,6 +75,8 @@ export const SingleInputTrigger = (props: TriggerProps) => {
   const errorMessage = inputOptions.caption === undefined ? 'Invalid value' : inputOptions.caption;
   const { label } = inputOptions;
   const { placeholderChar = '_' } = inputOptions;
+  const fieldIdRef = React.useRef<string>(`DateRangePicker-singleInput-${uidGenerator()}`);
+  const fieldId = inputOptions.id || fieldIdRef.current;
   const defaultValue = InputMask.utils.getDefaultValue(mask, placeholderChar).split(' - ');
   const sValue = startValue || defaultValue[0];
   const eValue = endValue || defaultValue[1];
@@ -144,7 +200,12 @@ export const SingleInputTrigger = (props: TriggerProps) => {
     <Row data-test="DesignSystem-DateRangePicker-SingleInputTrigger">
       <Column>
         {label && (
-          <Label required={inputOptions.required} withInput={true}>
+          <Label
+            required={inputOptions.required}
+            withInput={true}
+            htmlFor={fieldId}
+            onMouseDown={() => onInputMouseDown?.()}
+          >
             {label}
           </Label>
         )}
@@ -152,6 +213,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
           icon="events"
           placeholder={`${inputFormat} - ${inputFormat}`}
           {...inputOptions}
+          id={fieldId}
           mask={mask}
           value={!startDate && !endDate && !init ? undefined : `${sValue} - ${eValue}`}
           onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
@@ -164,10 +226,19 @@ export const SingleInputTrigger = (props: TriggerProps) => {
             onPasteHandler(e, val || '');
           }}
           onClear={onClearHandler}
+          onMouseDown={onMouseDownHandler}
+          onKeyDown={onKeyDownHandler}
+          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+            inputOptions.onFocus?.(e);
+            onTriggerFocus?.();
+          }}
           error={showError}
           caption={showError ? errorMessage : ''}
           validators={[inputValidator]}
           clearOnEmptyBlur={true}
+          ref={triggerRef}
+          aria-expanded={open}
+          aria-controls={panelId}
         />
       </Column>
     </Row>

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -249,6 +249,7 @@ export const SingleInputTrigger = (props: TriggerProps) => {
             caption={showError ? errorMessage : ''}
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
+            useDefaultValueOnEmpty={true}
             fillTemplateOnFocus={false}
             ref={triggerRef}
             role="combobox"

--- a/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
+++ b/core/components/organisms/dateRangePicker/SingleInputTrigger.tsx
@@ -244,6 +244,8 @@ export const SingleInputTrigger = (props: TriggerProps) => {
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
             ref={triggerRef}
+            role="combobox"
+            aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
           />

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -86,12 +86,16 @@ export const Trigger = (props: TriggerProps) => {
 
   const onStartMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
     startInputOptions.onMouseDown?.(e);
-    onInputMouseDown?.();
+    if (!startInputOptions.readOnly) {
+      onInputMouseDown?.();
+    }
   };
 
   const onEndMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
     endInputOptions.onMouseDown?.(e);
-    onInputMouseDown?.();
+    if (!endInputOptions.readOnly) {
+      onInputMouseDown?.();
+    }
   };
 
   const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>, type: 'start' | 'end') => {
@@ -214,7 +218,8 @@ export const Trigger = (props: TriggerProps) => {
   };
 
   const onClearHandler = (type: string, e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
-    if (e?.type === 'click') {
+    const readOnly = type === 'start' ? startInputOptions.readOnly : endInputOptions.readOnly;
+    if (e?.type === 'click' && !readOnly) {
       onInputMouseDown?.();
     }
     setState({
@@ -278,7 +283,9 @@ export const Trigger = (props: TriggerProps) => {
               required={startInputOptions.required}
               withInput={true}
               htmlFor={startFieldId}
-              onMouseDown={() => onInputMouseDown?.()}
+              onMouseDown={() => {
+                if (!startInputOptions.readOnly) onInputMouseDown?.();
+              }}
             >
               {startLabel}
             </Label>
@@ -332,7 +339,9 @@ export const Trigger = (props: TriggerProps) => {
               required={endInputOptions.required}
               withInput={true}
               htmlFor={endFieldId}
-              onMouseDown={() => onInputMouseDown?.()}
+              onMouseDown={() => {
+                if (!endInputOptions.readOnly) onInputMouseDown?.();
+              }}
             >
               {endLabel}
             </Label>

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -263,6 +263,8 @@ export const Trigger = (props: TriggerProps) => {
   const endFieldIdRef = React.useRef<string>(`DateRangePicker-endInput-${uidGenerator()}`);
   const startFieldId = startInputOptions.id || startFieldIdRef.current;
   const endFieldId = endInputOptions.id || endFieldIdRef.current;
+  const startLabelId = `${startFieldId}-label`;
+  const endLabelId = `${endFieldId}-label`;
   const inputValidator = (val: string): boolean => {
     return Utils.validators.isValid(validators, val, inputFormat);
   };
@@ -284,6 +286,7 @@ export const Trigger = (props: TriggerProps) => {
         <Column size={'6'} sizeXS={'12'} className={StartInputClassName}>
           {startLabel && (
             <Label
+              id={startLabelId}
               required={startInputOptions.required}
               withInput={true}
               htmlFor={startFieldId}
@@ -331,16 +334,19 @@ export const Trigger = (props: TriggerProps) => {
             caption={showStartError ? startErrorMessage : ''}
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
+            fillTemplateOnFocus={false}
             ref={startTriggerRef}
             role="combobox"
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
+            aria-labelledby={startLabel ? startLabelId : startInputOptions['aria-labelledby']}
           />
         </Column>
         <Column size={'6'} sizeXS={'12'} className={EndInputClassName}>
           {endLabel && (
             <Label
+              id={endLabelId}
               required={endInputOptions.required}
               withInput={true}
               htmlFor={endFieldId}
@@ -386,11 +392,13 @@ export const Trigger = (props: TriggerProps) => {
             caption={showEndError ? endErrorMessage : ''}
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
+            fillTemplateOnFocus={false}
             ref={endTriggerRef}
             role="combobox"
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
+            aria-labelledby={endLabel ? endLabelId : endInputOptions['aria-labelledby']}
           />
         </Column>
       </Row>

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -334,6 +334,7 @@ export const Trigger = (props: TriggerProps) => {
             caption={showStartError ? startErrorMessage : ''}
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
+            useDefaultValueOnEmpty={true}
             fillTemplateOnFocus={false}
             ref={startTriggerRef}
             role="combobox"
@@ -392,6 +393,7 @@ export const Trigger = (props: TriggerProps) => {
             caption={showEndError ? endErrorMessage : ''}
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
+            useDefaultValueOnEmpty={true}
             fillTemplateOnFocus={false}
             ref={endTriggerRef}
             role="combobox"

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -210,7 +210,10 @@ export const Trigger = (props: TriggerProps) => {
     }
   };
 
-  const onClearHandler = (type: string) => {
+  const onClearHandler = (type: string, e?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+    if (e?.type === 'click') {
+      onInputMouseDown?.();
+    }
     setState({
       init: true,
     });
@@ -297,7 +300,7 @@ export const Trigger = (props: TriggerProps) => {
           onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
             onBlurHandler(e, val || '', 'start');
           }}
-          onClear={() => onClearHandler('start')}
+          onClear={(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => onClearHandler('start', e)}
           onClick={() => onClickHandler('start')}
           onMouseDown={onStartMouseDown}
           onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'start')}
@@ -347,7 +350,7 @@ export const Trigger = (props: TriggerProps) => {
           onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
             onBlurHandler(e, val || '', 'end');
           }}
-          onClear={() => onClearHandler('end')}
+          onClear={(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => onClearHandler('end', e)}
           onClick={() => onClickHandler('end')}
           onMouseDown={onEndMouseDown}
           onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'end')}

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -4,6 +4,7 @@ import { compareDate, getDateInfo, translateToDate, translateToString } from '..
 import { DateRangePickerProps, DateRangePickerState } from './DateRangePicker';
 import styles from '@css/components/dateRangePicker.module.css';
 import classNames from 'classnames';
+import uidGenerator from '@/utils/uidGenerator';
 
 type TriggerProps = {
   inputFormat: DateRangePickerProps['inputFormat'];
@@ -12,12 +13,95 @@ type TriggerProps = {
   validators: DateRangePickerProps['validators'];
   state: DateRangePickerState;
   setState: any;
+  /**
+   * Whether the calendar popover is currently open (drives `aria-expanded`)
+   */
+  open?: boolean;
+  /**
+   * `id` of the calendar dialog panel this trigger controls (drives `aria-controls`)
+   */
+  panelId?: string;
+  /**
+   * Ref to the start-date input element, used to return focus on popover close
+   */
+  startTriggerRef?: React.Ref<HTMLInputElement>;
+  /**
+   * Ref to the end-date input element, used to return focus on popover close
+   */
+  endTriggerRef?: React.Ref<HTMLInputElement>;
+  /**
+   * Called with `'start'` or `'end'` when the corresponding input receives focus,
+   * so the parent knows which trigger to return focus to on close
+   */
+  onTriggerFocus?: (type: 'start' | 'end') => void;
+  /**
+   * Opens the popover as a side effect of typing/pasting, WITHOUT moving focus
+   * into the calendar dialog (keeps the caret in the input). Falls back to a
+   * plain `open` state update when not provided.
+   */
+  openViaInput?: () => void;
+  /**
+   * Called on `mousedown` on an input element (before the wrapper click that
+   * opens the popover) so a click INTO an editable field keeps the caret in
+   * that input instead of moving focus into the calendar.
+   */
+  onInputMouseDown?: () => void;
+  /**
+   * Called on an explicit keyboard open gesture (ArrowDown / Alt+ArrowDown) to
+   * open the calendar AND move focus into the grid.
+   */
+  onKeyboardOpen?: () => void;
 };
 
 export const Trigger = (props: TriggerProps) => {
-  const { inputFormat, startInputOptions, endInputOptions, validators, state, setState } = props;
+  const {
+    inputFormat,
+    startInputOptions,
+    endInputOptions,
+    validators,
+    state,
+    setState,
+    open,
+    panelId,
+    startTriggerRef,
+    endTriggerRef,
+    onTriggerFocus,
+    openViaInput,
+    onInputMouseDown,
+    onKeyboardOpen,
+  } = props;
 
   const { init, startDate, endDate, startError, endError } = state;
+
+  const openPopoverFromInput = () => {
+    if (openViaInput) {
+      openViaInput();
+    } else {
+      setState({ open: true });
+    }
+  };
+
+  const onStartMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+    startInputOptions.onMouseDown?.(e);
+    onInputMouseDown?.();
+  };
+
+  const onEndMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+    endInputOptions.onMouseDown?.(e);
+    onInputMouseDown?.();
+  };
+
+  const onKeyDownHandler = (e: React.KeyboardEvent<HTMLInputElement>, type: 'start' | 'end') => {
+    const consumerOnKeyDown = type === 'start' ? startInputOptions.onKeyDown : endInputOptions.onKeyDown;
+    consumerOnKeyDown?.(e);
+    if (e.key === 'ArrowDown') {
+      // Explicit keyboard open: enter the calendar grid (prevent caret jump).
+      e.preventDefault();
+      // Open the calendar to the month of the field being navigated from.
+      if (!open) updateNav(type);
+      onKeyboardOpen?.();
+    }
+  };
 
   const updateNav = (type: string) => {
     if (type === 'start') {
@@ -38,7 +122,7 @@ export const Trigger = (props: TriggerProps) => {
   };
 
   const onPasteHandler = (_e: React.ClipboardEvent<HTMLInputElement>, val: string, type: string) => {
-    setState({ open: true });
+    openPopoverFromInput();
 
     if (type === 'start') {
       const placeholderChar = startInputOptions.placeholderChar || '_';
@@ -69,7 +153,7 @@ export const Trigger = (props: TriggerProps) => {
   };
 
   const onChangeHandler = (_e: React.ChangeEvent<HTMLInputElement>, val: string, type: string) => {
-    setState({ open: true });
+    openPopoverFromInput();
 
     if (type === 'start') {
       const placeholderChar = startInputOptions.placeholderChar || '_';
@@ -160,6 +244,10 @@ export const Trigger = (props: TriggerProps) => {
   const endErrorMessage = endInputOptions.caption === undefined ? 'Invalid value' : endInputOptions.caption;
   const { label: startLabel } = startInputOptions;
   const { label: endLabel } = endInputOptions;
+  const startFieldIdRef = React.useRef<string>(`DateRangePicker-startInput-${uidGenerator()}`);
+  const endFieldIdRef = React.useRef<string>(`DateRangePicker-endInput-${uidGenerator()}`);
+  const startFieldId = startInputOptions.id || startFieldIdRef.current;
+  const endFieldId = endInputOptions.id || endFieldIdRef.current;
   const inputValidator = (val: string): boolean => {
     return Utils.validators.isValid(validators, val, inputFormat);
   };
@@ -178,7 +266,12 @@ export const Trigger = (props: TriggerProps) => {
     <Row data-test="DesignSystem-DateRangePicker-InputTrigger">
       <Column size={'6'} sizeXS={'12'} className={StartInputClassName}>
         {startLabel && (
-          <Label required={startInputOptions.required} withInput={true}>
+          <Label
+            required={startInputOptions.required}
+            withInput={true}
+            htmlFor={startFieldId}
+            onMouseDown={() => onInputMouseDown?.()}
+          >
             {startLabel}
           </Label>
         )}
@@ -186,6 +279,7 @@ export const Trigger = (props: TriggerProps) => {
           icon="events"
           placeholder={inputFormat}
           {...startInputOptions}
+          id={startFieldId}
           mask={mask}
           value={
             startDate
@@ -205,15 +299,29 @@ export const Trigger = (props: TriggerProps) => {
           }}
           onClear={() => onClearHandler('start')}
           onClick={() => onClickHandler('start')}
+          onMouseDown={onStartMouseDown}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'start')}
+          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+            startInputOptions.onFocus?.(e);
+            onTriggerFocus?.('start');
+          }}
           error={showStartError}
           caption={showStartError ? startErrorMessage : ''}
           validators={[inputValidator]}
           clearOnEmptyBlur={true}
+          ref={startTriggerRef}
+          aria-expanded={open}
+          aria-controls={panelId}
         />
       </Column>
       <Column size={'6'} sizeXS={'12'} className={EndInputClassName}>
         {endLabel && (
-          <Label required={endInputOptions.required} withInput={true}>
+          <Label
+            required={endInputOptions.required}
+            withInput={true}
+            htmlFor={endFieldId}
+            onMouseDown={() => onInputMouseDown?.()}
+          >
             {endLabel}
           </Label>
         )}
@@ -221,6 +329,7 @@ export const Trigger = (props: TriggerProps) => {
           icon="events"
           placeholder={inputFormat}
           {...endInputOptions}
+          id={endFieldId}
           mask={mask}
           value={
             endDate
@@ -240,10 +349,19 @@ export const Trigger = (props: TriggerProps) => {
           }}
           onClear={() => onClearHandler('end')}
           onClick={() => onClickHandler('end')}
+          onMouseDown={onEndMouseDown}
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'end')}
+          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+            endInputOptions.onFocus?.(e);
+            onTriggerFocus?.('end');
+          }}
           error={showEndError}
           caption={showEndError ? endErrorMessage : ''}
           validators={[inputValidator]}
           clearOnEmptyBlur={true}
+          ref={endTriggerRef}
+          aria-expanded={open}
+          aria-controls={panelId}
         />
       </Column>
     </Row>

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -279,6 +279,11 @@ export const Trigger = (props: TriggerProps) => {
     [styles['DateRangePicker-input--endDate']]: true,
   });
 
+  const resolvedStartAriaLabelledby =
+    [startLabel && startLabelId, startInputOptions['aria-labelledby']].filter(Boolean).join(' ') || undefined;
+  const resolvedEndAriaLabelledby =
+    [endLabel && endLabelId, endInputOptions['aria-labelledby']].filter(Boolean).join(' ') || undefined;
+
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
@@ -341,7 +346,7 @@ export const Trigger = (props: TriggerProps) => {
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
-            aria-labelledby={startLabel ? startLabelId : startInputOptions['aria-labelledby']}
+            aria-labelledby={resolvedStartAriaLabelledby}
           />
         </Column>
         <Column size={'6'} sizeXS={'12'} className={EndInputClassName}>
@@ -400,7 +405,7 @@ export const Trigger = (props: TriggerProps) => {
             aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
-            aria-labelledby={endLabel ? endLabelId : endInputOptions['aria-labelledby']}
+            aria-labelledby={resolvedEndAriaLabelledby}
           />
         </Column>
       </Row>

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -320,6 +320,8 @@ export const Trigger = (props: TriggerProps) => {
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
             ref={startTriggerRef}
+            role="combobox"
+            aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
           />
@@ -370,6 +372,8 @@ export const Trigger = (props: TriggerProps) => {
             validators={[inputValidator]}
             clearOnEmptyBlur={true}
             ref={endTriggerRef}
+            role="combobox"
+            aria-haspopup="dialog"
             aria-expanded={open}
             aria-controls={panelId}
           />

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -86,6 +86,7 @@ export const Trigger = (props: TriggerProps) => {
 
   const onStartMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
     startInputOptions.onMouseDown?.(e);
+    onTriggerFocus?.('start');
     if (!startInputOptions.readOnly) {
       onInputMouseDown?.();
     }
@@ -93,6 +94,7 @@ export const Trigger = (props: TriggerProps) => {
 
   const onEndMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
     endInputOptions.onMouseDown?.(e);
+    onTriggerFocus?.('end');
     if (!endInputOptions.readOnly) {
       onInputMouseDown?.();
     }
@@ -129,6 +131,7 @@ export const Trigger = (props: TriggerProps) => {
   };
 
   const onPasteHandler = (_e: React.ClipboardEvent<HTMLInputElement>, val: string, type: string) => {
+    onTriggerFocus?.(type === 'start' ? 'start' : 'end');
     openPopoverFromInput();
 
     if (type === 'start') {
@@ -160,6 +163,7 @@ export const Trigger = (props: TriggerProps) => {
   };
 
   const onChangeHandler = (_e: React.ChangeEvent<HTMLInputElement>, val: string, type: string) => {
+    onTriggerFocus?.(type === 'start' ? 'start' : 'end');
     openPopoverFromInput();
 
     if (type === 'start') {
@@ -284,6 +288,7 @@ export const Trigger = (props: TriggerProps) => {
               withInput={true}
               htmlFor={startFieldId}
               onMouseDown={() => {
+                onTriggerFocus?.('start');
                 if (!startInputOptions.readOnly) onInputMouseDown?.();
               }}
             >
@@ -340,6 +345,7 @@ export const Trigger = (props: TriggerProps) => {
               withInput={true}
               htmlFor={endFieldId}
               onMouseDown={() => {
+                onTriggerFocus?.('end');
                 if (!endInputOptions.readOnly) onInputMouseDown?.();
               }}
             >

--- a/core/components/organisms/dateRangePicker/Trigger.tsx
+++ b/core/components/organisms/dateRangePicker/Trigger.tsx
@@ -46,6 +46,8 @@ type TriggerProps = {
    * that input instead of moving focus into the calendar.
    */
   onInputMouseDown?: () => void;
+  /** Pointer on trigger chrome — distinguishes icon clicks from keyboard focus opens. */
+  onTriggerPointerDown?: () => void;
   /**
    * Called on an explicit keyboard open gesture (ArrowDown / Alt+ArrowDown) to
    * open the calendar AND move focus into the grid.
@@ -68,6 +70,7 @@ export const Trigger = (props: TriggerProps) => {
     onTriggerFocus,
     openViaInput,
     onInputMouseDown,
+    onTriggerPointerDown,
     onKeyboardOpen,
   } = props;
 
@@ -266,107 +269,112 @@ export const Trigger = (props: TriggerProps) => {
   });
 
   return (
-    <Row data-test="DesignSystem-DateRangePicker-InputTrigger">
-      <Column size={'6'} sizeXS={'12'} className={StartInputClassName}>
-        {startLabel && (
-          <Label
-            required={startInputOptions.required}
-            withInput={true}
-            htmlFor={startFieldId}
-            onMouseDown={() => onInputMouseDown?.()}
-          >
-            {startLabel}
-          </Label>
-        )}
-        <InputMask
-          icon="events"
-          placeholder={inputFormat}
-          {...startInputOptions}
-          id={startFieldId}
-          mask={mask}
-          value={
-            startDate
-              ? translateToString(inputFormat, startDate)
-              : init
-              ? InputMask.utils.getDefaultValue(mask, startPlaceholderChar)
-              : ''
-          }
-          onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
-            onChangeHandler(e, val || '', 'start');
-          }}
-          onPaste={(e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
-            onPasteHandler(e, val || '', 'start');
-          }}
-          onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
-            onBlurHandler(e, val || '', 'start');
-          }}
-          onClear={(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => onClearHandler('start', e)}
-          onClick={() => onClickHandler('start')}
-          onMouseDown={onStartMouseDown}
-          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'start')}
-          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
-            startInputOptions.onFocus?.(e);
-            onTriggerFocus?.('start');
-          }}
-          error={showStartError}
-          caption={showStartError ? startErrorMessage : ''}
-          validators={[inputValidator]}
-          clearOnEmptyBlur={true}
-          ref={startTriggerRef}
-          aria-expanded={open}
-          aria-controls={panelId}
-        />
-      </Column>
-      <Column size={'6'} sizeXS={'12'} className={EndInputClassName}>
-        {endLabel && (
-          <Label
-            required={endInputOptions.required}
-            withInput={true}
-            htmlFor={endFieldId}
-            onMouseDown={() => onInputMouseDown?.()}
-          >
-            {endLabel}
-          </Label>
-        )}
-        <InputMask
-          icon="events"
-          placeholder={inputFormat}
-          {...endInputOptions}
-          id={endFieldId}
-          mask={mask}
-          value={
-            endDate
-              ? translateToString(inputFormat, endDate)
-              : init
-              ? InputMask.utils.getDefaultValue(mask, endPlaceholderChar)
-              : ''
-          }
-          onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
-            onChangeHandler(e, val || '', 'end');
-          }}
-          onPaste={(e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
-            onPasteHandler(e, val || '', 'end');
-          }}
-          onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
-            onBlurHandler(e, val || '', 'end');
-          }}
-          onClear={(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => onClearHandler('end', e)}
-          onClick={() => onClickHandler('end')}
-          onMouseDown={onEndMouseDown}
-          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'end')}
-          onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
-            endInputOptions.onFocus?.(e);
-            onTriggerFocus?.('end');
-          }}
-          error={showEndError}
-          caption={showEndError ? endErrorMessage : ''}
-          validators={[inputValidator]}
-          clearOnEmptyBlur={true}
-          ref={endTriggerRef}
-          aria-expanded={open}
-          aria-controls={panelId}
-        />
-      </Column>
-    </Row>
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="w-100" onMouseDown={() => onTriggerPointerDown?.()}>
+      <Row data-test="DesignSystem-DateRangePicker-InputTrigger">
+        <Column size={'6'} sizeXS={'12'} className={StartInputClassName}>
+          {startLabel && (
+            <Label
+              required={startInputOptions.required}
+              withInput={true}
+              htmlFor={startFieldId}
+              onMouseDown={() => onInputMouseDown?.()}
+            >
+              {startLabel}
+            </Label>
+          )}
+          <InputMask
+            icon="events"
+            placeholder={inputFormat}
+            {...startInputOptions}
+            id={startFieldId}
+            mask={mask}
+            value={
+              startDate
+                ? translateToString(inputFormat, startDate)
+                : init
+                ? InputMask.utils.getDefaultValue(mask, startPlaceholderChar)
+                : ''
+            }
+            onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
+              onChangeHandler(e, val || '', 'start');
+            }}
+            onPaste={(e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
+              onPasteHandler(e, val || '', 'start');
+            }}
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
+              onBlurHandler(e, val || '', 'start');
+            }}
+            onClear={(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) =>
+              onClearHandler('start', e)
+            }
+            onClick={() => onClickHandler('start')}
+            onMouseDown={onStartMouseDown}
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'start')}
+            onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+              startInputOptions.onFocus?.(e);
+              onTriggerFocus?.('start');
+            }}
+            error={showStartError}
+            caption={showStartError ? startErrorMessage : ''}
+            validators={[inputValidator]}
+            clearOnEmptyBlur={true}
+            ref={startTriggerRef}
+            aria-expanded={open}
+            aria-controls={panelId}
+          />
+        </Column>
+        <Column size={'6'} sizeXS={'12'} className={EndInputClassName}>
+          {endLabel && (
+            <Label
+              required={endInputOptions.required}
+              withInput={true}
+              htmlFor={endFieldId}
+              onMouseDown={() => onInputMouseDown?.()}
+            >
+              {endLabel}
+            </Label>
+          )}
+          <InputMask
+            icon="events"
+            placeholder={inputFormat}
+            {...endInputOptions}
+            id={endFieldId}
+            mask={mask}
+            value={
+              endDate
+                ? translateToString(inputFormat, endDate)
+                : init
+                ? InputMask.utils.getDefaultValue(mask, endPlaceholderChar)
+                : ''
+            }
+            onChange={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
+              onChangeHandler(e, val || '', 'end');
+            }}
+            onPaste={(e: React.ClipboardEvent<HTMLInputElement>, val?: string) => {
+              onPasteHandler(e, val || '', 'end');
+            }}
+            onBlur={(e: React.ChangeEvent<HTMLInputElement>, val?: string) => {
+              onBlurHandler(e, val || '', 'end');
+            }}
+            onClear={(e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => onClearHandler('end', e)}
+            onClick={() => onClickHandler('end')}
+            onMouseDown={onEndMouseDown}
+            onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => onKeyDownHandler(e, 'end')}
+            onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
+              endInputOptions.onFocus?.(e);
+              onTriggerFocus?.('end');
+            }}
+            error={showEndError}
+            caption={showEndError ? endErrorMessage : ''}
+            validators={[inputValidator]}
+            clearOnEmptyBlur={true}
+            ref={endTriggerRef}
+            aria-expanded={open}
+            aria-controls={panelId}
+          />
+        </Column>
+      </Row>
+    </div>
   );
 };

--- a/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
+++ b/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
@@ -45,10 +45,10 @@ const customCode = `
       return (
         <div className="d-flex">
           <div className="d-flex flex-column">
-            <Label withInput>Date</Label>
             <DatePicker
               withInput={true}
               onDateChange={this.onDateChange.bind(this)}
+              inputOptions={{ label: 'Date' }}
             />
           </div>
           <div className="d-flex flex-column ml-5" style={{width: 'var(--spacing-440)'}}>

--- a/core/components/patterns/datePicker/datePickerWithPresets.story.tsx
+++ b/core/components/patterns/datePicker/datePickerWithPresets.story.tsx
@@ -53,7 +53,7 @@ const customCode = `() => {
     const selectedPreset = presets.find((p) => p.value === selectedChip);
 
     return (
-      <DatePicker date={date} showTodayDate={false} size={size} withInput={withInput}>
+      <DatePicker date={date} showTodayDate={false} size={size} withInput={withInput} inputOptions={withInput ? { label: 'Set an appointment date' } : undefined}>
         <div className="pt-6 px-5">
           <div className="d-flex align-items-center justify-content-between">
             <Subheading size="s" appearance="subtle">
@@ -112,7 +112,6 @@ const customCode = `() => {
         <DatePickerPreset size="small" />
       </Card>
       <Card className="w-50 my-5 p-5">
-        <Label>Set an appointment date:</Label>
         <DatePickerPreset withInput={true} />
       </Card>
     </>

--- a/core/components/patterns/datePicker/datePickerWithPresets.story.tsx
+++ b/core/components/patterns/datePicker/datePickerWithPresets.story.tsx
@@ -38,8 +38,8 @@ const customCode = `() => {
 
   const DatePickerPreset = ({ size, withInput=false }) => {
 
-    const [date, setDate] = React.useState(new Date());
-    const [selectedChip, setSelectedChip] = React.useState('today');
+    const [date, setDate] = React.useState(withInput ? undefined : new Date());
+    const [selectedChip, setSelectedChip] = React.useState(withInput ? undefined : 'today');
     const isMobile = useIsMobile();
 
     const onPresetChange = (value) => {

--- a/core/components/patterns/forms/InlineForm.story.tsx
+++ b/core/components/patterns/forms/InlineForm.story.tsx
@@ -80,11 +80,11 @@ const customCode = `
                   </div>
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true}>Date of Birth</Label>
                   <DatePicker
                     withInput={true}
                     onDateChange={(currentDate) => this.onChange(currentDate, 'date')}
                     inputOptions={{
+                      label: 'Date of Birth',
                       placeholder: 'MM/DD/YYYY',
                       icon: 'cake',
                       mask: [/\\d/, /\\d/, '/', /\\d/, /\\d/, '/', /\\d/, /\\d/, /\\d/, /\\d/]

--- a/core/components/patterns/forms/StepperForm.story.tsx
+++ b/core/components/patterns/forms/StepperForm.story.tsx
@@ -109,11 +109,11 @@ const customCode = `
                   The system automatically creates collection for multiple support.
                 </Text>
                 <div className="mt-4">
-                  <Label withInput={true}>Input Collection 1</Label>
+                  <Label withInput={true} htmlFor="stepper-input-collection-1">Input Collection 1</Label>
                   <Select
                     width="100%"
                     className="mb-4"
-                    triggerOptions={{ placeholder: "Input Collection 1", 'aria-label': "Input Collection 1" }}
+                    triggerOptions={{ id: "stepper-input-collection-1", placeholder: "Input Collection 1", 'aria-label': "Input Collection 1" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection1')}
                   >
                     <Select.List>
@@ -126,10 +126,10 @@ const customCode = `
                       })}
                     </Select.List>
                   </Select>
-                  <Label withInput={true}>Input Collection 2</Label>
+                  <Label withInput={true} htmlFor="stepper-input-collection-2">Input Collection 2</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ placeholder: "Input Collection 2", 'aria-label': "Input Collection 2" }}
+                    triggerOptions={{ id: "stepper-input-collection-2", placeholder: "Input Collection 2", 'aria-label': "Input Collection 2" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection2')}
                   >
                     <Select.List>
@@ -151,10 +151,10 @@ const customCode = `
                   The system automatically creates collection for multiple support.
                 </Text>
                 <div className="mt-6">
-                  <Label withInput={true}>Destination Collection</Label>
+                  <Label withInput={true} htmlFor="stepper-destination-collection">Destination Collection</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ placeholder: "Select Destination", 'aria-label': "Destination Collection" }}
+                    triggerOptions={{ id: "stepper-destination-collection", placeholder: "Select Destination", 'aria-label': "Destination Collection" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection')}
                   >
                     <Select.List>
@@ -180,10 +180,10 @@ const customCode = `
                   />
                 </div>
                 <div className="mt-6">
-                  <Label withInput={true} required>Retention Period</Label>
+                  <Label withInput={true} required htmlFor="stepper-retention-period">Retention Period</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ 'aria-label': "Retention Period" }}
+                    triggerOptions={{ id: "stepper-retention-period", 'aria-label': "Retention Period" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'retention')}
                   >
                     <Select.List>
@@ -196,10 +196,10 @@ const customCode = `
                       })}
                     </Select.List>
                   </Select>
-                  <Label className="mt-6" withInput={true}>Visibility Clarification</Label>
+                  <Label className="mt-6" withInput={true} htmlFor="stepper-visibility-clarification">Visibility Clarification</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ 'aria-label': "Visibility Clarification" }}
+                    triggerOptions={{ id: "stepper-visibility-clarification", 'aria-label': "Visibility Clarification" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'clarification')}
                   >
                     <Select.List>
@@ -225,9 +225,9 @@ const customCode = `
                   </div>
                 </div>
                 <div className="mt-6">
-                  <Label withInput={true} required>Mode</Label>
+                  <Label withInput={true} required htmlFor="stepper-mode">Mode</Label>
                   <Select
-                    triggerOptions={{ 'aria-label': "Mode" }}
+                    triggerOptions={{ id: "stepper-mode", 'aria-label': "Mode" }}
                     onSelect={(option) => {
                       this.setState({
                         configuration: { ...this.state.configuration, mode: option.value }

--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -31,13 +31,13 @@ const customCode = `
             <Heading size="s" className="mb-2">Population Filter</Heading>
             <div className="d-flex mt-5 mb-4">
               <div className="mr-6" style={{ width: 'var(--spacing-440)' }}>
-                <Label withInput={true}>Region</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Region" }}>
+                <Label withInput={true} htmlFor="time-period-region-select">Region</Label>
+                <Select width="100%" triggerOptions={{ id: "time-period-region-select", 'aria-label': "Region" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
-                        <Select.Option key={key} option={{ label: item.label, value: item.value }}> 
-                          {item.label} 
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }} aria-label={\`Region option \${item.label}\`}>
+                          {item.label}
                         </Select.Option>
                       )
                     })}
@@ -45,13 +45,13 @@ const customCode = `
                 </Select>
               </div>
               <div style={{ width: 'var(--spacing-640)' }}>
-                <Label withInput={true}>Organization</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Organization" }}>
+                <Label withInput={true} htmlFor="time-period-organization-select">Organization</Label>
+                <Select width="100%" triggerOptions={{ id: "time-period-organization-select", 'aria-label': "Organization" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
-                        <Select.Option key={key} option={{ label: item.label, value: item.value }}> 
-                          {item.label} 
+                        <Select.Option key={key} option={{ label: item.label, value: item.value }} aria-label={\`Organization option \${item.label}\`}>
+                          {item.label}
                         </Select.Option>
                       )
                     })}

--- a/core/utils/overlayHelper.ts
+++ b/core/utils/overlayHelper.ts
@@ -216,7 +216,10 @@ export const handleFocusTrapKeyDown = (
       first.focus({ preventScroll: true });
       return true;
     }
-    if (externalFocusable.length > 0 && externalFocusable.some((el) => el === activeElement)) {
+    const activeExternalIndex = externalFocusable.findIndex(
+      (el) => el === activeElement || (!!activeElement && el.contains(activeElement))
+    );
+    if (activeExternalIndex >= 0 && activeExternalIndex === externalFocusable.length - 1) {
       event.preventDefault();
       const dialogFirst = dialogFocusable[0] ?? last;
       dialogFirst.focus({ preventScroll: true });

--- a/core/utils/overlayHelper.ts
+++ b/core/utils/overlayHelper.ts
@@ -158,22 +158,33 @@ export const getAllFocusableElements = (container: HTMLElement, roleHint?: strin
  * @param staticFocusTarget - Optional non-tabbable element (tabindex="-1") that received
  *   focus on overlay open (e.g. the dialog heading). It is not in the tabbable focusable
  *   list, so without this parameter Shift+Tab from it would escape the trap.
+ * @param externalFocusTargets - Optional tabbable elements outside `container` that should
+ *   participate in the trap cycle (e.g. a DatePicker trigger input while the calendar is
+ *   open and focus remains in the field).
  *
  * Returns true if the event was handled (focus was redirected or prevented).
  */
 export const handleFocusTrapKeyDown = (
   event: KeyboardEvent,
   container: HTMLElement,
-  staticFocusTarget?: HTMLElement | null
+  staticFocusTarget?: HTMLElement | null,
+  externalFocusTargets?: (HTMLElement | null | undefined)[]
 ): boolean => {
   if (event.key !== 'Tab') return false;
 
-  const focusable = getFocusableElements(container);
+  const dialogFocusable = getFocusableElements(container);
+  const externalFocusable = (externalFocusTargets ?? []).filter(
+    (el): el is HTMLElement => !!el?.isConnected && !container.contains(el)
+  );
+  const focusable = [...externalFocusable, ...dialogFocusable.filter((el) => !externalFocusable.includes(el))];
   const activeElement = document.activeElement as HTMLElement | null;
 
-  if (!activeElement || !container.contains(activeElement)) {
-    return false;
-  }
+  const isInScope =
+    !!activeElement &&
+    (container.contains(activeElement) ||
+      externalFocusable.some((el) => el === activeElement || el.contains(activeElement)));
+
+  if (!isInScope) return false;
 
   if (focusable.length === 0) {
     event.preventDefault();
@@ -194,10 +205,21 @@ export const handleFocusTrapKeyDown = (
       last.focus({ preventScroll: true });
       return true;
     }
+    if (externalFocusable.length > 0 && dialogFocusable.length > 0 && activeElement === dialogFocusable[0]) {
+      event.preventDefault();
+      externalFocusable[externalFocusable.length - 1].focus({ preventScroll: true });
+      return true;
+    }
   } else {
     if (activeElement === last) {
       event.preventDefault();
       first.focus({ preventScroll: true });
+      return true;
+    }
+    if (externalFocusable.length > 0 && externalFocusable.some((el) => el === activeElement)) {
+      event.preventDefault();
+      const dialogFirst = dialogFocusable[0] ?? last;
+      dialogFirst.focus({ preventScroll: true });
       return true;
     }
   }

--- a/core/utils/overlayHelper.ts
+++ b/core/utils/overlayHelper.ts
@@ -153,6 +153,30 @@ export const getAllFocusableElements = (container: HTMLElement, roleHint?: strin
 };
 
 /**
+ * Expands external trigger refs into all focusable controls in each input
+ * wrapper (text field + clear button), keeping DOM order across triggers.
+ */
+export const getExternalFocusTrapElements = (
+  externalRoots: (HTMLElement | null | undefined)[],
+  container: HTMLElement
+): HTMLElement[] => {
+  const seen = new Set<HTMLElement>();
+  const out: HTMLElement[] = [];
+  for (const root of externalRoots) {
+    if (!root?.isConnected || container.contains(root)) continue;
+    const wrapper = root.closest('[data-test="DesignSystem-InputWrapper"]') as HTMLElement | null;
+    const scope = wrapper ?? root;
+    for (const el of getFocusableElements(scope)) {
+      if (!seen.has(el)) {
+        seen.add(el);
+        out.push(el);
+      }
+    }
+  }
+  return out;
+};
+
+/**
  * Handles Tab/Shift+Tab to trap focus within the container.
  *
  * @param staticFocusTarget - Optional non-tabbable element (tabindex="-1") that received
@@ -173,9 +197,7 @@ export const handleFocusTrapKeyDown = (
   if (event.key !== 'Tab') return false;
 
   const dialogFocusable = getFocusableElements(container);
-  const externalFocusable = (externalFocusTargets ?? []).filter(
-    (el): el is HTMLElement => !!el?.isConnected && !container.contains(el)
-  );
+  const externalFocusable = getExternalFocusTrapElements(externalFocusTargets ?? [], container);
   const focusable = [...externalFocusable, ...dialogFocusable.filter((el) => !externalFocusable.includes(el))];
   const activeElement = document.activeElement as HTMLElement | null;
 


### PR DESCRIPTION
### What this fixes
Two accessibility gaps in `DatePicker` and `DateRangePicker`:

1. **The trigger inputs had no accessible name** in a common configuration. When only `inputOptions.label` was set, an internal `aria-label: undefined` overwrote the label, so screen-reader users landed on an unlabeled date field ("edit text", no name).
2. **The calendar popover had no focus management or dialog semantics.** Opening it didn't move focus into the calendar, focus wasn't trapped, there was no `role="dialog"`/label, the trigger didn't expose expanded/controls state, and closing didn't return focus to the trigger. Keyboard and screen-reader users could lose their place entirely.

### What changed
- **Accessible name (label wiring):** the trigger inputs now get a proper name — the injected `aria-label: undefined` no longer clobbers a provided label, and the rendered `<Label>` is associated to the input via `htmlFor`/`id`.
- **Calendar dialog + focus management:** the calendar popover now
  - has `role="dialog"` + `aria-modal` + an accessible label;
  - moves focus to the calendar on open and returns focus to the trigger on close (Escape, outside click, and selection);
  - traps Tab within the popover while open;
  - the trigger exposes `aria-expanded` / `aria-controls`.
  This reuses the existing shared focus-trap helper and is scoped to the picker's own popover usage, so other `Popover` consumers are unaffected.

### Why it's worth a careful look
This touches the picker triggers and the calendar popover, which are used in many forms — hence raising it for review/testing. No visual change intended.

### 👀 VoiceOver / screen-reader check (Before vs After)
- **Before (prod):** https://mds.innovaccer.com/?path=/docs/components-datepicker--default and https://mds.innovaccer.com/?path=/docs/components-daterangepicker--default
- **After:** Chromatic build links to follow from this PR's "Storybook Publish" check.
Please verify: focus enters the calendar on open, Tab stays trapped, Escape/selection returns focus to the trigger, and the trigger input is announced with its label.

### Deque issues
Label / accessible name:
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/f9027608
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/ffcc8ea6
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/a6239db2

Calendar keyboard/focus:
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/c5b9ce80
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/ddada976
- https://axeauditor.dequecloud.com/test-run/45b36198-b498-11f0-a843-6f41ab87c814/issue/b438917c

### Testing
`lint`, `types`, `prettier` pass. DatePicker + DateRangePicker + Calendar Jest suites pass (315 tests, 182 snapshots); DateRangePicker snapshots regenerated for the new dialog/label attributes.