### PR TITLE
fix(StepperForm): add persistent format hint for Prefix input

### DIFF
--- a/core/components/patterns/forms/StepperForm.story.tsx
+++ b/core/components/patterns/forms/StepperForm.story.tsx
@@ -174,8 +174,10 @@ const customCode = `
                     id="prefix-input"
                     mask={[/\\d/, '_', /\\d/, '_', /\\d/]}
                     name="prefix"
+                    required
                     placeholder="ID_ID_ID"
                     placeholderChar="-"
+                    helpText="Use format ID_ID_ID"
                     onChange={(e) => this.onChangeOutput(e.target.value, e.target.name)}
                   />
                 </div>


### PR DESCRIPTION
## Summary
- Adds `helpText="Use format ID_ID_ID"` to the Prefix `InputMask` in the Stepper Form story so the expected format is announced via `aria-describedby`.
- Marks the Prefix input as `required` to match the visible label.

## Why
The Prefix field had a visible label ("Prefix") but the format hint lived only in placeholder text. Placeholder is not a reliable source for screen reader announcements once a real label is associated. A persistent help text gives a stable, programmatic description of the expected format.

## Test plan
- [ ] Open Stepper Form story in Storybook
- [ ] Focus the Prefix field with VoiceOver/NVDA
- [ ] Confirm accessible name is "Prefix (required)"
- [ ] Confirm format hint "Use format ID_ID_ID" is announced as description
- [ ] Confirm help text is visible below the input while typing