### PR TITLE
fix(a11y): form pattern stories — headings, labels & autocomplete (Deque 2356794, 2355895, 2355898, 2356021, 2356022, 2356853)

### DIFF
--- a/core/components/patterns/forms/CreatePassword.story.tsx
+++ b/core/components/patterns/forms/CreatePassword.story.tsx
@@ -121,7 +121,7 @@ const customCode = `
                 type={this.state.passwordVisible ? 'text' : 'password'}
                 value={this.state.password}
                 onChange={this.onPasswordChange}
-                autocomplete="off"
+                autoComplete="new-password"
                 actionIcon={(
                   <Input.ActionButton
                     className="p-3"
@@ -141,7 +141,7 @@ const customCode = `
                 type={this.state.confirmPasswordVisible ? 'text' : 'password'}
                 value={this.state.confirmPassword}
                 onChange={this.onConfirmPasswordChange}
-                autocomplete="off"
+                autoComplete="new-password"
                 actionIcon={(
                   <Input.ActionButton
                     className="p-3"

--- a/core/components/patterns/forms/InlineForm.story.tsx
+++ b/core/components/patterns/forms/InlineForm.story.tsx
@@ -55,7 +55,7 @@ const customCode = `
                     type="text"
                     placeholder="E.g. Doe, Smith, etc."
                     icon="person"
-                    autocomplete={'off'}
+                    autoComplete="family-name"
                     onChange={(event) => this.onChange(event.target.value, event.target.name)}
                   />
                 </div>
@@ -66,7 +66,7 @@ const customCode = `
                     type="text"
                     placeholder="E.g. John, Will, etc."
                     icon="person"
-                    autocomplete={'off'}
+                    autoComplete="given-name"
                     onChange={(event) => this.onChange(event.target.value, event.target.name)}
                   />
                 </div>
@@ -87,6 +87,7 @@ const customCode = `
                     inputOptions={{
                       placeholder: 'MM/DD/YYYY',
                       icon: 'cake',
+                      autoComplete: 'bday',
                       mask: [/\\d/, /\\d/, '/', /\\d/, /\\d/, '/', /\\d/, /\\d/, /\\d/, /\\d/]
                     }}
                   />
@@ -120,7 +121,7 @@ const customCode = `
                     type="text"
                     placeholder="00000"
                     icon="location_on"
-                    autocomplete={'off'}
+                    autoComplete="postal-code"
                     onChange={(event) => this.onChange(event.target.value, event.target.name)}
                   />
                 </div>

--- a/core/components/patterns/forms/InlineForm.story.tsx
+++ b/core/components/patterns/forms/InlineForm.story.tsx
@@ -49,8 +49,9 @@ const customCode = `
             <form onSubmit={this.onSubmit}>
               <div className="d-flex flex-wrap">
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>Last Name</Label>
+                  <Label withInput={true} htmlFor="inline-lastName">Last Name</Label>
                   <Input
+                    id="inline-lastName"
                     name="lastName"
                     type="text"
                     placeholder="E.g. Doe, Smith, etc."
@@ -60,8 +61,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>First Name</Label>
+                  <Label withInput={true} htmlFor="inline-firstName">First Name</Label>
                   <Input
+                    id="inline-firstName"
                     name="firstName"
                     type="text"
                     placeholder="E.g. John, Will, etc."
@@ -71,8 +73,8 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>Gender</Label>
-                  <div className="d-flex" role="group" aria-label="Gender">
+                  <Label withInput={true} id="inline-gender-label">Gender</Label>
+                  <div className="d-flex" role="group" aria-labelledby="inline-gender-label">
                     <Button className="mr-3" selected={this.state.data.gender === 'Male'} onClick={() => this.onChange('Male', 'gender')}>Male</Button>
                     <Button className="mr-3" selected={this.state.data.gender === 'Female'} onClick={() => this.onChange('Female', 'gender')}>Female</Button>
                     <Button className="mr-3" selected={this.state.data.gender === 'Other'} onClick={() => this.onChange('Other', 'gender')}>Other</Button>
@@ -80,9 +82,10 @@ const customCode = `
                   </div>
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true}>Date of Birth</Label>
+                  <Label withInput={true} id="inline-dob-label">Date of Birth</Label>
                   <DatePicker
                     withInput={true}
+                    aria-labelledby="inline-dob-label"
                     onDateChange={(currentDate) => this.onChange(currentDate, 'date')}
                     inputOptions={{
                       placeholder: 'MM/DD/YYYY',
@@ -93,8 +96,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>EMPI</Label>
+                  <Label withInput={true} htmlFor="inline-empi">EMPI</Label>
                   <Input
+                    id="inline-empi"
                     name="empi"
                     type="text"
                     placeholder="P000000"
@@ -104,8 +108,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>MRN</Label>
+                  <Label withInput={true} htmlFor="inline-mrn">MRN</Label>
                   <Input
+                    id="inline-mrn"
                     name="mrn"
                     type="text"
                     placeholder="Medical Record Number"
@@ -115,8 +120,9 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6">
-                  <Label withInput={true}>ZIP</Label>
+                  <Label withInput={true} htmlFor="inline-zip">ZIP</Label>
                   <Input
+                    id="inline-zip"
                     name="zip"
                     type="text"
                     placeholder="00000"
@@ -126,11 +132,11 @@ const customCode = `
                   />
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true}>Primary Care Physician</Label>
+                  <Label withInput={true} id="inline-pcp-label" htmlFor="inline-pcp-select">Primary Care Physician</Label>
                   <Select
                     width="100%"
                     onSelect={(option) => this.onChange(option.value, 'pcp')}
-                    triggerOptions={{ placeholder: "Select physician…", icon: "add_box", 'aria-label': "Primary Care Physician" }}
+                    triggerOptions={{ id: "inline-pcp-select", placeholder: "Select physician…", icon: "add_box", 'aria-labelledby': "inline-pcp-label" }}
                   >
                     <Select.List>
                       {options.map((item, key) => {
@@ -144,11 +150,11 @@ const customCode = `
                   </Select>
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true}>Region</Label>
+                  <Label withInput={true} id="inline-region-label" htmlFor="inline-region-select">Region</Label>
                   <Select
                     width="100%"
                     onSelect={(option) => this.onChange(option.value, 'region')}
-                    triggerOptions={{ placeholder: "Select region…", icon: "flag", 'aria-label': "Region" }}
+                    triggerOptions={{ id: "inline-region-select", placeholder: "Select region…", icon: "flag", 'aria-labelledby': "inline-region-label" }}
                   >
                     <Select.List>
                       {options.map((item, key) => {

--- a/core/components/patterns/forms/InlineForm.story.tsx
+++ b/core/components/patterns/forms/InlineForm.story.tsx
@@ -82,12 +82,13 @@ const customCode = `
                   </div>
                 </div>
                 <div className="mr-6 mb-6" style={{ width: 'var(--spacing-640)' }}>
-                  <Label withInput={true} id="inline-dob-label">Date of Birth</Label>
+                  <Label withInput={true} id="inline-dob-label" htmlFor="inline-dob">Date of Birth</Label>
                   <DatePicker
                     withInput={true}
                     aria-labelledby="inline-dob-label"
                     onDateChange={(currentDate) => this.onChange(currentDate, 'date')}
                     inputOptions={{
+                      id: 'inline-dob',
                       placeholder: 'MM/DD/YYYY',
                       icon: 'cake',
                       autoComplete: 'bday',

--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -28,7 +28,7 @@ const customCode = `
         <div className="w-75">
           <Card className="px-7 py-6">
             <Heading className="mb-6" size="s">Configure Initiative</Heading>
-            <Heading size="s" className="mb-2">Population Filter</Heading>
+            <Heading size="s" as="h6" className="mb-2">Population Filter</Heading>
             <div className="d-flex mt-5 mb-4">
               <div className="mr-6" style={{ width: 'var(--spacing-440)' }}>
                 <Label withInput={true}>Region</Label>
@@ -61,7 +61,7 @@ const customCode = `
             </div>
             <Link target="_blank" href="#">Add organizations</Link>
             <div className="my-6 pt-6" style={{ borderTop: 'var(--border-width-2-5) solid var(--secondary-light)' }}>
-              <Heading size="s">Time Period</Heading>
+              <Heading size="s" as="h6">Time Period</Heading>
               <div className="mt-5">
                 <DateRangePicker withInput />
               </div>

--- a/core/components/patterns/forms/basicForm.story.tsx
+++ b/core/components/patterns/forms/basicForm.story.tsx
@@ -71,7 +71,7 @@ const customCode = `
                 type="text"
                 placeholder="Enter email"
                 className="mb-6"
-                autocomplete={'off'}
+                autoComplete="email"
                 onChange={this.onEmailChange}
               />
               <Label withInput={true}>Password</Label>
@@ -79,7 +79,7 @@ const customCode = `
                 name="input"
                 className="mb-4"
                 placeholder="Enter password"
-                autocomplete={'off'}
+                autoComplete="current-password"
                 type={this.state.passwordVisible ? 'text' : 'password'}
                 value={password}
                 onChange={this.onPasswordChange}


### PR DESCRIPTION
## Summary

Storybook accessibility fixes across four form pattern docs, addressing six open Deque audit issues.

| Deque issue | Story | WCAG checkpoint | Fix |
|---|---|---|---|
| **2356794** | Time Period Form | 1.3.1 — Info and Relationships | Section titles (`Population Filter`, `Time Period`) render as `<Heading as="h6">` |
| **2355895** | Basic Form | 1.3.5.a — Identify Input Purpose | Email → `autoComplete="email"`, Password → `autoComplete="current-password"` |
| **2355898** | Create Password | 1.3.5.a — Identify Input Purpose | Password fields use `autoComplete="new-password"` instead of `off` |
| **2356021** | Inline Form | 2.4.6.b — Descriptive Labels | Visible labels programmatically associated with controls |
| **2356022** | Inline Form | 2.5.3.a — Label in Name | Accessible name includes visible label text |
| **2356853** | Inline Form | 1.3.5 — Identify Input Purpose | Personal data fields use correct `autocomplete` tokens |

## Changes

### `TimePeriodForm.story.tsx`
- Wrap **Population Filter** and **Time Period** section titles in `<Heading size="s" as="h6">`

### `basicForm.story.tsx`
- Set `autoComplete="email"` on Email input
- Set `autoComplete="current-password"` on Password input

### `CreatePassword.story.tsx`
- Set `autoComplete="new-password"` on Password and Confirm Password inputs

### `InlineForm.story.tsx`
- Wire `htmlFor` / `id` on text inputs (Last Name, First Name, EMPI, MRN, ZIP)
- Wire `aria-labelledby` on Date of Birth, Gender group, PCP Select, and Region Select
- Set autocomplete: `family-name`, `given-name`, `bday`, `postal-code`

## Root cause

- **2356794** — Titles were styled text, not semantic headings
- **2355895 / 2355898 / 2356853** — Inputs used `autocomplete="off"` instead of WCAG-recommended tokens
- **2356021 / 2356022** — Labels sat beside inputs with no association; screen readers fell back to placeholder text

## Test plan

- [ ] **Time Period Form** — Population Filter & Time Period render as `<h6>`; confirm in VoiceOver rotor → Headings
- [ ] **Basic Form** — Email has `autocomplete="email"`, Password has `autocomplete="current-password"`
- [ ] **Create Password** — Password inputs have `autocomplete="new-password"`
- [ ] **Inline Form** — Last Name, First Name, DOB, EMPI, MRN, ZIP announce visible label text, not placeholder
- [ ] **Inline Form** — Gender group, PCP Select, Region Select announce matching visible labels
- [ ] **Inline Form** — verify autocomplete attributes on personal data fields