### PR TITLE
fix(a11y): Time Period Form reflow at 320px (Deque 2356796)

### DIFF
--- a/core/components/patterns/forms/TimePeriodForm.story.tsx
+++ b/core/components/patterns/forms/TimePeriodForm.story.tsx
@@ -25,14 +25,14 @@ const customCode = `
       }
 
       return (
-        <div className="w-75">
+        <div className="w-100">
           <Card className="px-7 py-6">
             <Heading className="mb-6" size="s">Configure Initiative</Heading>
             <Heading size="s" className="mb-2">Population Filter</Heading>
-            <div className="d-flex mt-5 mb-4">
-              <div className="mr-6" style={{ width: 'var(--spacing-440)' }}>
+            <div className="d-flex flex-column mt-5 mb-4">
+              <div className="w-100 mb-4">
                 <Label withInput={true}>Region</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Region" }}>
+                <Select appendToBody width="100%" triggerOptions={{ 'aria-label': "Region" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (
@@ -44,9 +44,9 @@ const customCode = `
                   </Select.List>
                 </Select>
               </div>
-              <div style={{ width: 'var(--spacing-640)' }}>
+              <div className="w-100">
                 <Label withInput={true}>Organization</Label>
-                <Select width="100%" triggerOptions={{ 'aria-label': "Organization" }}>
+                <Select appendToBody width="100%" triggerOptions={{ 'aria-label': "Organization" }}>
                   <Select.List>
                     {options.map((item, key) => {
                       return (


### PR DESCRIPTION
## Summary
Fixes Deque axe Auditor issue **2356796** on the Time Period Form pattern: Region and Organization Select listboxes were clipped or unreachable at a 320px equivalent viewport width.

- Stack Population Filter fields vertically (`flex-column`, `w-100`) instead of a fixed-width horizontal row
- Use `appendToBody` on both Selects so listboxes are not clipped by the docs preview card overflow

## Scope
Pattern story only (`TimePeriodForm.story.tsx` `customCode`). No component API changes.

## Test plan
- [ ] Open `patterns-forms-time-period-form--time-period-form` in Storybook/docs
- [ ] Set viewport to 320px (or 1280px at 400% zoom)
- [ ] Open Region and Organization dropdowns — all options visible and selectable
- [ ] Confirm no loss of form functionality at narrow width