### PR TITLE
fix(Dropdown): wire Time label in Date And Time Picker story

### DIFF
--- a/core/components/atoms/dropdown/DropdownButton.tsx
+++ b/core/components/atoms/dropdown/DropdownButton.tsx
@@ -109,6 +109,7 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
   return (
     <button
       ref={ref}
+      id={id}
       type="button"
       value={children}
       className={buttonClass}

--- a/core/components/atoms/dropdown/DropdownButton.tsx
+++ b/core/components/atoms/dropdown/DropdownButton.tsx
@@ -75,6 +75,7 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
     inlineLabel,
     error,
     iconType,
+    id,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
     ...rest
@@ -84,6 +85,8 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
   const trimmedPlaceholder = placeholder.trim();
   const value = children ? children : trimmedPlaceholder;
   const isPlaceholder = !children && !menu;
+  const valueElementId = id && children ? `${id}-value` : undefined;
+  const triggerLabelledBy = ariaLabelledBy && valueElementId ? `${ariaLabelledBy} ${valueElementId}` : ariaLabelledBy;
   const iconName = !menu ? (open ? 'keyboard_arrow_up' : 'keyboard_arrow_down') : icon ? icon : 'more_horiz';
 
   const buttonClass = classNames({
@@ -114,7 +117,7 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
       aria-haspopup={menu ? 'menu' : 'listbox'}
       aria-expanded={open}
       aria-label={ariaLabelledBy ? undefined : ariaLabel}
-      aria-labelledby={ariaLabelledBy}
+      aria-labelledby={triggerLabelledBy}
       data-test="DesignSystem-DropdownTrigger"
       {...rest}
     >
@@ -129,7 +132,11 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
             <Icon appearance={buttonDisabled} className="d-flex align-items-center mr-4" name={icon} type={iconType} />
           )}
           {value && (
-            <span className={textClass} aria-hidden={isPlaceholder && ariaLabelledBy ? true : undefined}>
+            <span
+              id={valueElementId}
+              className={textClass}
+              aria-hidden={isPlaceholder && ariaLabelledBy ? true : undefined}
+            >
               {value}
             </span>
           )}

--- a/core/components/atoms/dropdown/DropdownButton.tsx
+++ b/core/components/atoms/dropdown/DropdownButton.tsx
@@ -71,12 +71,15 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
     inlineLabel,
     error,
     iconType,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
     ...rest
   } = props;
 
   const buttonDisabled = disabled ? 'disabled' : 'default';
   const trimmedPlaceholder = placeholder.trim();
   const value = children ? children : trimmedPlaceholder;
+  const isPlaceholder = !children && !menu;
   const iconName = !menu ? (open ? 'keyboard_arrow_up' : 'keyboard_arrow_down') : icon ? icon : 'more_horiz';
 
   const buttonClass = classNames({
@@ -106,6 +109,8 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
       tabIndex={0}
       aria-haspopup={menu ? 'menu' : 'listbox'}
       aria-expanded={open}
+      aria-label={ariaLabelledBy ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       data-test="DesignSystem-DropdownTrigger"
       {...rest}
     >
@@ -119,7 +124,11 @@ const DropdownButton = React.forwardRef<HTMLButtonElement, DropdownButtonProps>(
           {icon && !inlineLabel && (
             <Icon appearance={buttonDisabled} className="d-flex align-items-center mr-4" name={icon} type={iconType} />
           )}
-          {value && <span className={textClass}>{value}</span>}
+          {value && (
+            <span className={textClass} aria-hidden={isPlaceholder && ariaLabelledBy ? true : undefined}>
+              {value}
+            </span>
+          )}
         </div>
       )}
       <Icon appearance={buttonDisabled} name={iconName} type={iconType} />

--- a/core/components/atoms/dropdown/DropdownButton.tsx
+++ b/core/components/atoms/dropdown/DropdownButton.tsx
@@ -10,6 +10,10 @@ export type DropDownButtonSize = 'tiny' | 'regular';
 
 export interface TriggerProps {
   /**
+   * `id` for the dropdown trigger button; pair with a visible `<Label htmlFor={id}>`.
+   */
+  id?: string;
+  /**
    * Size of `Dropdown` trigger button
    * @default "regular"
    */

--- a/core/components/atoms/dropdown/DropdownList.tsx
+++ b/core/components/atoms/dropdown/DropdownList.tsx
@@ -347,6 +347,7 @@ const DropdownList = (props: OptionsProps) => {
     NewCustomTrigger
   ) : (
     <DropdownButton
+      id={props.id}
       placeholder={placeholder}
       triggerSize={triggerSize}
       open={dropdownOpen}
@@ -357,8 +358,8 @@ const DropdownList = (props: OptionsProps) => {
       error={error}
       ref={dropdownTriggerRef}
       iconType={iconType}
-      aria-label={props['aria-label']}
-      aria-labelledby={props['aria-labelledby']}
+      aria-label={triggerAriaLabelledBy ? undefined : triggerAriaLabel}
+      aria-labelledby={triggerAriaLabelledBy}
     >
       {triggerLabel}
     </DropdownButton>

--- a/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
+++ b/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
@@ -987,4 +987,9 @@ describe('Dropdown trigger accessibility and visual parity with Select', () => {
     const placeholder = within(dropdownTrigger).getByText('Select');
     expect(placeholder).toHaveAttribute('aria-hidden', 'true');
   });
+
+  it('forwards id to the trigger button for Label htmlFor pairing', () => {
+    const { getByTestId } = render(<Dropdown id="time-dropdown" options={storyOptions} aria-labelledby="time-label" />);
+    expect(getByTestId(trigger)).toHaveAttribute('id', 'time-dropdown');
+  });
 });

--- a/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
+++ b/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
@@ -992,4 +992,14 @@ describe('Dropdown trigger accessibility and visual parity with Select', () => {
     const { getByTestId } = render(<Dropdown id="time-dropdown" options={storyOptions} aria-labelledby="time-label" />);
     expect(getByTestId(trigger)).toHaveAttribute('id', 'time-dropdown');
   });
+
+  it('includes selected value in aria-labelledby when externally labelled', () => {
+    const selectedOptions = [{ label: '10:00 AM', value: '10:00 AM', selected: true }];
+    const { getByTestId } = render(
+      <Dropdown id="time-dropdown" options={selectedOptions} aria-labelledby="time-label" />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+    expect(dropdownTrigger).toHaveAttribute('aria-labelledby', 'time-label time-dropdown-value');
+    expect(within(dropdownTrigger).getByText('10:00 AM')).toHaveAttribute('id', 'time-dropdown-value');
+  });
 });

--- a/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
+++ b/core/components/atoms/dropdown/__tests__/Dropdown.test.tsx
@@ -974,4 +974,17 @@ describe('Dropdown trigger accessibility and visual parity with Select', () => {
     const options = getAllByTestId('DesignSystem-DropdownOption--DEFAULT');
     expect(options[0]).toHaveAttribute('tabindex', '0');
   });
+
+  it('uses aria-labelledby instead of aria-label and hides placeholder from assistive tech', () => {
+    const { getByTestId } = render(
+      <Dropdown options={storyOptions} aria-labelledby="time-label" aria-label="Stale label" />
+    );
+    const dropdownTrigger = getByTestId(trigger);
+
+    expect(dropdownTrigger).toHaveAttribute('aria-labelledby', 'time-label');
+    expect(dropdownTrigger).not.toHaveAttribute('aria-label');
+
+    const placeholder = within(dropdownTrigger).getByText('Select');
+    expect(placeholder).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
+++ b/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
@@ -53,7 +53,7 @@ const customCode = `
             />
           </div>
           <div className="d-flex flex-column ml-5" style={{width: 'var(--spacing-440)'}}>
-            <Label withInput id="datetime-time-label">Time</Label>
+            <Label withInput id="datetime-time-label" htmlFor="datetime-time-dropdown">Time</Label>
             <Dropdown
               id="datetime-time-dropdown"
               aria-labelledby="datetime-time-label"

--- a/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
+++ b/core/components/patterns/datePicker/dateAndTimePicker.story.tsx
@@ -45,15 +45,19 @@ const customCode = `
       return (
         <div className="d-flex">
           <div className="d-flex flex-column">
-            <Label withInput>Date</Label>
+            <Label withInput id="datetime-date-label">Date</Label>
             <DatePicker
               withInput={true}
               onDateChange={this.onDateChange.bind(this)}
+              aria-labelledby="datetime-date-label"
             />
           </div>
           <div className="d-flex flex-column ml-5" style={{width: 'var(--spacing-440)'}}>
-            <Label withInput>Time</Label>
+            <Label withInput id="datetime-time-label">Time</Label>
             <Dropdown
+              id="datetime-time-dropdown"
+              aria-labelledby="datetime-time-label"
+              optionsAriaLabel="Time options"
               open={open}
               onPopperToggle={this.onPopperToggle.bind(this)}
               options={timeValues.map(value => ({label: value, value}))}


### PR DESCRIPTION
## Summary
- Fixes the **Date And Time Picker** pattern story so the Time `Dropdown` announces **"Time"** instead of the **"Select"** placeholder
- Wires visible `Label` elements to `DatePicker` and `Dropdown` via `id` + `aria-labelledby` (same pattern as `Gender.story.jsx`)
- Hardens `DropdownButton` to hide placeholder text from assistive tech when `aria-labelledby` is set, and to prefer the visible label over a stale `aria-label`

## Root cause
The Time field showed a visible **Time** label, but the label was not associated with the `Dropdown` trigger. Screen readers therefore read the trigger's placeholder text ("Select") as the field name.

## Test plan
- [ ] Open **Patterns → DatePicker → Date And Time Picker** in Storybook
- [ ] VoiceOver: tab to **Date** — should hear "Date" before mask/placeholder
- [ ] VoiceOver: tab to **Time** — should hear **"Time"**, not "Select"
- [ ] Select a time option — trigger should announce the selected value, not "Select"
- [ ] `npm test -- --testPathPattern=Dropdown.test --testNamePattern=aria-labelledby` passes