### PR TITLE
fix(StepperForm): add aria-label to Prefix input for screen readers

### DIFF
--- a/core/components/patterns/forms/StepperForm.story.tsx
+++ b/core/components/patterns/forms/StepperForm.story.tsx
@@ -174,6 +174,8 @@ const customCode = `
                     id="prefix-input"
                     mask={[/\\d/, '_', /\\d/, '_', /\\d/]}
                     name="prefix"
+                    required
+                    aria-label="Prefix (required) ID_ID_ID"
                     placeholder="ID_ID_ID"
                     placeholderChar="-"
                     onChange={(e) => this.onChangeOutput(e.target.value, e.target.name)}


### PR DESCRIPTION
## Summary
- Add `aria-label="Prefix (required) ID_ID_ID"` and `required` to the Prefix `InputMask` in the Stepper Form story so screen readers announce both the field purpose and expected format.
- Story-only change; no component updates.

## Context
Deque issue **2356843** (2.4.6.b Descriptive Labels): the Prefix field's programmatic name was `Prefix (required)` but did not include the `ID_ID_ID` format hint shown as placeholder.

## Test plan
- [ ] Open Stepper Form story: `patterns/forms/stepper-form--stepper-form`
- [ ] Navigate to the Prefix field with VoiceOver/NVDA
- [ ] Confirm accessible name includes both Prefix and `ID_ID_ID` format
- [ ] Confirm no visual change to the field