### PR TITLE
fix(Select): wire story labels and hide placeholder from screen readers

### DIFF
--- a/core/components/molecules/stepper/__stories__/StepperWithAnimation.story.jsx
+++ b/core/components/molecules/stepper/__stories__/StepperWithAnimation.story.jsx
@@ -82,8 +82,16 @@ export const stepperWithAnimation = () => {
           <Row className="mt-5 mb-4">
             <Column size={6} className="d-flex">
               <div className="mr-6 w-100">
-                <Label withInput={true}>Region</Label>
-                <Select triggerOptions={{ withClearButton: false }}>
+                <Label withInput={true} id="stepper-animation-region-label" htmlFor="stepper-animation-region-select">
+                  Region
+                </Label>
+                <Select
+                  triggerOptions={{
+                    id: 'stepper-animation-region-select',
+                    withClearButton: false,
+                    'aria-labelledby': 'stepper-animation-region-label',
+                  }}
+                >
                   <Select.List>
                     {options.map((item, key) => {
                       return (
@@ -96,8 +104,20 @@ export const stepperWithAnimation = () => {
                 </Select>
               </div>
               <div className="w-100">
-                <Label withInput={true}>Organization</Label>
-                <Select triggerOptions={{ withClearButton: false }}>
+                <Label
+                  withInput={true}
+                  id="stepper-animation-organization-label"
+                  htmlFor="stepper-animation-organization-select"
+                >
+                  Organization
+                </Label>
+                <Select
+                  triggerOptions={{
+                    id: 'stepper-animation-organization-select',
+                    withClearButton: false,
+                    'aria-labelledby': 'stepper-animation-organization-label',
+                  }}
+                >
                   <Select.List>
                     {options.map((item, key) => {
                       return (
@@ -518,8 +538,8 @@ const customCode = `() => {
           <Row className="mt-5 mb-4">
             <Column size={6} className="d-flex">
               <div className="mr-6 w-100">
-                <Label withInput={true}>Region</Label>
-                <Select triggerOptions={{ withClearButton: false }}>
+                <Label withInput={true} id="stepper-animation-region-label" htmlFor="stepper-animation-region-select">Region</Label>
+                <Select triggerOptions={{ id: "stepper-animation-region-select", withClearButton: false, 'aria-labelledby': "stepper-animation-region-label" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
@@ -532,8 +552,8 @@ const customCode = `() => {
                 </Select>
               </div>
               <div className="w-100">
-                <Label withInput={true}>Organization</Label>
-                <Select triggerOptions={{ withClearButton: false }}>
+                <Label withInput={true} id="stepper-animation-organization-label" htmlFor="stepper-animation-organization-select">Organization</Label>
+                <Select triggerOptions={{ id: "stepper-animation-organization-select", withClearButton: false, 'aria-labelledby': "stepper-animation-organization-label" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (

--- a/core/components/organisms/select/SelectTrigger.tsx
+++ b/core/components/organisms/select/SelectTrigger.tsx
@@ -73,6 +73,11 @@ export interface SelectTriggerProps extends BaseProps {
    */
   onClear?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   /**
+   * Accessible name for the clear button. Defaults to `Clear {field label}` when the
+   * trigger has `aria-label` or `aria-labelledby`.
+   */
+  clearButtonAriaLabel?: string;
+  /**
    * A function used to customize the label displayed when multiple options are selected.
    *
    * The function receives the count of selected options as its argument and should return a string
@@ -101,6 +106,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
     inlineLabel,
     iconType,
     onClear,
+    clearButtonAriaLabel: clearButtonAriaLabelProp,
     setLabel,
     minWidth,
     maxWidth,
@@ -131,6 +137,25 @@ const SelectTrigger = (props: SelectTriggerProps) => {
   } = contextProp;
 
   const hidePlaceholderFromA11y = !isOptionSelected && !!(ariaLabelledBy || ariaLabelProp);
+
+  const [labelledByText, setLabelledByText] = React.useState<string>();
+
+  React.useLayoutEffect(() => {
+    if (!ariaLabelledBy) {
+      setLabelledByText(undefined);
+      return;
+    }
+
+    const labelId = ariaLabelledBy.split(/\s+/)[0];
+    const labelEl = document.getElementById(labelId);
+    const labelText = labelEl?.textContent?.replace(/\s*\(required\)\s*/gi, '').trim();
+    setLabelledByText(labelText || undefined);
+  }, [ariaLabelledBy]);
+
+  const clearButtonAriaLabel =
+    clearButtonAriaLabelProp ??
+    (ariaLabelProp && ariaLabelProp !== 'Select trigger' ? `Clear ${ariaLabelProp}` : undefined) ??
+    (labelledByText ? `Clear ${labelledByText}` : 'Clear selection');
 
   const buttonDisabled = disabled ? 'disabled' : 'default';
   const trimmedPlaceholder = placeholder?.trim();
@@ -237,7 +262,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
             className={iconClass}
             onClick={onClearHandler}
             onKeyDown={(e) => e.stopPropagation()}
-            aria-label="clear selected"
+            aria-label={clearButtonAriaLabel}
             data-test="DesignSystem-Select--closeIcon"
           >
             <Icon appearance={buttonDisabled} size={12} name="close" type={iconType} aria-hidden={true} />

--- a/core/components/organisms/select/SelectTrigger.tsx
+++ b/core/components/organisms/select/SelectTrigger.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Icon, Text, Tooltip } from '@/index';
 import { IconType } from '@/common.type';
 import { SelectContext } from './SelectContext';
-import { handleKeyDownTrigger, computeValue } from './utils';
+import { handleKeyDownTrigger, computeValue, getLabelTextFromElement } from './utils';
 import { BaseProps } from '@/utils/types';
 import selectStyles from '@css/components/select.module.css';
 import buttonStyles from '@css/components/button.module.css';
@@ -152,8 +152,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
 
     const labelId = ariaLabelledBy.split(/\s+/)[0];
     const labelEl = document.getElementById(labelId);
-    const labelText = labelEl?.textContent?.replace(/\s*\(required\)\s*/gi, '').trim();
-    setLabelledByText(labelText || undefined);
+    setLabelledByText(labelEl ? getLabelTextFromElement(labelEl) : undefined);
   }, [ariaLabelledBy]);
 
   const clearButtonAriaLabel =

--- a/core/components/organisms/select/SelectTrigger.tsx
+++ b/core/components/organisms/select/SelectTrigger.tsx
@@ -13,6 +13,10 @@ export type SelectTriggerSize = 'small' | 'regular';
 
 export interface SelectTriggerProps extends BaseProps {
   /**
+   * `id` for the trigger button; pair with a visible `<Label htmlFor={id}>`.
+   */
+  id?: string;
+  /**
    * Accessible label for the Select trigger button.
    * @default "Select trigger"
    */

--- a/core/components/organisms/select/SelectTrigger.tsx
+++ b/core/components/organisms/select/SelectTrigger.tsx
@@ -158,8 +158,9 @@ const SelectTrigger = (props: SelectTriggerProps) => {
 
   const clearButtonAriaLabel =
     clearButtonAriaLabelProp ??
+    (ariaLabelledBy && labelledByText ? `Clear ${labelledByText}` : undefined) ??
     (ariaLabelProp && ariaLabelProp !== 'Select trigger' ? `Clear ${ariaLabelProp}` : undefined) ??
-    (labelledByText ? `Clear ${labelledByText}` : 'Clear selection');
+    'Clear selection';
 
   const buttonDisabled = disabled ? 'disabled' : 'default';
   const trimmedPlaceholder = placeholder?.trim();

--- a/core/components/organisms/select/SelectTrigger.tsx
+++ b/core/components/organisms/select/SelectTrigger.tsx
@@ -18,6 +18,10 @@ export interface SelectTriggerProps extends BaseProps {
    */
   'aria-label'?: string;
   /**
+   * Associates the trigger with a visible label element (preferred over `aria-label`).
+   */
+  'aria-labelledby'?: string;
+  /**
    * Ids of supplementary description or help text (space-separated).
    */
   'aria-describedby'?: string;
@@ -88,7 +92,8 @@ export interface SelectTriggerProps extends BaseProps {
 const SelectTrigger = (props: SelectTriggerProps) => {
   const {
     triggerSize = 'regular',
-    'aria-label': ariaLabel = 'Select trigger',
+    'aria-label': ariaLabelProp,
+    'aria-labelledby': ariaLabelledBy,
     placeholder,
     withClearButton,
     icon,
@@ -103,6 +108,8 @@ const SelectTrigger = (props: SelectTriggerProps) => {
     'aria-controls': ariaControls,
     ...rest
   } = props;
+
+  const ariaLabel = ariaLabelledBy ? undefined : ariaLabelProp ?? 'Select trigger';
 
   const contextProp = React.useContext(SelectContext);
   const elementRef = React.useRef(null);
@@ -122,6 +129,8 @@ const SelectTrigger = (props: SelectTriggerProps) => {
     styleType,
     error,
   } = contextProp;
+
+  const hidePlaceholderFromA11y = !isOptionSelected && !!(ariaLabelledBy || ariaLabelProp);
 
   const buttonDisabled = disabled ? 'disabled' : 'default';
   const trimmedPlaceholder = placeholder?.trim();
@@ -194,6 +203,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
         aria-expanded={openPopover}
         aria-haspopup="listbox"
         aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         data-test="DesignSystem-Select-trigger"
         {...rest}
       >
@@ -215,7 +225,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
               />
             )}
             {value && (
-              <span ref={elementRef} className={textClass}>
+              <span ref={elementRef} className={textClass} aria-hidden={hidePlaceholderFromA11y || undefined}>
                 {value}
               </span>
             )}

--- a/core/components/organisms/select/__stories__/labelOnTop.story.jsx
+++ b/core/components/organisms/select/__stories__/labelOnTop.story.jsx
@@ -23,8 +23,13 @@ export const labelOnTop = () => {
 
   return (
     <div className="w-25">
-      <Label withInput={true}>Area code</Label>
-      <Select onSelect={onSelectHandler} triggerOptions={{ 'aria-label': 'Area code selector' }}>
+      <Label withInput={true} id="area-code-label" htmlFor="area-code-select">
+        Area code
+      </Label>
+      <Select
+        onSelect={onSelectHandler}
+        triggerOptions={{ id: 'area-code-select', 'aria-labelledby': 'area-code-label' }}
+      >
         <Select.List aria-label="Area code options">
           {areaCode.map((item, key) => {
             return (
@@ -63,8 +68,8 @@ const customCode = `() => {
 
   return (
     <div className="w-25">
-      <Label withInput={true}>Area code</Label>
-      <Select onSelect={onSelectHandler} triggerOptions={{ 'aria-label': 'Area code selector' }}>
+      <Label withInput={true} id="area-code-label" htmlFor="area-code-select">Area code</Label>
+      <Select onSelect={onSelectHandler} triggerOptions={{ id: 'area-code-select', 'aria-labelledby': 'area-code-label' }}>
         <Select.List aria-label="Area code options">
           {areaCode.map((item, key) => {
             return (

--- a/core/components/organisms/select/__stories__/preFilledValue.story.jsx
+++ b/core/components/organisms/select/__stories__/preFilledValue.story.jsx
@@ -23,12 +23,14 @@ export const preFilledValue = () => {
 
   return (
     <div className="w-25">
-      <Label withInput={true}>Area code</Label>
+      <Label withInput={true} id="area-code-label" htmlFor="area-code-select">
+        Area code
+      </Label>
       <Select
         width="var(--spacing-640)"
         onSelect={onSelectHandler}
         value={{ label: 'Alabama (205)', value: 'Alabama (205)' }}
-        triggerOptions={{ 'aria-label': 'Area code selector' }}
+        triggerOptions={{ id: 'area-code-select', 'aria-labelledby': 'area-code-label' }}
       >
         <Select.List aria-label="Area code options">
           {areaCode.map((item, key) => {
@@ -68,12 +70,12 @@ const customCode = `() => {
 
   return (
     <div className="w-25">
-      <Label withInput={true}>Area code</Label>
+      <Label withInput={true} id="area-code-label" htmlFor="area-code-select">Area code</Label>
       <Select 
         width="var(--spacing-640)" 
         onSelect={onSelectHandler} 
         value={{ label: 'Alabama (205)', value: 'Alabama (205)' }}
-        triggerOptions={{ 'aria-label': 'Area code selector' }}
+        triggerOptions={{ id: 'area-code-select', 'aria-labelledby': 'area-code-label' }}
       >
         <Select.List aria-label="Area code options">
           {areaCode.map((item, key) => {

--- a/core/components/organisms/select/__stories__/selectWithHelptext.story.jsx
+++ b/core/components/organisms/select/__stories__/selectWithHelptext.story.jsx
@@ -23,11 +23,13 @@ export const selectWithHelptext = () => {
 
   return (
     <div className="w-25">
-      <Label withInput={true}>Area code</Label>
+      <Label withInput={true} id="area-code-label" htmlFor="area-code-select">
+        Area code
+      </Label>
       <Select
         width="var(--spacing-640)"
         onSelect={onSelectHandler}
-        triggerOptions={{ 'aria-label': 'Area code selector' }}
+        triggerOptions={{ id: 'area-code-select', 'aria-labelledby': 'area-code-label' }}
       >
         <Select.List aria-label="Area code options">
           {areaCode.map((item, key) => {
@@ -68,8 +70,8 @@ const customCode = `() => {
 
   return (
     <div className="w-25">
-      <Label withInput={true}>Area code</Label>
-      <Select width="var(--spacing-640)" onSelect={onSelectHandler} triggerOptions={{ 'aria-label': 'Area code selector' }}>
+      <Label withInput={true} id="area-code-label" htmlFor="area-code-select">Area code</Label>
+      <Select width="var(--spacing-640)" onSelect={onSelectHandler} triggerOptions={{ id: 'area-code-select', 'aria-labelledby': 'area-code-label' }}>
         <Select.List aria-label="Area code options">
           {areaCode.map((item, key) => {
             return (

--- a/core/components/organisms/select/__test__/Select.test.tsx
+++ b/core/components/organisms/select/__test__/Select.test.tsx
@@ -174,6 +174,25 @@ describe('Select trigger accessibility for error and descriptions', () => {
     );
     expect(getByTestId('DesignSystem-Select-trigger')).toHaveAttribute('aria-describedby', 'opt-hint');
   });
+
+  it('uses aria-labelledby instead of aria-label and hides placeholder text from assistive tech', () => {
+    const { getByTestId } = render(
+      <Select
+        onSelect={FunctionValue}
+        triggerOptions={{
+          id: 'region-select',
+          placeholder: 'Select region…',
+          'aria-labelledby': 'region-label',
+        }}
+      >
+        {children}
+      </Select>
+    );
+    const trigger = getByTestId('DesignSystem-Select-trigger');
+    expect(trigger).toHaveAttribute('aria-labelledby', 'region-label');
+    expect(trigger).not.toHaveAttribute('aria-label');
+    expect(trigger.querySelector('span[aria-hidden="true"]')).toHaveTextContent('Select region…');
+  });
 });
 
 describe('Select component single input trigger tests', () => {

--- a/core/components/organisms/select/__test__/Select.test.tsx
+++ b/core/components/organisms/select/__test__/Select.test.tsx
@@ -215,6 +215,29 @@ describe('Select trigger accessibility for error and descriptions', () => {
 
     expect(getByTestId('DesignSystem-Select--closeIcon')).toHaveAttribute('aria-label', 'Clear Region');
   });
+
+  it('prefers visible label over aria-label for clear button when both are set', () => {
+    const { getByTestId } = render(
+      <>
+        <label id="region-label" htmlFor="region-select">
+          Region
+        </label>
+        <Select
+          onSelect={FunctionValue}
+          value={{ label: 'Option 1', value: 'Option 1' }}
+          triggerOptions={{
+            id: 'region-select',
+            'aria-label': 'Stale fallback label',
+            'aria-labelledby': 'region-label',
+          }}
+        >
+          {children}
+        </Select>
+      </>
+    );
+
+    expect(getByTestId('DesignSystem-Select--closeIcon')).toHaveAttribute('aria-label', 'Clear Region');
+  });
 });
 
 describe('Select component single input trigger tests', () => {

--- a/core/components/organisms/select/__test__/Select.test.tsx
+++ b/core/components/organisms/select/__test__/Select.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { axe } from '@/utils/testAxe';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { testHelper, filterUndefined, valueHelper, testMessageHelper } from '@/utils/testHelper';
-import { Select, AIIconButton } from '@/index';
+import { Select, AIIconButton, Label } from '@/index';
 import { SelectProps as Props } from '@/index.type';
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
@@ -237,6 +237,28 @@ describe('Select trigger accessibility for error and descriptions', () => {
     );
 
     expect(getByTestId('DesignSystem-Select--closeIcon')).toHaveAttribute('aria-label', 'Clear Region');
+  });
+
+  it('strips label adornments from clear button name when label has info icon', () => {
+    const { getByTestId } = render(
+      <>
+        <Label withInput={true} id="status-label" htmlFor="status-select" info="Additional status context">
+          Status
+        </Label>
+        <Select
+          onSelect={FunctionValue}
+          value={{ label: 'Option 1', value: 'Option 1' }}
+          triggerOptions={{
+            id: 'status-select',
+            'aria-labelledby': 'status-label',
+          }}
+        >
+          {children}
+        </Select>
+      </>
+    );
+
+    expect(getByTestId('DesignSystem-Select--closeIcon')).toHaveAttribute('aria-label', 'Clear Status');
   });
 });
 

--- a/core/components/organisms/select/__test__/Select.test.tsx
+++ b/core/components/organisms/select/__test__/Select.test.tsx
@@ -193,6 +193,28 @@ describe('Select trigger accessibility for error and descriptions', () => {
     expect(trigger).not.toHaveAttribute('aria-label');
     expect(trigger.querySelector('span[aria-hidden="true"]')).toHaveTextContent('Select region…');
   });
+
+  it('names the clear button after the labelled field', () => {
+    const { getByTestId } = render(
+      <>
+        <label id="region-label" htmlFor="region-select">
+          Region
+        </label>
+        <Select
+          onSelect={FunctionValue}
+          value={{ label: 'Option 1', value: 'Option 1' }}
+          triggerOptions={{
+            id: 'region-select',
+            'aria-labelledby': 'region-label',
+          }}
+        >
+          {children}
+        </Select>
+      </>
+    );
+
+    expect(getByTestId('DesignSystem-Select--closeIcon')).toHaveAttribute('aria-label', 'Clear Region');
+  });
 });
 
 describe('Select component single input trigger tests', () => {

--- a/core/components/organisms/select/utils.tsx
+++ b/core/components/organisms/select/utils.tsx
@@ -417,3 +417,17 @@ export const focusPopoverInitial = (
   }
   return idx;
 };
+
+const LABEL_ADORNMENT_SELECTOR =
+  '[aria-hidden="true"], [data-test="DesignSystem-Label--Info"], [data-test="DesignSystem-Label--OptionalText"]';
+
+/**
+ * Reads visible label text for clear-button naming, ignoring decorative adornments
+ * such as info icons, optional markers, and aria-hidden indicators.
+ */
+export const getLabelTextFromElement = (labelEl: HTMLElement): string | undefined => {
+  const clone = labelEl.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(LABEL_ADORNMENT_SELECTOR).forEach((el) => el.remove());
+  const text = clone.textContent?.replace(/\s*\(required\)\s*/gi, '').trim();
+  return text || undefined;
+};

--- a/core/components/patterns/forms/CreateUser.story.tsx
+++ b/core/components/patterns/forms/CreateUser.story.tsx
@@ -99,11 +99,11 @@ const customCode = `
                 />
               </Column>
               <Column sizeXL={4} sizeL={4} sizeM={5} className="mr-6 mb-6">
-                <Label withInput={true}>Gender</Label>
+                <Label withInput={true} id="createUser-gender-label" htmlFor="createUser-gender-select">Gender</Label>
                 <Select 
                   width="100%"
                   onSelect={(option) => this.onChange(option.value, 'gender')}
-                  triggerOptions={{ placeholder: "Select Gender", 'aria-label': "Gender", }}
+                  triggerOptions={{ id: "createUser-gender-select", placeholder: "Select Gender", 'aria-labelledby': "createUser-gender-label", }}
                 >
                   <Select.List>
                     {genderOptions.map((item, key) => {
@@ -153,11 +153,11 @@ const customCode = `
                 />
               </Column>
               <Column sizeXL={4} sizeL={4} sizeM={5} className="mr-6 mb-6">
-                <Label withInput={true}>User Type</Label>
+                <Label withInput={true} id="createUser-userType-label" htmlFor="createUser-userType-select">User Type</Label>
                 <Select 
                   width="100%"
                   onSelect={(option) => this.onChange(option.value, 'userType')}
-                  triggerOptions={{ placeholder: "Select User Type", 'aria-label': "User Type", }}
+                  triggerOptions={{ id: "createUser-userType-select", placeholder: "Select User Type", 'aria-labelledby': "createUser-userType-label", }}
                 >
                   <Select.List>
                     {userOptions.map((item, key) => {

--- a/core/components/patterns/forms/InlineForm.story.tsx
+++ b/core/components/patterns/forms/InlineForm.story.tsx
@@ -49,8 +49,9 @@ const customCode = `
             <form onSubmit={this.onSubmit}>
               <div className="d-flex flex-wrap">
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>Last Name</Label>
+                  <Label withInput={true} htmlFor="inline-lastName">Last Name</Label>
                   <Input
+                    id="inline-lastName"
                     name="lastName"
                     type="text"
                     placeholder="E.g. Doe, Smith, etc."
@@ -60,8 +61,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>First Name</Label>
+                  <Label withInput={true} htmlFor="inline-firstName">First Name</Label>
                   <Input
+                    id="inline-firstName"
                     name="firstName"
                     type="text"
                     placeholder="E.g. John, Will, etc."
@@ -71,8 +73,8 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>Gender</Label>
-                  <div className="d-flex" role="group" aria-label="Gender">
+                  <Label withInput={true} id="inline-gender-label">Gender</Label>
+                  <div className="d-flex" role="group" aria-labelledby="inline-gender-label">
                     <Button className="mr-3" selected={this.state.data.gender === 'Male'} onClick={() => this.onChange('Male', 'gender')}>Male</Button>
                     <Button className="mr-3" selected={this.state.data.gender === 'Female'} onClick={() => this.onChange('Female', 'gender')}>Female</Button>
                     <Button className="mr-3" selected={this.state.data.gender === 'Other'} onClick={() => this.onChange('Other', 'gender')}>Other</Button>
@@ -92,8 +94,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>EMPI</Label>
+                  <Label withInput={true} htmlFor="inline-empi">EMPI</Label>
                   <Input
+                    id="inline-empi"
                     name="empi"
                     type="text"
                     placeholder="P000000"
@@ -103,8 +106,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>MRN</Label>
+                  <Label withInput={true} htmlFor="inline-mrn">MRN</Label>
                   <Input
+                    id="inline-mrn"
                     name="mrn"
                     type="text"
                     placeholder="Medical Record Number"
@@ -114,8 +118,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>ZIP</Label>
+                  <Label withInput={true} htmlFor="inline-zip">ZIP</Label>
                   <Input
+                    id="inline-zip"
                     name="zip"
                     type="text"
                     placeholder="00000"
@@ -125,11 +130,11 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true}>Primary Care Physician</Label>
+                  <Label withInput={true} id="inline-pcp-label" htmlFor="inline-pcp-select">Primary Care Physician</Label>
                   <Select
                     width="100%"
                     onSelect={(option) => this.onChange(option.value, 'pcp')}
-                    triggerOptions={{ placeholder: "Select physician…", icon: "add_box", 'aria-label': "Primary Care Physician" }}
+                    triggerOptions={{ id: "inline-pcp-select", placeholder: "Select physician…", icon: "add_box", 'aria-labelledby': "inline-pcp-label" }}
                   >
                     <Select.List>
                       {options.map((item, key) => {
@@ -143,11 +148,11 @@ const customCode = `
                   </Select>
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true}>Region</Label>
+                  <Label withInput={true} id="inline-region-label" htmlFor="inline-region-select">Region</Label>
                   <Select
                     width="100%"
                     onSelect={(option) => this.onChange(option.value, 'region')}
-                    triggerOptions={{ placeholder: "Select region…", icon: "flag", 'aria-label': "Region" }}
+                    triggerOptions={{ id: "inline-region-select", placeholder: "Select region…", icon: "flag", 'aria-labelledby': "inline-region-label" }}
                   >
                     <Select.List>
                       {options.map((item, key) => {

--- a/core/components/patterns/forms/StepperForm.story.tsx
+++ b/core/components/patterns/forms/StepperForm.story.tsx
@@ -109,11 +109,11 @@ const customCode = `
                   The system automatically creates collection for multiple support.
                 </Text>
                 <div className="mt-4">
-                  <Label withInput={true}>Input Collection 1</Label>
+                  <Label withInput={true} id="stepper-input-collection-1-label" htmlFor="stepper-input-collection-1">Input Collection 1</Label>
                   <Select
                     width="100%"
                     className="mb-4"
-                    triggerOptions={{ placeholder: "Input Collection 1", 'aria-label': "Input Collection 1" }}
+                    triggerOptions={{ id: "stepper-input-collection-1", placeholder: "Input Collection 1", 'aria-labelledby': "stepper-input-collection-1-label" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection1')}
                   >
                     <Select.List>
@@ -126,10 +126,10 @@ const customCode = `
                       })}
                     </Select.List>
                   </Select>
-                  <Label withInput={true}>Input Collection 2</Label>
+                  <Label withInput={true} id="stepper-input-collection-2-label" htmlFor="stepper-input-collection-2">Input Collection 2</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ placeholder: "Input Collection 2", 'aria-label': "Input Collection 2" }}
+                    triggerOptions={{ id: "stepper-input-collection-2", placeholder: "Input Collection 2", 'aria-labelledby': "stepper-input-collection-2-label" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection2')}
                   >
                     <Select.List>
@@ -151,10 +151,10 @@ const customCode = `
                   The system automatically creates collection for multiple support.
                 </Text>
                 <div className="mt-6">
-                  <Label withInput={true}>Destination Collection</Label>
+                  <Label withInput={true} id="stepper-destination-collection-label" htmlFor="stepper-destination-collection">Destination Collection</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ placeholder: "Select Destination", 'aria-label': "Destination Collection" }}
+                    triggerOptions={{ id: "stepper-destination-collection", placeholder: "Select Destination", 'aria-labelledby': "stepper-destination-collection-label" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'collection')}
                   >
                     <Select.List>
@@ -180,10 +180,10 @@ const customCode = `
                   />
                 </div>
                 <div className="mt-6">
-                  <Label withInput={true} required>Retention Period</Label>
+                  <Label withInput={true} required id="stepper-retention-period-label" htmlFor="stepper-retention-period">Retention Period</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ 'aria-label': "Retention Period" }}
+                    triggerOptions={{ id: "stepper-retention-period", 'aria-labelledby': "stepper-retention-period-label" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'retention')}
                   >
                     <Select.List>
@@ -196,10 +196,10 @@ const customCode = `
                       })}
                     </Select.List>
                   </Select>
-                  <Label className="mt-6" withInput={true}>Visibility Clarification</Label>
+                  <Label className="mt-6" withInput={true} id="stepper-visibility-clarification-label" htmlFor="stepper-visibility-clarification">Visibility Clarification</Label>
                   <Select
                     width="100%"
-                    triggerOptions={{ 'aria-label': "Visibility Clarification" }}
+                    triggerOptions={{ id: "stepper-visibility-clarification", 'aria-labelledby': "stepper-visibility-clarification-label" }}
                     onSelect={(option) => this.onChangeOutput(option.value, 'clarification')}
                   >
                     <Select.List>
@@ -225,9 +225,9 @@ const customCode = `
                   </div>
                 </div>
                 <div className="mt-6">
-                  <Label withInput={true} required>Mode</Label>
+                  <Label withInput={true} required id="stepper-mode-label" htmlFor="stepper-mode">Mode</Label>
                   <Select
-                    triggerOptions={{ 'aria-label': "Mode" }}
+                    triggerOptions={{ id: "stepper-mode", 'aria-labelledby': "stepper-mode-label" }}
                     onSelect={(option) => {
                       this.setState({
                         configuration: { ...this.state.configuration, mode: option.value }

--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -31,8 +31,8 @@ const customCode = `
             <Heading size="s" className="mb-2">Population Filter</Heading>
             <div className="d-flex mt-5 mb-4">
               <div className="mr-6" style={{ width: 'var(--spacing-440)' }}>
-                <Label withInput={true}>Region</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Region" }}>
+                <Label withInput={true} id="time-period-region-label" htmlFor="time-period-region-select">Region</Label>
+                <Select width="100%" triggerOptions={{ id: "time-period-region-select", 'aria-labelledby': "time-period-region-label" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
@@ -45,8 +45,8 @@ const customCode = `
                 </Select>
               </div>
               <div style={{ width: 'var(--spacing-640)' }}>
-                <Label withInput={true}>Organization</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Organization" }}>
+                <Label withInput={true} id="time-period-organization-label" htmlFor="time-period-organization-select">Organization</Label>
+                <Select width="100%" triggerOptions={{ id: "time-period-organization-select", 'aria-labelledby': "time-period-organization-label" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (

--- a/core/components/patterns/forms/basicForm.story.tsx
+++ b/core/components/patterns/forms/basicForm.story.tsx
@@ -65,8 +65,9 @@ const customCode = `
           <Card className="px-6 py-6">
             <form onSubmit={this.onSubmit}>
               <Heading className="mb-7" size="m">Login</Heading>
-              <Label withInput={true}>Email</Label>
+              <Label withInput={true} htmlFor="basic-email-input">Email</Label>
               <Input
+                id="basic-email-input"
                 name="input"
                 type="text"
                 placeholder="Enter email"
@@ -74,8 +75,9 @@ const customCode = `
                 autocomplete={'off'}
                 onChange={this.onEmailChange}
               />
-              <Label withInput={true}>Password</Label>
+              <Label withInput={true} htmlFor="basic-password-input">Password</Label>
               <Input
+                id="basic-password-input"
                 name="input"
                 className="mb-4"
                 placeholder="Enter password"


### PR DESCRIPTION
## Summary
- Add `aria-labelledby` support to `SelectTrigger` and hide visible placeholder text from the accessibility tree when an explicit label is provided, so screen readers announce the field name before placeholder copy.
- Wire visible labels to Select and Input fields across pattern form stories and common Select demos using `htmlFor` + `id` + `aria-labelledby`.

## Test plan
- [ ] Inline Form — Region and Primary Care Physician selects announce label first
- [ ] Create User — Gender and User Type selects announce label first
- [ ] Basic Form — Email and Password inputs announce label before placeholder
- [ ] Time Period Form — Region and Organization selects
- [ ] Stepper Form — all Select fields on both steps
- [ ] Stepper With Animation — Region and Organization selects
- [ ] Select / Label On Top, With Helptext, PreFilled Value — Area code field